### PR TITLE
[Dubbo-warmup] can specified warmup weight in warmup time

### DIFF
--- a/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
+++ b/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
@@ -31,6 +31,7 @@ import java.util.List;
 public abstract class AbstractLoadBalance implements LoadBalance {
 
     static int calculateWarmupWeight(int uptime, int warmup, int weight, int warmupweight) {
+        // zero (default) means not use
         if (warmupweight > 0) {
             return warmupweight > weight ? weight : warmupweight;
         }

--- a/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
+++ b/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
@@ -18,7 +18,6 @@ package com.alibaba.dubbo.rpc.cluster.loadbalance;
 
 import com.alibaba.dubbo.common.Constants;
 import com.alibaba.dubbo.common.URL;
-import com.alibaba.dubbo.common.utils.StringUtils;
 import com.alibaba.dubbo.rpc.Invocation;
 import com.alibaba.dubbo.rpc.Invoker;
 import com.alibaba.dubbo.rpc.cluster.LoadBalance;
@@ -33,7 +32,7 @@ public abstract class AbstractLoadBalance implements LoadBalance {
 
     static int calculateWarmupWeight(int uptime, int warmup, int weight, int warmupweight) {
         if (warmupweight > 0) {
-            return (warmupweight > weight) ? weight : warmupweight;
+            return warmupweight > weight ? weight : warmupweight;
         }
 
         int ww = (int) ((float) uptime / ((float) warmup / (float) weight));

--- a/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
+++ b/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
@@ -18,6 +18,7 @@ package com.alibaba.dubbo.rpc.cluster.loadbalance;
 
 import com.alibaba.dubbo.common.Constants;
 import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.common.utils.StringUtils;
 import com.alibaba.dubbo.rpc.Invocation;
 import com.alibaba.dubbo.rpc.Invoker;
 import com.alibaba.dubbo.rpc.cluster.LoadBalance;
@@ -30,7 +31,11 @@ import java.util.List;
  */
 public abstract class AbstractLoadBalance implements LoadBalance {
 
-    static int calculateWarmupWeight(int uptime, int warmup, int weight) {
+    static int calculateWarmupWeight(int uptime, int warmup, int weight, int warmupweight) {
+        if (warmupweight > 0) {
+            return (warmupweight > weight) ? weight : warmupweight;
+        }
+
         int ww = (int) ((float) uptime / ((float) warmup / (float) weight));
         return ww < 1 ? 1 : (ww > weight ? weight : ww);
     }
@@ -53,8 +58,9 @@ public abstract class AbstractLoadBalance implements LoadBalance {
             if (timestamp > 0L) {
                 int uptime = (int) (System.currentTimeMillis() - timestamp);
                 int warmup = invoker.getUrl().getParameter(Constants.WARMUP_KEY, Constants.DEFAULT_WARMUP);
+                int warmupweight = invoker.getUrl().getParameter(Constants.WARMUP_WEIGHT_KEY, Constants.DEFAULT_WARMUP_WEIGHT);
                 if (uptime > 0 && uptime < warmup) {
-                    weight = calculateWarmupWeight(uptime, warmup, weight);
+                    weight = calculateWarmupWeight(uptime, warmup, weight, warmupweight);
                 }
             }
         }

--- a/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/loadbalance/LoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/loadbalance/LoadBalanceTest.java
@@ -172,33 +172,38 @@ public class LoadBalanceTest {
     @Test
     public void testLoadBalanceWarmup() {
         Assert.assertEquals(1,
-            AbstractLoadBalance.calculateWarmupWeight(0, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT));
+            AbstractLoadBalance.calculateWarmupWeight(0, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT, Constants.DEFAULT_WARMUP_WEIGHT));
         Assert.assertEquals(1,
-            AbstractLoadBalance.calculateWarmupWeight(13, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT));
+            AbstractLoadBalance.calculateWarmupWeight(13, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT, Constants.DEFAULT_WARMUP_WEIGHT));
         Assert.assertEquals(1,
-            AbstractLoadBalance.calculateWarmupWeight(6 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT));
+            AbstractLoadBalance.calculateWarmupWeight(6 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT, Constants.DEFAULT_WARMUP_WEIGHT));
         Assert.assertEquals(2,
-            AbstractLoadBalance.calculateWarmupWeight(12 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT));
+            AbstractLoadBalance.calculateWarmupWeight(12 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT, Constants.DEFAULT_WARMUP_WEIGHT));
         Assert.assertEquals(10,
-            AbstractLoadBalance.calculateWarmupWeight(60 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT));
+            AbstractLoadBalance.calculateWarmupWeight(60 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT, Constants.DEFAULT_WARMUP_WEIGHT));
         Assert.assertEquals(50, AbstractLoadBalance
-            .calculateWarmupWeight(5 * 60 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT));
+            .calculateWarmupWeight(5 * 60 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT, Constants.DEFAULT_WARMUP_WEIGHT));
         Assert.assertEquals(50, AbstractLoadBalance
-            .calculateWarmupWeight(5 * 60 * 1000 + 23, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT));
+            .calculateWarmupWeight(5 * 60 * 1000 + 23, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT, Constants.DEFAULT_WARMUP_WEIGHT));
         Assert.assertEquals(50, AbstractLoadBalance
-            .calculateWarmupWeight(5 * 60 * 1000 + 5999, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT));
+            .calculateWarmupWeight(5 * 60 * 1000 + 5999, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT, Constants.DEFAULT_WARMUP_WEIGHT));
         Assert.assertEquals(51, AbstractLoadBalance
-            .calculateWarmupWeight(5 * 60 * 1000 + 6000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT));
+            .calculateWarmupWeight(5 * 60 * 1000 + 6000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT, Constants.DEFAULT_WARMUP_WEIGHT));
         Assert.assertEquals(90, AbstractLoadBalance
-            .calculateWarmupWeight(9 * 60 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT));
+            .calculateWarmupWeight(9 * 60 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT, Constants.DEFAULT_WARMUP_WEIGHT));
         Assert.assertEquals(98, AbstractLoadBalance
-            .calculateWarmupWeight(10 * 60 * 1000 - 12 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT));
+            .calculateWarmupWeight(10 * 60 * 1000 - 12 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT, Constants.DEFAULT_WARMUP_WEIGHT));
         Assert.assertEquals(99, AbstractLoadBalance
-            .calculateWarmupWeight(10 * 60 * 1000 - 6 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT));
+            .calculateWarmupWeight(10 * 60 * 1000 - 6 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT, Constants.DEFAULT_WARMUP_WEIGHT));
         Assert.assertEquals(100, AbstractLoadBalance
-            .calculateWarmupWeight(10 * 60 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT));
+            .calculateWarmupWeight(10 * 60 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT, Constants.DEFAULT_WARMUP_WEIGHT));
         Assert.assertEquals(100, AbstractLoadBalance
-            .calculateWarmupWeight(20 * 60 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT));
+            .calculateWarmupWeight(20 * 60 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT, Constants.DEFAULT_WARMUP_WEIGHT));
+
+        // specified warmup weight in warmup time
+        int warmupweight = 10;
+        Assert.assertEquals(warmupweight, AbstractLoadBalance
+                .calculateWarmupWeight(20 * 60 * 1000, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT, warmupweight));
     }
 
 }

