### PR TITLE
[Dubbo-1330] Fix Support MetaspaceSize and MaxMetaspaceSize vm args in java8+

### DIFF
--- a/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.bat
+++ b/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.bat
@@ -11,8 +11,7 @@ cd ..\bin
 @REM set jvm args by different java version
 for /f tokens^=2-4^ delims^=.-_+^" %%j in ('java -fullversion 2^>^&1') do set "JAVA_VERSION=%%j%%k%%l"
 set VM_ARGS=%VM_ARGS_PERM_SIZE%
-if %JAVA_VERSION% GEQ %JAVA_8_VERSION% set VM_ARGS=%VM_ARGS_METASPACE_SIZE%
-
+if "%JAVA_VERSION%" GEQ %JAVA_8_VERSION% set VM_ARGS=%VM_ARGS_METASPACE_SIZE%
 if ""%1"" == ""debug"" goto debug
 if ""%1"" == ""jmx"" goto jmx
 

--- a/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.bat
+++ b/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.bat
@@ -1,22 +1,30 @@
 @echo off & setlocal enabledelayedexpansion
 
 set LIB_JARS=""
+set VM_ARGS_PERM_SIZE="MaxPermSize"
+set VM_ARGS_METASPACE_SIZE="MaxMetaspaceSize"
+set JAVA_8_VERSION="180"
 cd ..\lib
 for %%i in (*) do set LIB_JARS=!LIB_JARS!;..\lib\%%i
 cd ..\bin
 
+rem set jvm args by different java version
+for /f tokens^=2-4^ delims^=.-_+^" %%j in ('java -fullversion 2^>^&1') do set "JAVA_VERSION=%%j%%k%%l"
+set VM_ARGS=%VM_ARGS_PERM_SIZE%
+if %JAVA_VERSION% GEQ %JAVA_8_VERSION% set VM_ARGS=%VM_ARGS_METASPACE_SIZE%
+
 if ""%1"" == ""debug"" goto debug
 if ""%1"" == ""jmx"" goto jmx
 
-java -Xms64m -Xmx1024m -XX:MaxPermSize=64M -classpath ..\conf;%LIB_JARS% com.alibaba.dubbo.container.Main
+java -Xms64m -Xmx1024m -XX:%VM_ARGS%=64M -classpath ..\conf;%LIB_JARS% com.alibaba.dubbo.container.Main
 goto end
 
 :debug
-java -Xms64m -Xmx1024m -XX:MaxPermSize=64M -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n -classpath ..\conf;%LIB_JARS% com.alibaba.dubbo.container.Main
+java -Xms64m -Xmx1024m -XX:%VM_ARGS%=64M -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n -classpath ..\conf;%LIB_JARS% com.alibaba.dubbo.container.Main
 goto end
 
 :jmx
-java -Xms64m -Xmx1024m -XX:MaxPermSize=64M -Dcom.sun.management.jmxremote.port=1099 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -classpath ..\conf;%LIB_JARS% com.alibaba.dubbo.container.Main
+java -Xms64m -Xmx1024m -XX:%VM_ARGS%=64M -Dcom.sun.management.jmxremote.port=1099 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -classpath ..\conf;%LIB_JARS% com.alibaba.dubbo.container.Main
 
 :end
 pause

--- a/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.bat
+++ b/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.bat
@@ -8,7 +8,7 @@ cd ..\lib
 for %%i in (*) do set LIB_JARS=!LIB_JARS!;..\lib\%%i
 cd ..\bin
 
-rem set jvm args by different java version
+@REM set jvm args by different java version
 for /f tokens^=2-4^ delims^=.-_+^" %%j in ('java -fullversion 2^>^&1') do set "JAVA_VERSION=%%j%%k%%l"
 set VM_ARGS=%VM_ARGS_PERM_SIZE%
 if %JAVA_VERSION% GEQ %JAVA_8_VERSION% set VM_ARGS=%VM_ARGS_METASPACE_SIZE%

