### PR TITLE
[Dubbo-unsubscribe failed] fixed zookeeper unsubscribe failed.

### DIFF
--- a/dubbo-registry/dubbo-registry-zookeeper/src/main/java/com/alibaba/dubbo/registry/zookeeper/ZookeeperRegistry.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/main/java/com/alibaba/dubbo/registry/zookeeper/ZookeeperRegistry.java
@@ -191,7 +191,10 @@ public class ZookeeperRegistry extends FailbackRegistry {
         if (listeners != null) {
             ChildListener zkListener = listeners.get(listener);
             if (zkListener != null) {
-                zkClient.removeChildListener(toUrlPath(url), zkListener);
+                // maybe url has many subscribe path
+                for(String path : toUnsubscribedPath(url)){
+                    zkClient.removeChildListener(path, zkListener);
+                }
             }
         }
     }
@@ -254,6 +257,23 @@ public class ZookeeperRegistry extends FailbackRegistry {
 
     private String toUrlPath(URL url) {
         return toCategoryPath(url) + Constants.PATH_SEPARATOR + URL.encode(url.toFullString());
+    }
+
+    protected List<String> toUnsubscribedPath(URL url){
+        List<String> categories = new ArrayList<String>();
+        if(Constants.ANY_VALUE.equals(url.getServiceInterface())) {
+            String group = url.getParameter(Constants.GROUP_KEY, DEFAULT_ROOT);
+            if (!group.startsWith(Constants.PATH_SEPARATOR)) {
+                group = Constants.PATH_SEPARATOR + group;
+            }
+            categories.add(group);
+            return categories;
+        }else{
+            for (String path : toCategoriesPath(url)) {
+                categories.add(path);
+            }
+        }
+        return categories;
     }
 
     private List<URL> toUrlsWithoutEmpty(URL consumer, List<String> providers) {


### PR DESCRIPTION
## What is the purpose of the change

Got failed when unsubscribe any url from zookeeper.

## Brief changelog  com.alibaba.dubbo.registry.zookeeper.ZookeeperRegistry：
``` java
     protected void doUnsubscribe(URL url, NotifyListener listener) {
         ConcurrentMap<NotifyListener, ChildListener> listeners = zkListeners.get(url);
         if (listeners != null) {
             ChildListener zkListener = listeners.get(listener);
             if (zkListener != null) {
-                zkClient.removeChildListener(toUrlPath(url), zkListener);
+                // maybe url has many subscribe path
+                for(String path : toUnsubscribedPath(url)){
+                    zkClient.removeChildListener(path, zkListener);
+                }
             }
         }
     }

+    protected List<String> toUnsubscribedPath(URL url){
+        List<String> categories = new ArrayList<String>();
+        if(Constants.ANY_VALUE.equals(url.getServiceInterface())) {
+            String group = url.getParameter(Constants.GROUP_KEY, DEFAULT_ROOT);
+            if (!group.startsWith(Constants.PATH_SEPARATOR)) {
+                group = Constants.PATH_SEPARATOR + group;
+            }
+            categories.add(group);
+            return categories;
+        }else{
+            for (String path : toCategoriesPath(url)) {
+                categories.add(path);
+            }
+        }
+        return categories;
+    }
```

## Verifying this change

see: com.youzan.dubbo.registry.etcd.EtcdRegistryTest#test_unsubscribe

``` java
    @Test
    @Ignore public void test_unsubscribe() throws InterruptedException {

        registry.unregister(serviceUrl);

        Assert.assertTrue(registry.getRegistered().size() == 0);
        Assert.assertTrue(registry.getSubscribed().size() == 0);

        final CountDownLatch notNotified = new CountDownLatch(2);

        final AtomicReference<URL> notifiedUrl = new AtomicReference<URL>();

        NotifyListener listener = new NotifyListener() {
            public void notify(List<URL> urls) {
                if(urls != null) {
                    for(Iterator<URL> iterator = urls.iterator(); iterator.hasNext();) {
                        URL url = iterator.next();
                        if(!url.getProtocol().equals("empty")){
                            notifiedUrl.set(url);
                            notNotified.countDown();
                        }
                    }
                }
            }
        };
        registry.subscribe(consumerUrl, listener);
        registry.unsubscribe(consumerUrl, listener);

        registry.register(serviceUrl);

        Assert.assertFalse(notNotified.await(2, TimeUnit.SECONDS));
        // expect nothing happen
        Assert.assertTrue(notifiedUrl.get() == null);
    }
```

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/alibaba/dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
