### PR TITLE
Fix typo for remoting module

### DIFF
--- a/dubbo-remoting/dubbo-remoting-grizzly/src/main/java/com/alibaba/dubbo/remoting/transport/grizzly/GrizzlyChannel.java
+++ b/dubbo-remoting/dubbo-remoting-grizzly/src/main/java/com/alibaba/dubbo/remoting/transport/grizzly/GrizzlyChannel.java
@@ -75,7 +75,7 @@ final class GrizzlyChannel extends AbstractChannel {
         return ret;
     }
 
-    static void removeChannelIfDisconnectd(Connection<?> connection) {
+    static void removeChannelIfDisconnected(Connection<?> connection) {
         if (connection != null && !connection.isOpen()) {
             ATTRIBUTE.remove(connection);
         }
@@ -119,7 +119,7 @@ final class GrizzlyChannel extends AbstractChannel {
             logger.warn(e.getMessage(), e);
         }
         try {
-            removeChannelIfDisconnectd(connection);
+            removeChannelIfDisconnected(connection);
         } catch (Exception e) {
             logger.warn(e.getMessage(), e);
         }

--- a/dubbo-remoting/dubbo-remoting-grizzly/src/main/java/com/alibaba/dubbo/remoting/transport/grizzly/GrizzlyClient.java
+++ b/dubbo-remoting/dubbo-remoting-grizzly/src/main/java/com/alibaba/dubbo/remoting/transport/grizzly/GrizzlyClient.java
@@ -83,7 +83,7 @@ public class GrizzlyClient extends AbstractClient {
     @Override
     protected void doDisConnect() throws Throwable {
         try {
-            GrizzlyChannel.removeChannelIfDisconnectd(connection);
+            GrizzlyChannel.removeChannelIfDisconnected(connection);
         } catch (Throwable t) {
             logger.warn(t.getMessage());
         }

--- a/dubbo-remoting/dubbo-remoting-grizzly/src/main/java/com/alibaba/dubbo/remoting/transport/grizzly/GrizzlyCodecAdapter.java
+++ b/dubbo-remoting/dubbo-remoting-grizzly/src/main/java/com/alibaba/dubbo/remoting/transport/grizzly/GrizzlyCodecAdapter.java
@@ -66,14 +66,14 @@ public class GrizzlyCodecAdapter extends BaseFilter {
             Object msg = context.getMessage();
             codec.encode(channel, channelBuffer, msg);
 
-            GrizzlyChannel.removeChannelIfDisconnectd(connection);
+            GrizzlyChannel.removeChannelIfDisconnected(connection);
             Buffer buffer = connection.getTransport().getMemoryManager().allocate(channelBuffer.readableBytes());
             buffer.put(channelBuffer.toByteBuffer());
             buffer.flip();
             buffer.allowBufferDispose(true);
             context.setMessage(buffer);
         } finally {
-            GrizzlyChannel.removeChannelIfDisconnectd(connection);
+            GrizzlyChannel.removeChannelIfDisconnected(connection);
         }
         return context.getInvokeAction();
     }
@@ -134,7 +134,7 @@ public class GrizzlyCodecAdapter extends BaseFilter {
                 return context.getInvokeAction();
             }
         } finally {
-            GrizzlyChannel.removeChannelIfDisconnectd(connection);
+            GrizzlyChannel.removeChannelIfDisconnected(connection);
         }
     }
 

--- a/dubbo-remoting/dubbo-remoting-grizzly/src/main/java/com/alibaba/dubbo/remoting/transport/grizzly/GrizzlyHandler.java
+++ b/dubbo-remoting/dubbo-remoting-grizzly/src/main/java/com/alibaba/dubbo/remoting/transport/grizzly/GrizzlyHandler.java
@@ -55,7 +55,7 @@ public class GrizzlyHandler extends BaseFilter {
         } catch (RemotingException e) {
             throw new IOException(StringUtils.toString(e));
         } finally {
-            GrizzlyChannel.removeChannelIfDisconnectd(connection);
+            GrizzlyChannel.removeChannelIfDisconnected(connection);
         }
         return ctx.getInvokeAction();
     }
