### PR TITLE
exclude dubbo-demo when calc coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "dubbo-demo/.*"


### PR DESCRIPTION
## What is the purpose of the change

Exclude `dubbo-demo` project when calc coverage

## Brief changelog

Add ignore config for codecov

## Verifying this change

CI Passs

