### PR TITLE
fix: service config listener check should check ExporterListener

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractServiceConfig.java
@@ -198,14 +198,17 @@ public abstract class AbstractServiceConfig extends AbstractInterfaceConfig {
         this.executes = executes;
     }
 
+    @Override
     @Parameter(key = Constants.SERVICE_FILTER_KEY, append = true)
     public String getFilter() {
         return super.getFilter();
     }
 
+    @Override
     @Parameter(key = Constants.EXPORTER_LISTENER_KEY, append = true)
     public String getListener() {
-        return super.getListener();
+        checkMultiExtension(ExporterListener.class,"listener",listener);
+        return listener;
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

<dubbo:service listener="xxx" />  , AbstractServiceConfig should check ExporterListener ,not InvokerListener 