@@ -69,7 +69,7 @@ public class GrizzlyHandler extends BaseFilter {
         } catch (RemotingException e) {
             throw new IOException(StringUtils.toString(e));
         } finally {
-            GrizzlyChannel.removeChannelIfDisconnectd(connection);
+            GrizzlyChannel.removeChannelIfDisconnected(connection);
         }
         return ctx.getInvokeAction();
     }
@@ -83,7 +83,7 @@ public class GrizzlyHandler extends BaseFilter {
         } catch (RemotingException e) {
             throw new IOException(StringUtils.toString(e));
         } finally {
-            GrizzlyChannel.removeChannelIfDisconnectd(connection);
+            GrizzlyChannel.removeChannelIfDisconnected(connection);
         }
         return ctx.getInvokeAction();
     }
@@ -97,7 +97,7 @@ public class GrizzlyHandler extends BaseFilter {
         } catch (RemotingException e) {
             throw new IOException(StringUtils.toString(e));
         } finally {
-            GrizzlyChannel.removeChannelIfDisconnectd(connection);
+            GrizzlyChannel.removeChannelIfDisconnected(connection);
         }
         return ctx.getInvokeAction();
     }
@@ -111,7 +111,7 @@ public class GrizzlyHandler extends BaseFilter {
         } catch (RemotingException e) {
             logger.error("RemotingException on channel " + channel, e);
         } finally {
-            GrizzlyChannel.removeChannelIfDisconnectd(connection);
+            GrizzlyChannel.removeChannelIfDisconnected(connection);
         }
     }
 

--- a/dubbo-remoting/dubbo-remoting-mina/src/main/java/com/alibaba/dubbo/remoting/transport/mina/MinaChannel.java
+++ b/dubbo-remoting/dubbo-remoting-mina/src/main/java/com/alibaba/dubbo/remoting/transport/mina/MinaChannel.java
@@ -66,7 +66,7 @@ final class MinaChannel extends AbstractChannel {
         return ret;
     }
 
