### PR TITLE
修复使用simpleregistry时provider注册异常

### DIFF
--- a/dubbo-simple/dubbo-registry-simple/src/main/java/com/alibaba/dubbo/registry/simple/SimpleRegistryService.java
+++ b/dubbo-simple/dubbo-registry-simple/src/main/java/com/alibaba/dubbo/registry/simple/SimpleRegistryService.java
@@ -57,7 +57,7 @@ public class SimpleRegistryService extends AbstractRegistry {
         List<URL> urls = new ArrayList<URL>();
         for (URL u : getRegistered()) {
             if (UrlUtils.isMatch(url, u)) {
-                urls.add(u);
+            	urls.add(u.clearParameters());
             }
         }
         return urls;


### PR DESCRIPTION
修复使用simpleregistry时provider注册异常，原因：simpleregistry在notify时将URL对象中的para
meters中的bind.port传给客户端，导致异常

[21/03/18 06:07:16:016 CST] New I/O client worker #1-1  INFO dubbo.CallbackServiceCodec:  [DUBBO] Not found exported service: com.alibaba.dubbo.registry.NotifyListener.617013740:61709 in [com.alibaba.dubbo.registry.NotifyListener.1141296884:61709, com.alibaba.dubbo.registry.NotifyListener.617013740:9090, com.alibaba.dubbo.demo.DemoService:20880], may be version or group mismatch , channel: consumer: /192.168.84.31:9090 --> provider: /192.168.84.31:61709, message:RpcInvocation [methodName=notify, parameterTypes=[interface java.util.List], arguments=null, attachments={dubbo=2.0.1, input=721, _isCallBackServiceInvoke=true, sys_callback_arg-1=617013740, path=com.alibaba.dubbo.registry.NotifyListener, callback.service.instid=617013740, interface=com.alibaba.dubbo.registry.RegistryService, version=null}], dubbo version: 2.0.1, current host: 192.168.84.31
com.alibaba.dubbo.remoting.RemotingException: Not found exported service: com.alibaba.dubbo.registry.NotifyListener.617013740:61709 in [com.alibaba.dubbo.registry.NotifyListener.1141296884:61709, com.alibaba.dubbo.registry.NotifyListener.617013740:9090, com.alibaba.dubbo.demo.DemoService:20880], may be version or group mismatch , channel: consumer: /192.168.84.31:9090 --> provider: /192.168.84.31:61709, message:RpcInvocation [methodName=notify, parameterTypes=[interface java.util.List], arguments=null, attachments={dubbo=2.0.1, input=721, _isCallBackServiceInvoke=true, sys_callback_arg-1=617013740, path=com.alibaba.dubbo.registry.NotifyListener, callback.service.instid=617013740, interface=com.alibaba.dubbo.registry.RegistryService, version=null}]
	at com.alibaba.dubbo.rpc.protocol.dubbo.DubboProtocol.getInvoker(DubboProtocol.java:202)
	at com.alibaba.dubbo.rpc.protocol.dubbo.CallbackServiceCodec.decodeInvocationArgument(CallbackServiceCodec.java:270)
	at com.alibaba.dubbo.rpc.protocol.dubbo.DecodeableRpcInvocation.decode(DecodeableRpcInvocation.java:127)
	at com.alibaba.dubbo.rpc.protocol.dubbo.DecodeableRpcInvocation.decode(DecodeableRpcInvocation.java:68)
	at com.alibaba.dubbo.rpc.protocol.dubbo.DubboCodec.decodeBody(DubboCodec.java:128)
	at com.alibaba.dubbo.remoting.exchange.codec.ExchangeCodec.decode(ExchangeCodec.java:120)
	at com.alibaba.dubbo.remoting.exchange.codec.ExchangeCodec.decode(ExchangeCodec.java:81)
	at com.alibaba.dubbo.rpc.protocol.dubbo.DubboCountCodec.decode(DubboCountCodec.java:44)
	at com.alibaba.dubbo.remoting.transport.netty.NettyCodecAdapter$InternalDecoder.messageReceived(NettyCodecAdapter.java:133)
	at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:80)
	at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:564)
	at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:559)
	at org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:274)
	at org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:261)
	at org.jboss.netty.channel.socket.nio.NioWorker.read(NioWorker.java:349)
	at org.jboss.netty.channel.socket.nio.NioWorker.processSelectedKeys(NioWorker.java:280)
	at org.jboss.netty.channel.socket.nio.NioWorker.run(NioWorker.java:200)
	at org.jboss.netty.util.ThreadRenamingRunnable.run(ThreadRenamingRunnable.java:108)
	at org.jboss.netty.util.internal.DeadLockProofWorker$1.run(DeadLockProofWorker.java:44)
	at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:895)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:918)
	at java.lang.Thread.run(Thread.java:662)