### PR TITLE
提供更优雅的异步方式实现 

### DIFF
--- a/dubbo-async/async/pom.xml
+++ b/dubbo-async/async/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-async</artifactId>
+        <groupId>com.alibaba</groupId>
+        <version>2.5.4-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>async</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-async-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-async-processor</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/dubbo-async/dubbo-async-api/pom.xml
+++ b/dubbo-async/dubbo-async-api/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-async</artifactId>
+        <groupId>com.alibaba</groupId>
+        <version>2.5.4-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dubbo-async-api</artifactId>
+
+    <properties>
+        <skip_maven_deploy>false</skip_maven_deploy>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/dubbo-async/dubbo-async-api/src/main/java/com/alibaba/dubbo/async/Async.java
+++ b/dubbo-async/dubbo-async-api/src/main/java/com/alibaba/dubbo/async/Async.java
@@ -1,0 +1,13 @@
+package com.alibaba.dubbo.async;
+
+import java.lang.annotation.*;
+
+/**
+ * Created by zhaohui.yu
+ * 15/11/13
+ */
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.TYPE})
+public @interface Async {
+}

--- a/dubbo-async/dubbo-async-api/src/main/java/com/alibaba/dubbo/async/AsyncContext.java
+++ b/dubbo-async/dubbo-async-api/src/main/java/com/alibaba/dubbo/async/AsyncContext.java
@@ -1,0 +1,16 @@
+package com.alibaba.dubbo.async;
+
+import java.io.Serializable;
+
+/**
+ * Created by zhaohui.yu
+ * 15/11/13
+ */
+public interface AsyncContext<T extends Serializable> {
+    void commit();
+
+    void commit(T result);
+
+    void fail(Throwable t);
+}
+

--- a/dubbo-async/dubbo-async-api/src/main/java/com/alibaba/dubbo/async/AsyncContextImpl.java
+++ b/dubbo-async/dubbo-async-api/src/main/java/com/alibaba/dubbo/async/AsyncContextImpl.java
@@ -1,0 +1,69 @@
+package com.alibaba.dubbo.async;
+
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Created by zhaohui.yu
+ * 15/11/13
+ */
+public class AsyncContextImpl<T extends Serializable> implements AsyncContext<T> {
+    private volatile Runnable runnable;
+
+    private static final int INIT = 0;
+    private static final int DONE = 1;
+    private static final int EXECUTED = 2;
+
+    private final AtomicInteger state = new AtomicInteger(0);
+
+    private T result;
+
+    private Throwable exception;
+
+    @Override
+    public void commit() {
+        if (state.compareAndSet(INIT, DONE)) {
+            trigger();
+        }
+    }
+
+    @Override
+    public void commit(T result) {
+        this.result = result;
+        if (state.compareAndSet(INIT, DONE)) {
+            trigger();
+        }
+    }
+
+    @Override
+    public void fail(Throwable t) {
+        this.exception = t;
+        if (state.compareAndSet(INIT, DONE)) {
+            trigger();
+        }
+    }
+
+    public void then(Runnable runnable) {
+        this.runnable = runnable;
+        trigger();
+    }
+
+    protected final void trigger() {
+        Runnable run = runnable;
+        if (run == null) return;
+
+        if (state.compareAndSet(DONE, EXECUTED)) {
+            run.run();
+        }
+    }
+
+    public Object getResult() {
+        if (state.get() < DONE) return null;
+        return this.result;
+    }
+
+    public Throwable getException() {
+        if (state.get() < DONE) return null;
+        return this.exception;
+    }
+}