-    static void removeChannelIfDisconnectd(IoSession session) {
+    static void removeChannelIfDisconnected(IoSession session) {
         if (session != null && !session.isConnected()) {
             session.removeAttribute(CHANNEL_KEY);
         }
@@ -112,7 +112,7 @@ final class MinaChannel extends AbstractChannel {
             logger.warn(e.getMessage(), e);
         }
         try {
-            removeChannelIfDisconnectd(session);
+            removeChannelIfDisconnected(session);
         } catch (Exception e) {
             logger.warn(e.getMessage(), e);
         }

--- a/dubbo-remoting/dubbo-remoting-mina/src/main/java/com/alibaba/dubbo/remoting/transport/mina/MinaClient.java
+++ b/dubbo-remoting/dubbo-remoting-mina/src/main/java/com/alibaba/dubbo/remoting/transport/mina/MinaClient.java
@@ -107,7 +107,7 @@ public class MinaClient extends AbstractClient {
                                     }
                                     oldSession.close();
                                 } finally {
-                                    MinaChannel.removeChannelIfDisconnectd(oldSession);
+                                    MinaChannel.removeChannelIfDisconnected(oldSession);
                                 }
                             }
                         } finally {
@@ -119,7 +119,7 @@ public class MinaClient extends AbstractClient {
                                     newSession.close();
                                 } finally {
                                     MinaClient.this.session = null;
-                                    MinaChannel.removeChannelIfDisconnectd(newSession);
+                                    MinaChannel.removeChannelIfDisconnected(newSession);
                                 }
                             } else {
                                 MinaClient.this.session = newSession;
@@ -150,7 +150,7 @@ public class MinaClient extends AbstractClient {
     @Override
     protected void doDisConnect() throws Throwable {
         try {
-            MinaChannel.removeChannelIfDisconnectd(session);
+            MinaChannel.removeChannelIfDisconnected(session);
         } catch (Throwable t) {
             logger.warn(t.getMessage());
         }

--- a/dubbo-remoting/dubbo-remoting-mina/src/main/java/com/alibaba/dubbo/remoting/transport/mina/MinaCodecAdapter.java
+++ b/dubbo-remoting/dubbo-remoting-mina/src/main/java/com/alibaba/dubbo/remoting/transport/mina/MinaCodecAdapter.java
@@ -77,7 +77,7 @@ final class MinaCodecAdapter implements ProtocolCodecFactory {
             try {
                 codec.encode(channel, buffer, msg);
             } finally {
-                MinaChannel.removeChannelIfDisconnectd(session);
+                MinaChannel.removeChannelIfDisconnected(session);
             }
             out.write(ByteBuffer.wrap(buffer.toByteBuffer()));
             out.flush();
@@ -141,7 +141,7 @@ final class MinaCodecAdapter implements ProtocolCodecFactory {
                 } else {
                     buffer = ChannelBuffers.EMPTY_BUFFER;
                 }
-                MinaChannel.removeChannelIfDisconnectd(session);
+                MinaChannel.removeChannelIfDisconnected(session);
             }
         }
 

--- a/dubbo-remoting/dubbo-remoting-mina/src/main/java/com/alibaba/dubbo/remoting/transport/mina/MinaHandler.java
+++ b/dubbo-remoting/dubbo-remoting-mina/src/main/java/com/alibaba/dubbo/remoting/transport/mina/MinaHandler.java
@@ -48,7 +48,7 @@ public class MinaHandler extends IoHandlerAdapter {
         try {
             handler.connected(channel);
         } finally {
-            MinaChannel.removeChannelIfDisconnectd(session);
+            MinaChannel.removeChannelIfDisconnected(session);
         }
     }
 
@@ -58,7 +58,7 @@ public class MinaHandler extends IoHandlerAdapter {
         try {
             handler.disconnected(channel);
         } finally {
-            MinaChannel.removeChannelIfDisconnectd(session);
+            MinaChannel.removeChannelIfDisconnected(session);
         }
     }
 
@@ -68,7 +68,7 @@ public class MinaHandler extends IoHandlerAdapter {
         try {
             handler.received(channel, message);
         } finally {
-            MinaChannel.removeChannelIfDisconnectd(session);
+            MinaChannel.removeChannelIfDisconnected(session);
         }
     }
 
@@ -78,7 +78,7 @@ public class MinaHandler extends IoHandlerAdapter {
         try {
             handler.sent(channel, message);
         } finally {
-            MinaChannel.removeChannelIfDisconnectd(session);
+            MinaChannel.removeChannelIfDisconnected(session);
         }
     }
 
@@ -88,7 +88,7 @@ public class MinaHandler extends IoHandlerAdapter {
         try {
             handler.caught(channel, cause);
         } finally {
-            MinaChannel.removeChannelIfDisconnectd(session);
+            MinaChannel.removeChannelIfDisconnected(session);
         }
     }
 

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/logging/FormattingTuple.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/logging/FormattingTuple.java
@@ -46,9 +46,9 @@ class FormattingTuple {
         if (argArray == null || argArray.length == 0) {
             throw new IllegalStateException("non-sensical empty or null argument array");
         }
-        final int trimemdLen = argArray.length - 1;
-        Object[] trimmed = new Object[trimemdLen];
-        System.arraycopy(argArray, 0, trimmed, 0, trimemdLen);
+        final int trimmedLen = argArray.length - 1;
+        Object[] trimmed = new Object[trimmedLen];
+        System.arraycopy(argArray, 0, trimmed, 0, trimmedLen);
         return trimmed;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Fix typo from `Disconnectd` to `Disconnected`
Fix typo from `trimemdLen` to `trimmedLen`

