### PR TITLE
Mirror improvement for test cases in dubbo-rpc-api module

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/com/alibaba/dubbo/rpc/filter/tps/StatItemTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/com/alibaba/dubbo/rpc/filter/tps/StatItemTest.java
@@ -19,8 +19,8 @@ package com.alibaba.dubbo.rpc.filter.tps;
 import org.junit.After;
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class StatItemTest {
 

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/com/alibaba/dubbo/rpc/support/RpcUtilsTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/com/alibaba/dubbo/rpc/support/RpcUtilsTest.java
@@ -21,11 +21,15 @@ import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.rpc.Invocation;
 import com.alibaba.dubbo.rpc.RpcInvocation;
 
-import junit.framework.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 
 public class RpcUtilsTest {
 
@@ -43,9 +47,9 @@ public class RpcUtilsTest {
         long id1 = RpcUtils.getInvocationId(inv);
         RpcUtils.attachInvocationIdIfAsync(url, inv);
         long id2 = RpcUtils.getInvocationId(inv);
-        Assert.assertTrue(id1 == id2); // verify if it's idempotent
-        Assert.assertTrue(id1 >= 0);
-        Assert.assertEquals("bb", attachments.get("aa"));
+        assertTrue(id1 == id2); // verify if it's idempotent
+        assertTrue(id1 >= 0);
+        assertEquals("bb", attachments.get("aa"));
     }
 
     /**
@@ -57,7 +61,7 @@ public class RpcUtilsTest {
         URL url = URL.valueOf("dubbo://localhost/");
         Invocation inv = new RpcInvocation("test", new Class[]{}, new String[]{});
         RpcUtils.attachInvocationIdIfAsync(url, inv);
-        Assert.assertNull(RpcUtils.getInvocationId(inv));
+        assertNull(RpcUtils.getInvocationId(inv));
     }
 
     /**
@@ -69,7 +73,7 @@ public class RpcUtilsTest {
         URL url = URL.valueOf("dubbo://localhost/?test.async=true");
         Invocation inv = new RpcInvocation("test", new Class[]{}, new String[]{});
         RpcUtils.attachInvocationIdIfAsync(url, inv);
-        Assert.assertTrue(RpcUtils.getInvocationId(inv) >= 0l);
+        assertTrue(RpcUtils.getInvocationId(inv) >= 0l);
     }
 
     /**
@@ -81,7 +85,7 @@ public class RpcUtilsTest {
         URL url = URL.valueOf("dubbo://localhost/?test.async=true&" + Constants.AUTO_ATTACH_INVOCATIONID_KEY + "=false");
         Invocation inv = new RpcInvocation("test", new Class[]{}, new String[]{});
         RpcUtils.attachInvocationIdIfAsync(url, inv);
-        Assert.assertNull(RpcUtils.getInvocationId(inv));
+        assertNull(RpcUtils.getInvocationId(inv));
     }
 
     /**
@@ -93,6 +97,6 @@ public class RpcUtilsTest {
         URL url = URL.valueOf("dubbo://localhost/?" + Constants.AUTO_ATTACH_INVOCATIONID_KEY + "=true");
         Invocation inv = new RpcInvocation("test", new Class[]{}, new String[]{});
         RpcUtils.attachInvocationIdIfAsync(url, inv);
-        Assert.assertNotNull(RpcUtils.getInvocationId(inv));
+        assertNotNull(RpcUtils.getInvocationId(inv));
     }
 }


### PR DESCRIPTION

## What is the purpose of the change
In dubbo-rpc-api module:
1.  Since junit.framework.Assert are deprecated since Junit 4 and other test case classes in this module have already use org.junit.Assert for instead, it is necessary to update related codes in StatItemTest  and RpcUtilsTest.
2.  Make codes more easy to read


## Brief changelog
In dubbo-rpc-api module:
1. Use org.junit.Assert instead of junit.framework.Assert(@Deprecated since Junit 4)
2. Use assertTrue and other assert methods through static import to make codes easier to read

## Verifying this change

Test cases run with success