--- a/dubbo-async/dubbo-async-api/src/main/java/com/alibaba/dubbo/async/AsyncImpl.java
+++ b/dubbo-async/dubbo-async-api/src/main/java/com/alibaba/dubbo/async/AsyncImpl.java
@@ -1,0 +1,14 @@
+package com.alibaba.dubbo.async;
+
+import java.lang.annotation.*;
+
+/**
+ * Created by zhaohui.yu
+ * 15/11/13
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface AsyncImpl {
+    Class<?> value();
+}

--- a/dubbo-async/dubbo-async-processor/pom.xml
+++ b/dubbo-async/dubbo-async-processor/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-async</artifactId>
+        <groupId>com.alibaba</groupId>
+        <version>2.5.4-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dubbo-async-processor</artifactId>
+
+    <properties>
+        <skip_maven_deploy>false</skip_maven_deploy>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-async-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/dubbo-async/dubbo-async-processor/src/main/java/com/alibaba/dubbo/async/processor/AsyncAnnotationProcessor.java
+++ b/dubbo-async/dubbo-async-processor/src/main/java/com/alibaba/dubbo/async/processor/AsyncAnnotationProcessor.java
@@ -1,0 +1,309 @@
+package com.alibaba.dubbo.async.processor;
+
+
+import com.alibaba.dubbo.async.Async;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.*;
+import javax.lang.model.type.*;
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Created by zhaohui.yu
+ * 5/2/15
+ */
+@SupportedAnnotationTypes("com.alibaba.dubbo.async.Async")
+public class AsyncAnnotationProcessor extends AbstractProcessor {
+
+    private static final String OBJECT_NAME = "java.lang.Object";
+
+    private static final String FUTURE_NAME = "ListenableFuture";
+
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (roundEnv.processingOver()) return false;
+        Set<? extends Element> elements = roundEnv.getElementsAnnotatedWith(Async.class);
+        if (elements == null || elements.isEmpty()) return false;
+
+        for (Element element : elements) {
+            if (element.getKind() == ElementKind.INTERFACE) {
+                generateAsyncInterface((TypeElement) element);
+            }
+        }
+
+        return false;
+    }
+
+    private void generateAsyncInterface(TypeElement element) {
+        Name qualified = element.getQualifiedName();
+        if (qualified == null) return;
+        String qualifiedName = qualified.toString();
+        if (qualifiedName.length() == 0) return;
+
+
+        String className = element.getSimpleName().toString();
+        PackageElement packageElement = (PackageElement) element.getEnclosingElement();
+        String packageName = packageElement.getQualifiedName().toString();
+
+
+        StringBuilder result = new StringBuilder();
+        startAsyncInterface(result, qualifiedName, className, packageName);
+        generateAsyncMethods(result, element);
+        endAsyncInterface(result);
+
+        Writer writer = null;
+        try {
+            JavaFileObject sourceFile = processingEnv.getFiler().createSourceFile(qualifiedName + "Async");
+            if (sourceFile.getLastModified() > 0) return;
+
+            writer = sourceFile.openWriter();
+            writer.write(result.toString());
+            writer.close();
+        } catch (IOException e) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, "生成async接口失败");
+        } finally {
+            close(writer);
+        }
+    }
+
+    private void generateAsyncMethods(StringBuilder result, TypeElement typeElement) {
+        List<? extends Element> elements = typeElement.getEnclosedElements();
+        Set<String> existMethods = extractExistMethods(elements);
+        for (Element element : elements) {
+            if (element.getKind() != ElementKind.METHOD) continue;
+            generateAsyncMethod(result, (ExecutableElement) element, existMethods);
+        }
+    }
+
+    private Set<String> extractExistMethods(List<? extends Element> elements) {
+        Set<String> result = new HashSet<String>();
+        for (Element element : elements) {
+            result.add(element.getSimpleName().toString());
+        }
+        return result;
+    }
+
+    private void generateAsyncMethod(StringBuilder result, ExecutableElement element, Set<String> existMethods) {
+        String asyncMethodName = element.getSimpleName().toString() + "Async";
+        if (existMethods.contains(asyncMethodName)) return;
+
+        appendTypeParameters(result, element);
+        appendReturnType(result, element);
+        result.append(asyncMethodName).append('(');
+        appendParameters(result, element);
+        result.append(");");
+    }
+
+    //泛型参数
+    private void appendTypeParameters(StringBuilder result, ExecutableElement element) {
+        List<? extends TypeParameterElement> typeParameters = element.getTypeParameters();
+        if (typeParameters == null || typeParameters.size() == 0) return;
+
+        result.append("<");
+        int i = 1;
+        for (TypeParameterElement typeParameter : typeParameters) {
+            result.append(typeParameter.getSimpleName().toString());
+            appendBounds(result, typeParameter);
+            if (i++ < typeParameters.size()) result.append(",");
+        }
+        result.append("> ");
+    }
+
+    //返回值
+    private void appendReturnType(StringBuilder result, ExecutableElement element) {
+        TypeMirror returnType = element.getReturnType();
+        if (returnType.getKind() == TypeKind.VOID) {
+            result.append(FUTURE_NAME).append(" ");
+        } else {
+            result.append(FUTURE_NAME).append('<').append(type2ReturnName(returnType)).append("> ");
+        }
+    }
+
+    //参数
+    private void appendParameters(StringBuilder result, ExecutableElement method) {
+        List<? extends VariableElement> parameters = method.getParameters();
+        int i = 1;
+        for (VariableElement element : parameters) {
+            result.append(type2ParameterName(element.asType())).append(" ").append(element.getSimpleName().toString());
+            if (i++ < parameters.size()) {
+                result.append(",");
+            }
+        }
+    }
+
+    private void appendBounds(StringBuilder result, TypeParameterElement typeParameter) {
+        List<? extends TypeMirror> bounds = typeParameter.getBounds();
+        if (bounds == null || bounds.size() == 0) return;
+        if (bounds.size() == 1) {
+            String boundName = type2ReturnName(bounds.get(0));
+            if (OBJECT_NAME.equals(boundName)) return;
+        }
+
+        result.append(" extends ");
+        int i = 1;
+        for (TypeMirror bound : bounds) {
+            String boundName = type2ReturnName(bound);
+            result.append(boundName);
+            if (i < bounds.size()) result.append(",");
+        }
+    }
+
+    private String type2ReturnName(TypeMirror typeMirror) {
+        TypeKind kind = typeMirror.getKind();
+        if (kind == TypeKind.VOID) return "";
+        if (kind == TypeKind.ARRAY) {
+            ArrayType arrayType = (ArrayType) typeMirror;
+            TypeMirror componentType = arrayType.getComponentType();
+            return type2ReturnName(componentType) + "[]";
+        }
+        if (kind == TypeKind.BOOLEAN) {
+            return "Boolean";
+        }
+        if (kind == TypeKind.BYTE) {
+            return "Byte";
+        }
+        if (kind == TypeKind.CHAR) {
+            return "Char";
+        }
+        if (kind == TypeKind.DOUBLE) {
+            return "Double";
+        }
+        if (kind == TypeKind.FLOAT) {
+            return "Float";
+        }
+        if (kind == TypeKind.INT) {
+            return "Integer";
+        }
+        if (kind == TypeKind.LONG) {
+            return "Long";
+        }
+        if (kind == TypeKind.SHORT) {
+            return "Short";
+        }
+        if (kind == TypeKind.DECLARED) {
+            DeclaredType declaredType = (DeclaredType) typeMirror;
+            Element element = declaredType.asElement();
+            List<? extends TypeMirror> typeArguments = declaredType.getTypeArguments();
+            if (typeArguments == null || typeArguments.size() == 0) {
+                return typeName(element);
+            }
+
+            StringBuilder result = new StringBuilder();
+            result.append(typeName(element)).append("<");
+            int i = 1;
+            for (TypeMirror typeArgument : typeArguments) {
+                result.append(type2ReturnName(typeArgument));
+                if (i++ < typeArguments.size()) result.append(",");
+            }
+            result.append(">");
+            return result.toString();
+        }
+        if (kind == TypeKind.TYPEVAR) {
+            TypeVariable typeVariable = (TypeVariable) typeMirror;
+            return typeVariable.asElement().getSimpleName().toString();
+        }
+        if (kind == TypeKind.WILDCARD) {
+            WildcardType wildcardType = (WildcardType) typeMirror;
+            StringBuilder result = new StringBuilder();
+            result.append("?");
+            appendSuperBound(result, wildcardType.getSuperBound());
+            appendExtendsBound(result, wildcardType.getExtendsBound());
+            return result.toString();
+        }
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, kind.toString());
+        return "";
+    }
+
+    private void appendExtendsBound(StringBuilder resut, TypeMirror extendsBound) {
+        if (extendsBound == null) return;
+        String name = type2ReturnName(extendsBound);
+        if (name.equals(OBJECT_NAME)) return;
+        resut.append(" extends ").append(name);
+    }
+
+    private void appendSuperBound(StringBuilder result, TypeMirror superBound) {
+        if (superBound == null) return;
+        String name = type2ReturnName(superBound);
+        if (name.equals(OBJECT_NAME)) return;
+        result.append(" super ").append(name);
+    }
+
+    private String type2ParameterName(TypeMirror typeMirror) {
+        TypeKind kind = typeMirror.getKind();
+        if (kind == TypeKind.BOOLEAN) {
+            return "boolean";
+        }
+        if (kind == TypeKind.BYTE) {
+            return "byte";
+        }
+        if (kind == TypeKind.CHAR) {
+            return "char";
+        }
+        if (kind == TypeKind.DOUBLE) {
+            return "double";
+        }
+        if (kind == TypeKind.FLOAT) {
+            return "float";
+        }
+        if (kind == TypeKind.INT) {
+            return "int";
+        }
+        if (kind == TypeKind.LONG) {
+            return "long";
+        }
+        if (kind == TypeKind.SHORT) {
+            return "short";
+        }
+        return type2ReturnName(typeMirror);
+    }
+
+    private String typeName(Element element) {
+        if (element.getKind() == ElementKind.CLASS
+                || element.getKind() == ElementKind.INTERFACE
+                || element.getKind() == ElementKind.ENUM) {
+            return ((TypeElement) element).getQualifiedName().toString();
+        }
+        return element.getSimpleName().toString();
+    }
+
+    private void endAsyncInterface(StringBuilder result) {
+        result.append("\n}");
+    }
+
+    private void startAsyncInterface(StringBuilder result, String qualifiedName, String className, String packageName) {
+        result.append("package ").append(packageName).append(";\n");
+        result.append("import com.google.common.util.concurrent.ListenableFuture;\n");
+        result.append("@javax.annotation.Generated(\"com.alibaba.dubbo.async.processor.AsyncAnnotationProcessor\")\n");
+        result.append("@com.alibaba.dubbo.async.AsyncImpl(").append(qualifiedName).append(".class)\n");
+        result.append("public interface ").append(className).append("Async extends ").append(className).append(" {\n");
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
+    }
+
+    private void close(Writer writer) {
+        if (writer == null) return;
+        try {
+            writer.close();
+        } catch (IOException e) {
+
+        }
+    }
+}

