### PR TITLE
Fix #1411 Java Locale use '_' split language, country, variant.

### DIFF
--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/LocaleHandle.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/LocaleHandle.java
@@ -54,17 +54,37 @@ import java.util.Locale;
  * Handle for a locale object.
  */
 public class LocaleHandle implements java.io.Serializable, HessianHandle {
-    private String language;
-    private String country;
-    private String variant;
+    private String value;
 
-    public LocaleHandle(String language, String country, String variant) {
-        this.language = language;
-        this.country = country;
-        this.variant = variant;
+    public LocaleHandle(String locale) {
+        this.value = locale;
     }
 
     private Object readResolve() {
+        if (value == null) {
+            return null;
+        }
+
+        if (value.length() == 0) {
+            return new Locale("");
+        }
+
+        int extStart = value.indexOf("_#");
+        if (extStart != -1) value = value.substring(0, extStart);
+
+        String language = value, country = "", variant = "";
+        int pos1 = value.indexOf('_');
+        if (pos1 != -1) {
+            language = value.substring(0, pos1++);
+
+            int pos2 = value.indexOf('_', pos1);
+            if (pos2 == -1) {
+                country = value.substring(pos1);
+            } else {
+                country = value.substring(pos1, pos2);
+                variant = value.substring(pos2 + 1);
+            }
+        }
         return new Locale(language, country, variant);
     }
 }

--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/LocaleSerializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/LocaleSerializer.java
@@ -68,7 +68,7 @@ public class LocaleSerializer extends AbstractSerializer {
         else {
             Locale locale = (Locale) obj;
 
-            out.writeObject(new LocaleHandle(locale.getLanguage(), locale.getCountry(), locale.getVariant()));
+            out.writeObject(new LocaleHandle(locale.toString()));
         }
     }
 }

--- a/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/LocaleSerializerTest.java
+++ b/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/LocaleSerializerTest.java
@@ -1,41 +1,29 @@
 package com.alibaba.com.caucho.hessian.io;
 
-import com.alibaba.com.caucho.hessian.io.base.SerializeTestBase;
-import junit.framework.TestCase;
-import org.junit.Test;
-
+import java.io.IOException;
 import java.util.Locale;
 
+import org.junit.Test;
+
+import com.alibaba.com.caucho.hessian.io.base.SerializeTestBase;
+
+import junit.framework.TestCase;
+
 public class LocaleSerializerTest extends SerializeTestBase {
+
+    /** {@linkplain LocaleSerializer#writeObject(Object, AbstractHessianOutput)} */
     @Test
-    public void hessian2() throws Exception {
-        Locale locale = new Locale("zh");
-        Locale result = baseHession2Serialize(locale);
-        TestCase.assertEquals(locale, result);
-        locale = new Locale("zh", "CN");
-        result = baseHession2Serialize(locale);
-        TestCase.assertEquals(locale, result);
-        locale = new Locale("zh", "CN", "GBK");
-        result = baseHession2Serialize(locale);
-        TestCase.assertEquals(locale, result);
-        locale = new Locale("zh-hant", "CN");
-        result = baseHession2Serialize(locale);
-        TestCase.assertEquals(locale, result);
+    public void locale() throws IOException {
+        assertLocale(null);
+        assertLocale(new Locale(""));
+        assertLocale(new Locale("zh"));
+        assertLocale(new Locale("zh", "CN"));
+        assertLocale(new Locale("zh-hant", "CN"));
+        assertLocale(new Locale("zh-hant", "CN", "GBK"));
     }
 
-    @Test
-    public void hessian1() throws Exception {
-        Locale locale = new Locale("zh");
-        Locale result = baseHessionSerialize(locale);
-        TestCase.assertEquals(locale, result);
-        locale = new Locale("zh", "CN");
-        result = baseHessionSerialize(locale);
-        TestCase.assertEquals(locale, result);
-        locale = new Locale("zh", "CN", "GBK");
-        result = baseHessionSerialize(locale);
-        TestCase.assertEquals(locale, result);
-        locale = new Locale("zh-hant", "CN");
-        result = baseHessionSerialize(locale);
-        TestCase.assertEquals(locale, result);
+    private void assertLocale(Locale locale) throws IOException {
+        TestCase.assertEquals(locale, baseHession2Serialize(locale));
+        TestCase.assertEquals(locale, baseHessionSerialize(locale));
     }
 }


### PR DESCRIPTION
see #1411 

Java Locale.toString() split language, country and variant with char `\_`.

but not support the extentions, because of truncate `\_#.*` in the commit.