### PR TITLE
Add feature：require Reference service dynamically

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/RefConf.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/RefConf.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 1999-2012 Alibaba Group.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.config;
+
+/**
+ * Reference  注解对应的实体配置类
+ * 
+ * @author zhouzhipeng
+ */
+public class RefConf {
+
+   public Class<?> interfaceClass = void.class;
+
+   public String interfaceName = "";
+
+   public String version = "";
+
+   public String group = "";
+
+   public String url = "";
+
+   public String client = "";
+
+   public boolean generic = false;
+
+   public boolean injvm = false;
+
+   public boolean check = true;
+
+   public boolean init = false;
+
+   public boolean lazy = false;
+
+   public boolean stubevent = false;
+
+   public String reconnect = "";
+
+   public boolean sticky = false;
+
+   public String proxy = "";
+
+   public String stub = "";
+
+   public String cluster = "";
+
+   public int connections = 0;
+
+   public int callbacks = 0;
+
+   public String onconnect = "";
+
+   public String ondisconnect = "";
+
+   public String owner = "";
+
+   public String layer = "";
+
+   public int retries = 0;
+
+   public String loadbalance = "";
+
+   public boolean async = false;
+
+   public int actives = 0;
+
+   public boolean sent = false;
+
+   public String mock = "";
+
+   public String validation = "";
+
+   public int timeout = 0;
+
+   public String cache = "";
+
+   public String[] filter = {};
+
+   public String[] listener = {};
+
+   public String[] parameters = {};
+
+   public String application = "";
+
+   public String module = "";
+
+   public String consumer = "";
+
+   public String monitor = "";
+
+   public String protocol = "";
+
+   public String[] registry = {};
+
+}

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/AnnotationBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/AnnotationBean.java
@@ -96,6 +96,14 @@ public class AnnotationBean extends AbstractConfig implements DisposableBean, Be
                 // spring 2.0
             }
         }