--- a/dubbo-async/pom.xml
+++ b/dubbo-async/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-parent</artifactId>
+        <groupId>com.alibaba</groupId>
+        <version>2.5.4-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dubbo-async</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>dubbo-async-processor</module>
+        <module>dubbo-async-api</module>
+        <module>async</module>
+    </modules>
+
+    <properties>
+        <skip_maven_deploy>false</skip_maven_deploy>
+    </properties>
+
+
+</project>

--- a/dubbo-cluster/pom.xml
+++ b/dubbo-cluster/pom.xml
@@ -35,6 +35,10 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.bsf</groupId>
             <artifactId>bsf-api</artifactId>
             <scope>provided</scope>

--- a/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/support/FailoverClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/support/FailoverClusterInvoker.java
@@ -16,96 +16,265 @@
 package com.alibaba.dubbo.rpc.cluster.support;
 
 import com.alibaba.dubbo.common.Constants;
+import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.common.Version;
 import com.alibaba.dubbo.common.logger.Logger;
 import com.alibaba.dubbo.common.logger.LoggerFactory;
 import com.alibaba.dubbo.common.utils.NetUtils;
-import com.alibaba.dubbo.rpc.Invocation;
-import com.alibaba.dubbo.rpc.Invoker;
-import com.alibaba.dubbo.rpc.Result;
-import com.alibaba.dubbo.rpc.RpcContext;
-import com.alibaba.dubbo.rpc.RpcException;
+import com.alibaba.dubbo.rpc.*;
 import com.alibaba.dubbo.rpc.cluster.Directory;
 import com.alibaba.dubbo.rpc.cluster.LoadBalance;