--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/Constants.java
@@ -311,6 +311,10 @@ public class Constants {
 
     public static final int DEFAULT_WARMUP = 10 * 60 * 1000;
 
+    public static final String WARMUP_WEIGHT_KEY = "warmupweight";
+
+    public static final int DEFAULT_WARMUP_WEIGHT = 0;
+
     public static final String CHECK_KEY = "check";
 
     public static final String REGISTER_KEY = "register";

--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractServiceConfig.java
@@ -70,6 +70,9 @@ public abstract class AbstractServiceConfig extends AbstractInterfaceConfig {
     // warm up period
     private Integer warmup;
 
+    // warm up weight in warm up period
+    private Integer warmupweight;
+
     // serialization
     private String serialization;
 
@@ -230,6 +233,14 @@ public abstract class AbstractServiceConfig extends AbstractInterfaceConfig {
 
     public void setWarmup(Integer warmup) {
         this.warmup = warmup;
+    }
+
+    public Integer getWarmupweight() {
+        return warmupweight;
+    }
+
+    public void setWarmupweight(Integer warmupweight) {
+        this.warmupweight = warmupweight;
     }
 
     public String getSerialization() {

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
@@ -302,6 +302,11 @@
                         <xsd:documentation><![CDATA[ The warmup time in Milliseconds. ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
+                <xsd:attribute name="warmupweight" type="xsd:string" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation><![CDATA[ The specified warmup weight in warmup time. ]]></xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
                 <xsd:attribute name="serialization" type="xsd:string" use="optional">
                     <xsd:annotation>
                         <xsd:documentation><![CDATA[ The serialization protocol of service. ]]></xsd:documentation>


### PR DESCRIPTION
## What is the purpose of the change

The original logic for wamup is the weight increases with time.
but I think we should provide another way: can specified warmup weight in warmup time

## Brief changelog

add warmupweight property for service.

## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