--- a/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh
+++ b/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh
@@ -12,6 +12,7 @@ SERVER_PORT=`sed '/dubbo.protocol.port/!d;s/.*=//' conf/dubbo.properties | tr -d
 LOGS_FILE=`sed '/dubbo.log4j.file/!d;s/.*=//' conf/dubbo.properties | tr -d '\r'`
 VM_ARGS_PERM_SIZE='PermSize'
 VM_ARGS_METASPACE_SIZE='MetaspaceSize'
+JAVA_8_VERSION="180"
 
 if [ -z "$SERVER_HOST" ]; then
     SERVER_HOST='127.0.0.1'
@@ -61,9 +62,9 @@ if [ "$1" = "jmx" ]; then
 fi
 JAVA_MEM_OPTS=""
 #set jvm args by different java version
-JAVA_VERSION=`java -version 2>&1 | awk -F[\"\.] -v OFS=. 'NR==1{print $3}'`
+JAVA_VERSION=`java -fullversion 2>&1 | awk -F[\"\.] '{print $2$3$4}' |awk -F"_" '{print $1}'`
 VM_ARGS=${VM_ARGS_PERM_SIZE}
-if [ "${JAVA_VERSION}" -ge "8" ]; then
+if [ "${JAVA_VERSION}" -ge ${JAVA_8_VERSION} ]; then
     VM_ARGS=${VM_ARGS_METASPACE_SIZE}
 fi
 

--- a/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh
+++ b/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh
@@ -61,7 +61,7 @@ if [ "$1" = "jmx" ]; then
     JAVA_JMX_OPTS=" -Dcom.sun.management.jmxremote.port=1099 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false "
 fi
 JAVA_MEM_OPTS=""
-#set jvm args by different java version
+# set jvm args by different java version
 JAVA_VERSION=`java -fullversion 2>&1 | awk -F[\"\.] '{print $2$3$4}' |awk -F"_" '{print $1}'`
 VM_ARGS=${VM_ARGS_PERM_SIZE}
 if [ "${JAVA_VERSION}" -ge ${JAVA_8_VERSION} ]; then

--- a/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh
+++ b/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh
@@ -64,6 +64,12 @@ JAVA_MEM_OPTS=""
 # set jvm args by different java version
 JAVA_VERSION=`java -fullversion 2>&1 | awk -F[\"\.] '{print $2$3$4}' |awk -F"_" '{print $1}'`
 VM_ARGS=${VM_ARGS_PERM_SIZE}
+# if you use dubbo in java 9
+TEMP_VERSION=$(echo ${JAVA_VERSION} | grep "+")
+if [[ "$TEMP_VERSION" != "" ]]; then
+        JAVA_VERSION=$(echo ${JAVA_VERSION} | awk -F"+" '{print $1}')
+fi
+# compare java version
 if [ "${JAVA_VERSION}" -ge ${JAVA_8_VERSION} ]; then
     VM_ARGS=${VM_ARGS_METASPACE_SIZE}
 fi

--- a/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh
+++ b/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh
@@ -10,6 +10,8 @@ SERVER_PROTOCOL=`sed '/dubbo.protocol.name/!d;s/.*=//' conf/dubbo.properties | t
 SERVER_HOST=`sed '/dubbo.protocol.host/!d;s/.*=//' conf/dubbo.properties | tr -d '\r'`
 SERVER_PORT=`sed '/dubbo.protocol.port/!d;s/.*=//' conf/dubbo.properties | tr -d '\r'`
 LOGS_FILE=`sed '/dubbo.log4j.file/!d;s/.*=//' conf/dubbo.properties | tr -d '\r'`
+VM_ARGS_PERM_SIZE='PermSize'
+VM_ARGS_METASPACE_SIZE='MetaspaceSize'
 
 if [ -z "$SERVER_HOST" ]; then
     SERVER_HOST='127.0.0.1'
@@ -58,11 +60,18 @@ if [ "$1" = "jmx" ]; then
     JAVA_JMX_OPTS=" -Dcom.sun.management.jmxremote.port=1099 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false "
 fi
 JAVA_MEM_OPTS=""
+#set jvm args by different java version
+JAVA_VERSION=`java -version 2>&1 | awk -F[\"\.] -v OFS=. 'NR==1{print $3}'`
+VM_ARGS=${VM_ARGS_PERM_SIZE}
+if [ "${JAVA_VERSION}" -ge "8" ]; then
+    VM_ARGS=${VM_ARGS_METASPACE_SIZE}
+fi
+
 BITS=`java -version 2>&1 | grep -i 64-bit`
 if [ -n "$BITS" ]; then
-    JAVA_MEM_OPTS=" -server -Xmx2g -Xms2g -Xmn256m -XX:PermSize=128m -Xss256k -XX:+DisableExplicitGC -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSCompactAtFullCollection -XX:LargePageSizeInBytes=128m -XX:+UseFastAccessorMethods -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70 "
+    JAVA_MEM_OPTS=" -server -Xmx2g -Xms2g -Xmn256m -XX:${VM_ARGS}=128m -Xss256k -XX:+DisableExplicitGC -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSCompactAtFullCollection -XX:LargePageSizeInBytes=128m -XX:+UseFastAccessorMethods -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70 "
 else
-    JAVA_MEM_OPTS=" -server -Xms1g -Xmx1g -XX:PermSize=128m -XX:SurvivorRatio=2 -XX:+UseParallelGC "
+    JAVA_MEM_OPTS=" -server -Xms1g -Xmx1g -XX:${VM_ARGS}=128m -XX:SurvivorRatio=2 -XX:+UseParallelGC "
 fi
 
 echo -e "Starting the $SERVER_NAME ...\c"


### PR DESCRIPTION
## What is the purpose of the change

see #1330 
- Support `MetaspaceSize` and `MaxMetaspaceSize ` in java8+

## Brief changelog

In linux and windows I use shell or batch to get java version by `java -fullversion`, you can see it in commit.

In the commit ,you can find I use `JAVA_8_VERSION="180"` to compare java vesion. The reasion is that java version naming rule change in java 9.

> `java -fullversion` output example  

- in jdk1.7 -> java full version "1.7.0_79-b15"
- in jdk1.7 -> java full version "1.8.0_152-b16"
- in jdk9 -> java full version "9.0.4+11"

I find many `dos` symbol in `start.sh`, if you run `start.sh` in linux, it may be a problem. I use `dos2unix` cmd to format the file.

## Verifying this change
Test result in windows 
- jdk9
![image](https://user-images.githubusercontent.com/6828647/35967816-01b849a4-0cfd-11e8-8ca9-a29e45a15cff.png)
- jdk1.8
![image](https://user-images.githubusercontent.com/6828647/35967892-3f9e4d36-0cfd-11e8-9f38-74ea1d7d2a36.png)
- jdk1.7
![image](https://user-images.githubusercontent.com/6828647/35967903-48ce1242-0cfd-11e8-90c5-1d85aae1c144.png)