+import com.google.common.util.concurrent.AbstractFuture;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 
 /**
  * 失败转移，当出现失败，重试其它服务器，通常用于读操作，但重试会带来更长延迟。
- * <p>
+ * <p/>
  * <a href="http://en.wikipedia.org/wiki/Failover">Failover</a>
  *
  * @author william.liangf
  * @author chao.liuc
  */
 public class FailoverClusterInvoker<T> extends AbstractClusterInvoker<T> {
-
     private static final Logger logger = LoggerFactory.getLogger(FailoverClusterInvoker.class);
+
+    private static final Executor SAME_EXECUTOR = MoreExecutors.sameThreadExecutor();
 
     public FailoverClusterInvoker(Directory<T> directory) {
         super(directory);
     }
 
+    protected int getRetries(URL url, String methodName) {
+        return url.getMethodParameter(methodName, Constants.RETRIES_KEY, Constants.DEFAULT_RETRIES);
+    }
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     public Result doInvoke(Invocation invocation, final List<Invoker<T>> invokers, LoadBalance loadbalance) throws RpcException {
-        List<Invoker<T>> copyinvokers = invokers;
-        checkInvokers(copyinvokers, invocation);
-        int len = getUrl().getMethodParameter(invocation.getMethodName(), Constants.RETRIES_KEY, Constants.DEFAULT_RETRIES) + 1;
-        if (len <= 0) {
-            len = 1;
+        checkInvokers(invokers, invocation);
+        int totalRetries = getRetries(getUrl(), invocation.getMethodName()) + 1;
+        if (totalRetries <= 0) {
+            totalRetries = 1;
         }
-        // retry loop.
-        RpcException le = null; // last exception.
-        List<Invoker<T>> invoked = new ArrayList<Invoker<T>>(copyinvokers.size()); // invoked invokers.
-        Set<String> providers = new HashSet<String>(len);
-        for (int i = 0; i < len; i++) {
-            //重试时，进行重新选择，避免重试时invoker列表已发生变化.
-            //注意：如果列表发生了变化，那么invoked判断会失效，因为invoker示例已经改变
-            if (i > 0) {
-                checkWhetherDestroyed();
-                copyinvokers = list(invocation);
-                //重新检查一下
-                checkInvokers(copyinvokers, invocation);
-            }
-            Invoker<T> invoker = select(loadbalance, invocation, copyinvokers, invoked);
-            invoked.add(invoker);
-            RpcContext.getContext().setInvokers((List) invoked);
-            try {
-                Result result = invoker.invoke(invocation);
-                if (le != null && logger.isWarnEnabled()) {
-                    logger.warn("Although retry the method " + invocation.getMethodName()
-                            + " in the service " + getInterface().getName()
-                            + " was successful by the provider " + invoker.getUrl().getAddress()
-                            + ", but there have been failed providers " + providers
-                            + " (" + providers.size() + "/" + copyinvokers.size()
-                            + ") from the registry " + directory.getUrl().getAddress()
-                            + " on the consumer " + NetUtils.getLocalHost()
-                            + " using the dubbo version " + Version.getVersion() + ". Last error is: "
-                            + le.getMessage(), le);
-                }
-                return result;
-            } catch (RpcException e) {
-                if (e.isBiz()) { // biz exception.
-                    throw e;
-                }
-                le = e;
-            } catch (Throwable e) {
-                le = new RpcException(e.getMessage(), e);
-            } finally {
-                providers.add(invoker.getUrl().getAddress());
-            }
+        List<Invoker<T>> invoked = new ArrayList<Invoker<T>>(totalRetries);
+        Set<String> providers = new HashSet<String>(totalRetries);
+        Holder<RpcException> lastRpcException = new Holder<RpcException>();
+        Holder<Invoker<T>> lastInvoked = new Holder<Invoker<T>>();
+
+        Result result = doInvoke(invokers, invoked, lastRpcException, providers, invocation, loadbalance, totalRetries, totalRetries, lastInvoked);
+        if (isAsync(result)) {
+            return asyncFailoverInvoke(result, invokers, invoked, providers, invocation, loadbalance, totalRetries, totalRetries, lastInvoked);
         }
-        throw new RpcException(le != null ? le.getCode() : 0, "Failed to invoke the method "
+        recordLog(invokers, lastRpcException.value, providers, invocation, lastInvoked.value);
+        return result;
+    }
+
+    private Result doInvoke(List<Invoker<T>> invokers,
+                            final List<Invoker<T>> invoked,
+                            Holder<RpcException> lastException,
+                            final Set<String> providers,
+                            final Invocation invocation,
+                            final LoadBalance loadbalance,
+                            final int totalRetries,
+                            int retries,
+                            Holder<Invoker<T>> lastInvoked) throws RpcException {
+        if (retries < totalRetries) {
+            checkWhetherDestroyed();
+            invokers = list(invocation);
+            checkInvokers(invokers, invocation);
+        }
+
+        final Invoker<T> invoker = select(loadbalance, invocation, invokers, invoked);
+        invoked.add(invoker);
+        lastInvoked.value = invoker;
+        RpcContext.getContext().setInvokers((List) invoked);
+
+        try {
+            return invoker.invoke(invocation);
+        } catch (RpcException e) {
+            //业务异常不重试
+            if (e.isBiz()) {
+                throw e;
+            }
+            lastException.value = e;
+        } catch (Throwable e) {
+            lastException.value = new RpcException(e.getMessage(), e);
+        } finally {
+            providers.add(invoker.getUrl().getAddress());
+        }
+
+        if (--retries == 0) {
+            throw populateException(invokers, lastException.value, providers, invocation, totalRetries);
+        }
+
+        return doInvoke(invokers, invoked, lastException, providers, invocation, loadbalance, totalRetries, retries, lastInvoked);
+    }
+
+    private Result asyncFailoverInvoke(final Result lastResult,
+                                       final List<Invoker<T>> copyInvokers,
+                                       final List<Invoker<T>> invoked,
+                                       final Set<String> providers,
+                                       final Invocation invocation,
+                                       final LoadBalance loadbalance,
+                                       final int totalRetries,
+                                       final int retries,
+                                       final Holder<Invoker<T>> invoker) {
+        if (retries - 1 == 0) return lastResult;
+
+        final FailoverAsyncResult result = new FailoverAsyncResult();
+        doAsyncFailoverInvoke(result, lastResult, copyInvokers, invoked, new Holder<RpcException>(), providers, invocation, loadbalance, totalRetries, retries, invoker);
+        return result;
+    }
+
+    private void doAsyncFailoverInvoke(final FailoverAsyncResult result,
+                                       final Result lastResult,
+                                       final List<Invoker<T>> copyInvokers,
+                                       final List<Invoker<T>> invoked,
+                                       final Holder<RpcException> lastException,
+                                       final Set<String> providers,
+                                       final Invocation invocation,
+                                       final LoadBalance loadBalance,
+                                       final int totalRetries,
+                                       final int retries,
+                                       final Holder<Invoker<T>> invoker) {
+        final ListenableFuture future = (ListenableFuture) lastResult;
+        future.addListener(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Object o = future.get();
+                    recordLog(copyInvokers, lastException.value, providers, invocation, invoker.value);
+                    result.setResult(o);
+                    return;
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } catch (ExecutionException e) {
+                    Throwable cause = e.getCause();
+                    if (cause instanceof RpcException) {
+                        RpcException te = (RpcException) cause;
+                        //业务异常不重试
+                        if (te.isBiz()) {
+                            result.setResult(te);
+                            return;
+                        }
+                        lastException.value = te;
+                    } else {
+                        //不是RpcException必定是业务异常
+                        result.setResult(cause);
+                        return;
+                    }
+                } catch (Throwable e) {
+                    lastException.value = new RpcException(e.getMessage(), e);
+                }
+
+                int nextRetries = retries - 1;
+                if (nextRetries == 0) {
+                    result.setResult(populateException(copyInvokers, lastException.value, providers, invocation, totalRetries));
+                } else {
+                    invocation.getAttachments().put(Constants.ASYNC_KEY, "true");
+                    Result nextResult = doInvoke(copyInvokers, invoked, lastException, providers, invocation, loadBalance, totalRetries, nextRetries, invoker);
+                    doAsyncFailoverInvoke(result, nextResult, copyInvokers, invoked, lastException, providers, invocation, loadBalance, totalRetries, nextRetries, invoker);
+                }
+            }
+        }, SAME_EXECUTOR);
+    }
+
+    private boolean isAsync(Result result) {
+        return result != null && result instanceof ListenableFuture;
+    }
+
+    private RpcException populateException(List<Invoker<T>> copyInvokers, RpcException lastException, Set<String> providers, Invocation invocation, int totalRetries) {
+        return new RpcException(lastException != null ? lastException.getCode() : 0, "Failed to invoke the method "
                 + invocation.getMethodName() + " in the service " + getInterface().getName()
-                + ". Tried " + len + " times of the providers " + providers
-                + " (" + providers.size() + "/" + copyinvokers.size()
+                + ". Tried " + totalRetries + " times of the providers " + providers
+                + " (" + providers.size() + "/" + copyInvokers.size()
                 + ") from the registry " + directory.getUrl().getAddress()
                 + " on the consumer " + NetUtils.getLocalHost() + " using the dubbo version "
                 + Version.getVersion() + ". Last error is: "
-                + (le != null ? le.getMessage() : ""), le != null && le.getCause() != null ? le.getCause() : le);
+                + (lastException != null ? lastException.getMessage() : ""), lastException != null && lastException.getCause() != null ? lastException.getCause() : lastException);
+    }
+
+    private void recordLog(List<Invoker<T>> copyInvokers,
+                           RpcException lastException,
+                           Set<String> providers,
+                           Invocation invocation,
+                           Invoker<T> successInvoker) {
+        if (lastException == null || !logger.isWarnEnabled()) return;
+        logger.warn("Although retry the method " + invocation.getMethodName()
+                + " in the service " + getInterface().getName()
+                + " was successful by the provider " + successInvoker.getUrl().getAddress()
+                + ", but there have been failed providers " + providers
+                + " (" + providers.size() + "/" + copyInvokers.size()
+                + ") from the registry " + directory.getUrl().getAddress()
+                + " on the consumer " + NetUtils.getLocalHost()
+                + " using the dubbo version " + Version.getVersion() + ". Last error is: "
+                + lastException.getMessage(), lastException);
+    }
+
+    private static class FailoverAsyncResult extends AbstractFuture implements AsyncResult {
+
+        private Object value;
+
+        private Throwable throwable;
+
+
+        @Override
+        public Object getValue() {
+            return value;
+        }
+
+        @Override
+        public Throwable getException() {
+            return throwable;
+        }
+
+        @Override
+        public boolean hasException() {
+            return throwable != null;
+        }
+
+        @Override
+        public Object recreate() throws Throwable {
+            return null;
+        }
+
+        @Override
+        public Object getResult() {
+            return null;
+        }
+
+        @Override
+        public Map<String, String> getAttachments() {
+            return null;
+        }
+
+        @Override
+        public String getAttachment(String key) {
+            return null;
+        }
+
+        @Override
+        public String getAttachment(String key, String defaultValue) {
+            return null;
+        }
+
+        public void setResult(Object value) {
+            if (value instanceof Throwable) {
+                throwable = (Throwable) value;
+                setException(throwable);
+            } else {
+                this.value = value;
+                set(value);
+            }
+        }
+    }
+
+    private static class Holder<T> {
+        public volatile T value;
     }
 
 }