+
+
+        //
+        if(!beanFactory.containsBean(DynamicReferenceService.class.getName())) {
+            //注册服务bean
+            beanFactory.registerSingleton(DynamicReferenceService.class.getName(), new DynamicReferenceService(this));
+        }
+
     }
 
     public void destroy() throws Exception {
@@ -273,6 +281,73 @@ public class AnnotationBean extends AbstractConfig implements DisposableBean, Be
                 }
                 if (reference.consumer() != null && reference.consumer().length() > 0) {
                     referenceConfig.setConsumer((ConsumerConfig) applicationContext.getBean(reference.consumer(), ConsumerConfig.class));
+                }
+                try {
+                    referenceConfig.afterPropertiesSet();
+                } catch (RuntimeException e) {
+                    throw (RuntimeException) e;
+                } catch (Exception e) {
+                    throw new IllegalStateException(e.getMessage(), e);
+                }
+            }
+            referenceConfigs.putIfAbsent(key, referenceConfig);
+            referenceConfig = referenceConfigs.get(key);
+        }
+        return referenceConfig.get();
+    }
+
+    /**
+     * refer 方法的公开版，将注解参数Reference换为 ReferenceConf 类
+     * @param reference
+     * @param referenceClass
+     * @return
+     */
+    public Object referNew(RefConf reference, Class<?> referenceClass) { //method.getParameterTypes()[0]
+        String interfaceName;
+
+        if (! "".equals( reference.interfaceName)) {
+            interfaceName =  reference.interfaceName;
+        } else if (! void.class.equals( reference.interfaceClass)) {
+            interfaceName =  reference.interfaceClass.getName();
+        } else if (referenceClass.isInterface()) {
+            interfaceName = referenceClass.getName();
+        } else {
+            throw new IllegalStateException("The @Reference undefined interfaceClass or interfaceName, and the property type " + referenceClass.getName() + " is not a interface.");
+        }
+        String key =  reference.group + "/" + interfaceName + ":" +  reference.version;
+        ReferenceBean<?> referenceConfig = referenceConfigs.get(key);
+        if (referenceConfig == null) {
+            referenceConfig = new ReferenceBean<Object>(reference);
+            if (void.class.equals( reference.interfaceClass)
+                    && "".equals( reference.interfaceName)
+                    && referenceClass.isInterface()) {
+                referenceConfig.setInterface(referenceClass);
+            }
+            if (applicationContext != null) {
+                referenceConfig.setApplicationContext(applicationContext);
+                if ( reference.registry != null &&  reference.registry.length > 0) {
+                    List<RegistryConfig> registryConfigs = new ArrayList<RegistryConfig>();
+                    for (String registryId :  reference.registry) {
+                        if (registryId != null && registryId.length() > 0) {
+                            registryConfigs.add((RegistryConfig)applicationContext.getBean(registryId, RegistryConfig.class));
+                        }
+                    }
+                    referenceConfig.setRegistries(registryConfigs);
+                }
+                if ( reference.consumer != null &&  reference.consumer.length() > 0) {
+                    referenceConfig.setConsumer((ConsumerConfig)applicationContext.getBean( reference.consumer, ConsumerConfig.class));
+                }
+                if ( reference.monitor != null &&  reference.monitor.length() > 0) {
+                    referenceConfig.setMonitor((MonitorConfig)applicationContext.getBean( reference.monitor, MonitorConfig.class));
+                }
+                if ( reference.application != null &&  reference.application.length() > 0) {
+                    referenceConfig.setApplication((ApplicationConfig)applicationContext.getBean( reference.application, ApplicationConfig.class));
+                }
+                if ( reference.module != null &&  reference.module.length() > 0) {
+                    referenceConfig.setModule((ModuleConfig)applicationContext.getBean( reference.module, ModuleConfig.class));
+                }
+                if ( reference.consumer != null &&  reference.consumer.length() > 0) {
+                    referenceConfig.setConsumer((ConsumerConfig)applicationContext.getBean( reference.consumer, ConsumerConfig.class));
                 }
                 try {
                     referenceConfig.afterPropertiesSet();

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/AnnotationBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/AnnotationBean.java
@@ -34,6 +34,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -237,67 +238,28 @@ public class AnnotationBean extends AbstractConfig implements DisposableBean, Be
     }
 
     private Object refer(Reference reference, Class<?> referenceClass) { //method.getParameterTypes()[0]
-        String interfaceName;
-        if (!"".equals(reference.interfaceName())) {
-            interfaceName = reference.interfaceName();
-        } else if (!void.class.equals(reference.interfaceClass())) {
-            interfaceName = reference.interfaceClass().getName();
-        } else if (referenceClass.isInterface()) {
-            interfaceName = referenceClass.getName();
-        } else {
-            throw new IllegalStateException("The @Reference undefined interfaceClass or interfaceName, and the property type " + referenceClass.getName() + " is not a interface.");
-        }
-        String key = reference.group() + "/" + interfaceName + ":" + reference.version();
-        ReferenceBean<?> referenceConfig = referenceConfigs.get(key);
-        if (referenceConfig == null) {
-            referenceConfig = new ReferenceBean<Object>(reference);
-            if (void.class.equals(reference.interfaceClass())
-                    && "".equals(reference.interfaceName())
-                    && referenceClass.isInterface()) {
-                referenceConfig.setInterface(referenceClass);
-            }
-            if (applicationContext != null) {
-                referenceConfig.setApplicationContext(applicationContext);
-                if (reference.registry() != null && reference.registry().length > 0) {
-                    List<RegistryConfig> registryConfigs = new ArrayList<RegistryConfig>();
-                    for (String registryId : reference.registry()) {
-                        if (registryId != null && registryId.length() > 0) {
-                            registryConfigs.add((RegistryConfig) applicationContext.getBean(registryId, RegistryConfig.class));
-                        }
+        RefConf refConf=new RefConf();
+
+        //将注解类reference上的属性复制到refConf
+        for(Field field:refConf.getClass().getFields()){
+            for(Method method:reference.getClass().getMethods()){
+                if(method.getName().equals(field.getName())){
+                    try {
+                        field.set(refConf,method.invoke(reference));
+                    } catch (IllegalAccessException e) {
+                        logger.error("error @Reference or RefConf definition");
+                    } catch (InvocationTargetException e) {
+                        logger.error("error @Reference or RefConf definition");
                     }
-                    referenceConfig.setRegistries(registryConfigs);
-                }
-                if (reference.consumer() != null && reference.consumer().length() > 0) {
-                    referenceConfig.setConsumer((ConsumerConfig) applicationContext.getBean(reference.consumer(), ConsumerConfig.class));
-                }
-                if (reference.monitor() != null && reference.monitor().length() > 0) {
-                    referenceConfig.setMonitor((MonitorConfig) applicationContext.getBean(reference.monitor(), MonitorConfig.class));
-                }
-                if (reference.application() != null && reference.application().length() > 0) {
-                    referenceConfig.setApplication((ApplicationConfig) applicationContext.getBean(reference.application(), ApplicationConfig.class));
-                }
-                if (reference.module() != null && reference.module().length() > 0) {
-                    referenceConfig.setModule((ModuleConfig) applicationContext.getBean(reference.module(), ModuleConfig.class));
-                }
-                if (reference.consumer() != null && reference.consumer().length() > 0) {
-                    referenceConfig.setConsumer((ConsumerConfig) applicationContext.getBean(reference.consumer(), ConsumerConfig.class));
-                }
-                try {
-                    referenceConfig.afterPropertiesSet();
-                } catch (RuntimeException e) {
-                    throw (RuntimeException) e;
-                } catch (Exception e) {
-                    throw new IllegalStateException(e.getMessage(), e);
                 }
             }
-            referenceConfigs.putIfAbsent(key, referenceConfig);
-            referenceConfig = referenceConfigs.get(key);
         }
-        return referenceConfig.get();
+
+        return referNew(refConf,referenceClass);
     }
 
     /**
-     * refer 方法的公开版，将注解参数Reference换为 ReferenceConf 类
+     * refer 方法的公开版，将注解参数Reference换为 RefConf 类
      * @param reference
      * @param referenceClass
      * @return

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/DynamicReferenceService.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/DynamicReferenceService.java
@@ -1,0 +1,29 @@
+package com.alibaba.dubbo.config.spring;
+
+import com.alibaba.dubbo.config.RefConf;
+
+/**
+ * 动态reference服务
+ * User: zhouzhipeng
+ * Date: 2018/3/21:22:34
+ */
+public class DynamicReferenceService {
+
+    private AnnotationBean annotationBean;
+
+    private DynamicReferenceService() {
+    }
+
+    DynamicReferenceService(AnnotationBean annotationBean) {
+        this.annotationBean = annotationBean;
+    }
+
+    public <T> T getDubboService(Class<T> interfaceClass) {
+        return (T) annotationBean.referNew(new RefConf(), interfaceClass);
+    }
+
+    public <T> T getDubboService(Class<T> interfaceClass, RefConf referenceConf) {
+        return (T) annotationBean.referNew(referenceConf, interfaceClass);
+    }
+
+}

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/ReferenceBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/ReferenceBean.java
@@ -16,12 +16,7 @@
  */
 package com.alibaba.dubbo.config.spring;
 
-import com.alibaba.dubbo.config.ApplicationConfig;
-import com.alibaba.dubbo.config.ConsumerConfig;
-import com.alibaba.dubbo.config.ModuleConfig;
-import com.alibaba.dubbo.config.MonitorConfig;
-import com.alibaba.dubbo.config.ReferenceConfig;
-import com.alibaba.dubbo.config.RegistryConfig;
+import com.alibaba.dubbo.config.*;
 import com.alibaba.dubbo.config.annotation.Reference;
 import com.alibaba.dubbo.config.spring.extension.SpringExtensionFactory;
 import com.alibaba.dubbo.config.support.Parameter;
@@ -55,6 +50,16 @@ public class ReferenceBean<T> extends ReferenceConfig<T> implements FactoryBean,
     public ReferenceBean(Reference reference) {
         super(reference);
     }
+
+    /**
+     * 增加构造函数，支持 RefConf 配置
+     * @param reference
+     */
+    public ReferenceBean(RefConf reference) {
+        super(reference);
+    }
+
+
 
     public void setApplicationContext(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;


### PR DESCRIPTION
## require Reference service dynamically


Supports dynamic retrieval of dubbo reference services, facilitating multiple dubbo implementation classes on the same interface. (You can use group to distinguish, eg: dynamically obtain the group name from the configuration to dynamically call the specified group service, see below example code)

## Service Provider Code Example
```java

    @Service(group = "abctest")
    public class TagSearchServiceImpl implements TagSearchService {
    ...
    }


    @Service(group = "abctest2")
    public class TagSearchServiceImpl2 implements TagSearchService {
    ...
    }
```


## Consumer code example
```java
    //inject the util service
    @Autowired
    private DynamicReferenceService dynamicReferenceService;
```

```java

    // Business code, dynamically obtain the specified interface and group implementation class
    RefConf rc=new RefConf();

    rc.group="abctest"; //Or abctest2, suggesting dynamic acquisition

    TagSearchService tagSearchService = dynamicReferenceService.getDubboService(TagSearchService.class,rc);

```