--- a/dubbo-common/pom.xml
+++ b/dubbo-common/pom.xml
@@ -30,6 +30,11 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-async-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>

--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/Constants.java
@@ -579,6 +579,8 @@ public class Constants {
 
     public static final String GENERIC_SERIALIZATION_BEAN = "bean";
 
+    public static final String INTERFACES = "interfaces";
+
     /*
      * private Constants(){ }
      */

--- a/dubbo-config/dubbo-config-api/pom.xml
+++ b/dubbo-config/dubbo-config-api/pom.xml
@@ -56,6 +56,11 @@
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-async-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
             <artifactId>dubbo-registry-default</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>

--- a/dubbo-remoting/dubbo-remoting-api/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-api/pom.xml
@@ -34,5 +34,10 @@
             <artifactId>dubbo-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-rpc-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-rpc/dubbo-rpc-api/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-api/pom.xml
@@ -34,5 +34,10 @@
             <artifactId>dubbo-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-async-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/AsyncResult.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/AsyncResult.java
@@ -1,0 +1,9 @@
+package com.alibaba.dubbo.rpc;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+/**
+ * @author zhenyu.nie created on 2016 2016/11/15 21:17
+ */
+public interface AsyncResult extends Result, ListenableFuture {
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/RpcContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/RpcContext.java
@@ -15,10 +15,13 @@
  */
 package com.alibaba.dubbo.rpc;
 
+import com.alibaba.dubbo.async.AsyncContext;
+import com.alibaba.dubbo.async.AsyncContextImpl;
 import com.alibaba.dubbo.common.Constants;
 import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.common.utils.NetUtils;
 
+import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -621,5 +624,27 @@ public class RpcContext {
         } finally {
             removeAttachment(Constants.RETURN_KEY);
         }
+    }
+
+    private AsyncContext asyncContext;
+
+    private Thread dubboThread;
+
+    public void setDubboThread(Thread thread) {
+        this.dubboThread = thread;
+    }
+
+    public static <T extends Serializable> AsyncContext<T> startAsync() {
+        RpcContext current = getContext();
+        if (current.dubboThread == null || Thread.currentThread() != current.dubboThread) {
+            throw new RuntimeException("必须在服务方法的入口处调用startAsync");
+        }
+        AsyncContext<T> asyncContext = new AsyncContextImpl<T>();
+        current.asyncContext = asyncContext;
+        return asyncContext;
+    }
+
+    public AsyncContext getAsyncContext() {
+        return this.asyncContext;
     }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/proxy/AbstractProxyFactory.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/proxy/AbstractProxyFactory.java
@@ -31,7 +31,7 @@ public abstract class AbstractProxyFactory implements ProxyFactory {
 
     public <T> T getProxy(Invoker<T> invoker) throws RpcException {
         Class<?>[] interfaces = null;
-        String config = invoker.getUrl().getParameter("interfaces");
+        String config = invoker.getUrl().getParameter(Constants.INTERFACES);
         if (config != null && config.length() > 0) {
             String[] types = Constants.COMMA_SPLIT_PATTERN.split(config);
             if (types != null && types.length > 0) {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/proxy/InvokerInvocationHandler.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/proxy/InvokerInvocationHandler.java
@@ -15,11 +15,15 @@
  */
 package com.alibaba.dubbo.rpc.proxy;
 
+import com.alibaba.dubbo.common.Constants;
 import com.alibaba.dubbo.rpc.Invoker;
+import com.alibaba.dubbo.rpc.Result;
 import com.alibaba.dubbo.rpc.RpcInvocation;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * InvokerHandler
@@ -50,6 +54,13 @@ public class InvokerInvocationHandler implements InvocationHandler {
             return invoker.equals(args[0]);
         }
         return invoker.invoke(new RpcInvocation(method, args)).recreate();
+    }
+
+    public Object invokeAsync(Method method, Object[] args, String originalMethod) throws Throwable {
+        Map<String, String> attachments = new HashMap<String, String>();
+        attachments.put(Constants.ASYNC_KEY, "true");
+        RpcInvocation invocation = new RpcInvocation(originalMethod, method.getParameterTypes(), args, attachments);
+        return invoker.invoke(invocation);
     }
 
 }

--- a/dubbo-rpc/dubbo-rpc-default/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-default/pom.xml
@@ -51,6 +51,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>dubbo-remoting-netty</artifactId>
             <version>${project.parent.version}</version>

--- a/dubbo-rpc/dubbo-rpc-default/src/main/java/com/alibaba/dubbo/rpc/protocol/dubbo/AsyncRpcResult.java
+++ b/dubbo-rpc/dubbo-rpc-default/src/main/java/com/alibaba/dubbo/rpc/protocol/dubbo/AsyncRpcResult.java
@@ -1,0 +1,140 @@
+package com.alibaba.dubbo.rpc.protocol.dubbo;
+
+import com.alibaba.dubbo.remoting.RemotingException;
+import com.alibaba.dubbo.remoting.exchange.ResponseCallback;
+import com.alibaba.dubbo.remoting.exchange.ResponseFuture;
+import com.alibaba.dubbo.remoting.exchange.support.DefaultFuture;
+import com.alibaba.dubbo.rpc.AsyncResult;
+import com.alibaba.dubbo.rpc.Result;
+import com.alibaba.dubbo.rpc.RpcException;
+import com.google.common.util.concurrent.ExecutionList;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Created by zhaohui.yu
+ * 15/10/14
+ */
+class AsyncRpcResult implements AsyncResult, Serializable {
+
+    private final ExecutionList executionList = new ExecutionList();
+
+    private ResponseFuture internal;
+
+    AsyncRpcResult(ResponseFuture internal) {
+        this.internal = internal;
+
+        internal.setCallback(new ResponseCallback() {
+            @Override
+            public void done(Object response) {
+                executionList.execute();
+            }
+
+            @Override
+            public void caught(Throwable exception) {
+                executionList.execute();
+            }
+        });
+    }
+
+    @Override
+    public void addListener(final Runnable runnable, final Executor executor) {
+        executionList.add(runnable, executor);
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        if (internal instanceof DefaultFuture) {
+            ((DefaultFuture) internal).cancel();
+        }
+        return true;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return false;
+    }
+
+    @Override
+    public boolean isDone() {
+        return internal.isDone();
+    }
+
+    @Override
+    public Object get() throws InterruptedException, ExecutionException {
+        try {
+            return getWithException(internal.get());
+        } catch (com.alibaba.dubbo.remoting.TimeoutException e) {
+            throw new ExecutionException(new RpcException(RpcException.TIMEOUT_EXCEPTION, e.getMessage()));
+        } catch (RemotingException e) {
+            throw new ExecutionException(new RpcException(RpcException.NETWORK_EXCEPTION, e.getMessage()));
+        }
+    }
+
+    @Override
+    public Object get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        try {
+            return getWithException(internal.get((int) unit.toMillis(timeout)));
+        } catch (com.alibaba.dubbo.remoting.TimeoutException e) {
+            throw new TimeoutException(e.getMessage());
+        } catch (RemotingException e) {
+            throw new ExecutionException(new RpcException(RpcException.NETWORK_EXCEPTION, e.getMessage()));
+        }
+    }
+
+    private Object getWithException(Object ret) throws ExecutionException {
+        if (ret instanceof Result) {
+            Result result = (Result) ret;
+            if (result.hasException()) {
+                throw new ExecutionException(result.getException());
+            }
+            return result.getValue();
+        }
+        return ret;
+    }
+
+    @Override
+    public Object getValue() {
+        return null;
+    }
+
+    @Override
+    public Throwable getException() {
+        return null;
+    }
+
+    @Override
+    public boolean hasException() {
+        return false;
+    }
+
+    @Override
+    public Object recreate() throws Throwable {
+        return null;
+    }
+
+    @Override
+    public Object getResult() {
+        return null;
+    }
+
+    @Override
+    public Map<String, String> getAttachments() {
+        return null;
+    }
+
+    @Override
+    public String getAttachment(String key) {
+        return null;
+    }
+
+    @Override
+    public String getAttachment(String key, String defaultValue) {
+        return null;
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-default/src/main/java/com/alibaba/dubbo/rpc/protocol/dubbo/DubboInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-default/src/main/java/com/alibaba/dubbo/rpc/protocol/dubbo/DubboInvoker.java
@@ -91,7 +91,7 @@ public class DubboInvoker<T> extends AbstractInvoker<T> {
             } else if (isAsync) {
                 ResponseFuture future = currentClient.request(inv, timeout);
                 RpcContext.getContext().setFuture(new FutureAdapter<Object>(future));
-                return new RpcResult();
+                return new AsyncRpcResult(future);
             } else {
                 RpcContext.getContext().setFuture(null);
                 return (Result) currentClient.request(inv, timeout).get();

--- a/dubbo/pom.xml
+++ b/dubbo/pom.xml
@@ -31,6 +31,11 @@
     <dependencies>
         <dependency>
             <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-async-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
             <artifactId>dubbo-config-api</artifactId>
             <version>${project.parent.version}</version>
             <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <module>dubbo-simple</module>
         <module>dubbo-admin</module>
         <module>dubbo-demo</module>
+        <module>dubbo-async</module>
     </modules>
     <profiles>
         <profile>
@@ -148,6 +149,11 @@
     </properties>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>15.0</version>
+            </dependency>
             <!-- Common libs -->
             <dependency>
                 <groupId>org.springframework</groupId>


### PR DESCRIPTION
用于在dubbo提供一种比较简单易用的异步方式，dubbo现有的各种异步方式使用起来怪异且晦涩。
这篇文章是当初实现的时候写的： https://mp.weixin.qq.com/s?__biz=MzAxMjQ5NDM1Mg==&mid=403540515&idx=1&sn=129354d83482ea44570254e909eea164&mpshare=1&scene=1&srcid=0906zp1tqI9iPgO5jID4lGlY&pass_ticket=ejLNVWu2aTn%2FesrGNKlr4YFzgoFMlolUj%2BZDHroifqBxyaOFeDJXV4R9DtjJNovj#rd

麻烦review一下，看看能不能进入官方代码里，谢谢

如果要使用这种方式的异步，除了引入dubbo包本身外，还需要引入
com.alibaba:dubbo-async