### PR TITLE
use mockito to replace easymock and jmockit

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -191,13 +191,6 @@ cache-api:
   * HOMEPAGE:
     * https://github.com/jsr107/jsr107spec
 
-easymock
-
-  * LICENSE:
-    * http://www.apache.org/licenses/LICENSE-2.0 (Apache License 2.0)
-  * HOMEPAGE:
-    * http://easymock.org
-
 cglib-nodep
 
   * LICENSE:
@@ -218,13 +211,6 @@ fst
     * http://www.apache.org/licenses/LICENSE-2.0 (Apache License 2.0)
   * HOMEPAGE:
     * http://ruedigermoeller.github.io/fast-serialization
-
-jmockit
-
-  * LICENSE:
-    * https://opensource.org/licenses/MIT (MIT)
-  * HOMEPAGE:
-    * http://www.jmockit.org
 
 jedis
 

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -350,20 +350,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <version>${easymock_version}</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jmockit</groupId>
-            <artifactId>jmockit</artifactId>
-            <version>${jmockit_version}</version>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>cglib</groupId>
             <artifactId>cglib-nodep</artifactId>
             <version>${cglib_version}</version>

--- a/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/StickyTest.java
+++ b/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/StickyTest.java
@@ -27,47 +27,43 @@ import com.alibaba.dubbo.rpc.RpcInvocation;
 import com.alibaba.dubbo.rpc.RpcResult;
 import com.alibaba.dubbo.rpc.cluster.support.AbstractClusterInvoker;
 
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
 @SuppressWarnings("unchecked")
 public class StickyTest {
 
-    List<Invoker<StickyTest>> invokers = new ArrayList<Invoker<StickyTest>>();
+    private List<Invoker<StickyTest>> invokers = new ArrayList<Invoker<StickyTest>>();
 
 
-    Invoker<StickyTest> invoker1 = EasyMock.createMock(Invoker.class);
-    Invoker<StickyTest> invoker2 = EasyMock.createMock(Invoker.class);
-    RpcInvocation invocation;
-    Directory<StickyTest> dic;
-    Result result = new RpcResult();
-    StickyClusterInvoker<StickyTest> clusterinvoker = null;
-    URL url = URL.valueOf("test://test:11/test?"
+    private Invoker<StickyTest> invoker1 = mock(Invoker.class);
+    private  Invoker<StickyTest> invoker2 = mock(Invoker.class);
+    private RpcInvocation invocation;
+    private Directory<StickyTest> dic;
+    private Result result = new RpcResult();
+    private StickyClusterInvoker<StickyTest> clusterinvoker = null;
+    private URL url = URL.valueOf("test://test:11/test?"
                     + "&loadbalance=roundrobin"
-//            +"&"+Constants.CLUSTER_AVAILABLE_CHECK_KEY+"=true"
                     + "&" + Constants.CLUSTER_STICKY_KEY + "=true"
     );
-    int runs = 1;
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
+    private int runs = 1;
 
     @Before
     public void setUp() throws Exception {
-        dic = EasyMock.createMock(Directory.class);
+        dic = mock(Directory.class);
         invocation = new RpcInvocation();
 
-        EasyMock.expect(dic.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(dic.list(invocation)).andReturn(invokers).anyTimes();
-        EasyMock.expect(dic.getInterface()).andReturn(StickyTest.class).anyTimes();
-        EasyMock.replay(dic);
+        given(dic.getUrl()).willReturn(url);
+        given(dic.list(invocation)).willReturn(invokers);
+        given(dic.getInterface()).willReturn(StickyTest.class);
+
         invokers.add(invoker1);
         invokers.add(invoker2);
 
@@ -115,19 +111,16 @@ public class StickyTest {
         } else {
             url = url.addParameter(methodName + "." + Constants.CLUSTER_STICKY_KEY, String.valueOf(check));
         }
-        EasyMock.reset(invoker1);
-        EasyMock.expect(invoker1.invoke(invocation)).andReturn(result).anyTimes();
-        EasyMock.expect(invoker1.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker1.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker1.getInterface()).andReturn(StickyTest.class).anyTimes();
-        EasyMock.replay(invoker1);
 
-        EasyMock.reset(invoker2);
-        EasyMock.expect(invoker2.invoke(invocation)).andReturn(result).anyTimes();
-        EasyMock.expect(invoker2.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker2.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker2.getInterface()).andReturn(StickyTest.class).anyTimes();
-        EasyMock.replay(invoker2);
+        given(invoker1.invoke(invocation)).willReturn(result);
+        given(invoker1.isAvailable()).willReturn(true);
+        given(invoker1.getUrl()).willReturn(url);
+        given(invoker1.getInterface()).willReturn(StickyTest.class);
+
+        given(invoker2.invoke(invocation)).willReturn(result);
+        given(invoker2.isAvailable()).willReturn(true);
+        given(invoker2.getUrl()).willReturn(url);
+        given(invoker2.getInterface()).willReturn(StickyTest.class);
 
         invocation.setMethodName(methodName);
 

--- a/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/loadbalance/LoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/loadbalance/LoadBalanceTest.java
@@ -25,7 +25,6 @@ import com.alibaba.dubbo.rpc.RpcStatus;
 import com.alibaba.dubbo.rpc.cluster.LoadBalance;
 
 import junit.framework.Assert;
-import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -35,6 +34,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * RoundRobinLoadBalanceTest
@@ -63,14 +65,14 @@ public class LoadBalanceTest {
     @Before
     public void setUp() throws Exception {
 
-        invocation = EasyMock.createMock(Invocation.class);
-        EasyMock.expect(invocation.getMethodName()).andReturn("method1").anyTimes();
+        invocation = mock(Invocation.class);
+        given(invocation.getMethodName()).willReturn("method1");
 
-        invoker1 = EasyMock.createMock(Invoker.class);
-        invoker2 = EasyMock.createMock(Invoker.class);
-        invoker3 = EasyMock.createMock(Invoker.class);
-        invoker4 = EasyMock.createMock(Invoker.class);
-        invoker5 = EasyMock.createMock(Invoker.class);
+        invoker1 = mock(Invoker.class);
+        invoker2 = mock(Invoker.class);
+        invoker3 = mock(Invoker.class);
+        invoker4 = mock(Invoker.class);
+        invoker5 = mock(Invoker.class);
 
         URL url1 = URL.valueOf("test://127.0.0.1:1/DemoService");
         URL url2 = URL.valueOf("test://127.0.0.1:2/DemoService");
@@ -78,27 +80,25 @@ public class LoadBalanceTest {
         URL url4 = URL.valueOf("test://127.0.0.1:4/DemoService");
         URL url5 = URL.valueOf("test://127.0.0.1:5/DemoService");
 
-        EasyMock.expect(invoker1.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker1.getInterface()).andReturn(LoadBalanceTest.class).anyTimes();
-        EasyMock.expect(invoker1.getUrl()).andReturn(url1).anyTimes();
+        given(invoker1.isAvailable()).willReturn(true);
+        given(invoker1.getInterface()).willReturn(LoadBalanceTest.class);
+        given(invoker1.getUrl()).willReturn(url1);
 
-        EasyMock.expect(invoker2.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker2.getInterface()).andReturn(LoadBalanceTest.class).anyTimes();
-        EasyMock.expect(invoker2.getUrl()).andReturn(url2).anyTimes();
+        given(invoker2.isAvailable()).willReturn(true);
+        given(invoker2.getInterface()).willReturn(LoadBalanceTest.class);
+        given(invoker2.getUrl()).willReturn(url2);
 
-        EasyMock.expect(invoker3.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker3.getInterface()).andReturn(LoadBalanceTest.class).anyTimes();
-        EasyMock.expect(invoker3.getUrl()).andReturn(url3).anyTimes();
+        given(invoker3.isAvailable()).willReturn(true);
+        given(invoker3.getInterface()).willReturn(LoadBalanceTest.class);
+        given(invoker3.getUrl()).willReturn(url3);
 
-        EasyMock.expect(invoker4.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker4.getInterface()).andReturn(LoadBalanceTest.class).anyTimes();
-        EasyMock.expect(invoker4.getUrl()).andReturn(url4).anyTimes();
+        given(invoker4.isAvailable()).willReturn(true);
+        given(invoker4.getInterface()).willReturn(LoadBalanceTest.class);
+        given(invoker4.getUrl()).willReturn(url4);
 
-        EasyMock.expect(invoker5.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker5.getInterface()).andReturn(LoadBalanceTest.class).anyTimes();
-        EasyMock.expect(invoker5.getUrl()).andReturn(url5).anyTimes();
-
-        EasyMock.replay(invocation, invoker1, invoker2, invoker3, invoker4, invoker5);
+        given(invoker5.isAvailable()).willReturn(true);
+        given(invoker5.getInterface()).willReturn(LoadBalanceTest.class);
+        given(invoker5.getUrl()).willReturn(url5);
 
         invokers.add(invoker1);
         invokers.add(invoker2);

--- a/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/router/file/FileRouterEngineTest.java
+++ b/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/router/file/FileRouterEngineTest.java
@@ -32,7 +32,6 @@ import com.alibaba.dubbo.rpc.cluster.directory.StaticDirectory;
 import com.alibaba.dubbo.rpc.cluster.support.AbstractClusterInvoker;
 
 import junit.framework.Assert;
-import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -42,12 +41,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
 @SuppressWarnings("unchecked")
 public class FileRouterEngineTest {
     private static boolean isScriptUnsupported = new ScriptEngineManager().getEngineByName("javascript") == null;
     List<Invoker<FileRouterEngineTest>> invokers = new ArrayList<Invoker<FileRouterEngineTest>>();
-    Invoker<FileRouterEngineTest> invoker1 = EasyMock.createMock(Invoker.class);
-    Invoker<FileRouterEngineTest> invoker2 = EasyMock.createMock(Invoker.class);
+    Invoker<FileRouterEngineTest> invoker1 = mock(Invoker.class);
+    Invoker<FileRouterEngineTest> invoker2 = mock(Invoker.class);
     Invocation invocation;
     Directory<FileRouterEngineTest> dic;
     Result result = new RpcResult();
@@ -145,19 +147,15 @@ public class FileRouterEngineTest {
     }
 
     private void initInvokers(URL url, boolean invoker1Status, boolean invoker2Status) {
-        EasyMock.reset(invoker1);
-        EasyMock.expect(invoker1.invoke(invocation)).andReturn(result).anyTimes();
-        EasyMock.expect(invoker1.isAvailable()).andReturn(invoker1Status).anyTimes();
-        EasyMock.expect(invoker1.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker1.getInterface()).andReturn(FileRouterEngineTest.class).anyTimes();
-        EasyMock.replay(invoker1);
+        given(invoker1.invoke(invocation)).willReturn(result);
+        given(invoker1.isAvailable()).willReturn(invoker1Status);
+        given(invoker1.getUrl()).willReturn(url);
+        given(invoker1.getInterface()).willReturn(FileRouterEngineTest.class);
 
-        EasyMock.reset(invoker2);
-        EasyMock.expect(invoker2.invoke(invocation)).andReturn(result).anyTimes();
-        EasyMock.expect(invoker2.isAvailable()).andReturn(invoker2Status).anyTimes();
-        EasyMock.expect(invoker2.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker2.getInterface()).andReturn(FileRouterEngineTest.class).anyTimes();
-        EasyMock.replay(invoker2);
+        given(invoker2.invoke(invocation)).willReturn(result);
+        given(invoker2.isAvailable()).willReturn(invoker2Status);
+        given(invoker2.getUrl()).willReturn(url);
+        given(invoker2.getInterface()).willReturn(FileRouterEngineTest.class);
     }
 
     private void initDic(URL url) {

--- a/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/support/AbstractClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/support/AbstractClusterInvokerTest.java
@@ -34,7 +34,6 @@ import com.alibaba.dubbo.rpc.cluster.loadbalance.RandomLoadBalance;
 import com.alibaba.dubbo.rpc.cluster.loadbalance.RoundRobinLoadBalance;
 
 import junit.framework.Assert;
-import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -44,6 +43,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * AbstractClusterInvokerTest
@@ -76,40 +78,38 @@ public class AbstractClusterInvokerTest {
     public void setUp() throws Exception {
         invocation.setMethodName("sayHello");
 
-        invoker1 = EasyMock.createMock(Invoker.class);
-        invoker2 = EasyMock.createMock(Invoker.class);
-        invoker3 = EasyMock.createMock(Invoker.class);
-        invoker4 = EasyMock.createMock(Invoker.class);
-        invoker5 = EasyMock.createMock(Invoker.class);
-        mockedInvoker1 = EasyMock.createMock(Invoker.class);
+        invoker1 = mock(Invoker.class);
+        invoker2 = mock(Invoker.class);
+        invoker3 = mock(Invoker.class);
+        invoker4 = mock(Invoker.class);
+        invoker5 = mock(Invoker.class);
+        mockedInvoker1 = mock(Invoker.class);
 
         URL turl = URL.valueOf("test://test:11/test");
 
-        EasyMock.expect(invoker1.isAvailable()).andReturn(false).anyTimes();
-        EasyMock.expect(invoker1.getInterface()).andReturn(IHelloService.class).anyTimes();
-        EasyMock.expect(invoker1.getUrl()).andReturn(turl.addParameter("name", "invoker1")).anyTimes();
+        given(invoker1.isAvailable()).willReturn(false);
+        given(invoker1.getInterface()).willReturn(IHelloService.class);
+        given(invoker1.getUrl()).willReturn(turl.addParameter("name", "invoker1"));
 
-        EasyMock.expect(invoker2.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker2.getInterface()).andReturn(IHelloService.class).anyTimes();
-        EasyMock.expect(invoker2.getUrl()).andReturn(turl.addParameter("name", "invoker2")).anyTimes();
+        given(invoker2.isAvailable()).willReturn(true);
+        given(invoker2.getInterface()).willReturn(IHelloService.class);
+        given(invoker2.getUrl()).willReturn(turl.addParameter("name", "invoker2"));
 
-        EasyMock.expect(invoker3.isAvailable()).andReturn(false).anyTimes();
-        EasyMock.expect(invoker3.getInterface()).andReturn(IHelloService.class).anyTimes();
-        EasyMock.expect(invoker3.getUrl()).andReturn(turl.addParameter("name", "invoker3")).anyTimes();
+        given(invoker3.isAvailable()).willReturn(false);
+        given(invoker3.getInterface()).willReturn(IHelloService.class);
+        given(invoker3.getUrl()).willReturn(turl.addParameter("name", "invoker3"));
 
-        EasyMock.expect(invoker4.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker4.getInterface()).andReturn(IHelloService.class).anyTimes();
-        EasyMock.expect(invoker4.getUrl()).andReturn(turl.addParameter("name", "invoker4")).anyTimes();
+        given(invoker4.isAvailable()).willReturn(true);
+        given(invoker4.getInterface()).willReturn(IHelloService.class);
+        given(invoker4.getUrl()).willReturn(turl.addParameter("name", "invoker4"));
 
-        EasyMock.expect(invoker5.isAvailable()).andReturn(false).anyTimes();
-        EasyMock.expect(invoker5.getInterface()).andReturn(IHelloService.class).anyTimes();
-        EasyMock.expect(invoker5.getUrl()).andReturn(turl.addParameter("name", "invoker5")).anyTimes();
+        given(invoker5.isAvailable()).willReturn(false);
+        given(invoker5.getInterface()).willReturn(IHelloService.class);
+        given(invoker5.getUrl()).willReturn(turl.addParameter("name", "invoker5"));
 
-        EasyMock.expect(mockedInvoker1.isAvailable()).andReturn(false).anyTimes();
-        EasyMock.expect(mockedInvoker1.getInterface()).andReturn(IHelloService.class).anyTimes();
-        EasyMock.expect(mockedInvoker1.getUrl()).andReturn(turl.setProtocol("mock")).anyTimes();
-
-        EasyMock.replay(invoker1, invoker2, invoker3, invoker4, invoker5, mockedInvoker1);
+        given(mockedInvoker1.isAvailable()).willReturn(false);
+        given(mockedInvoker1.getInterface()).willReturn(IHelloService.class);
+        given(mockedInvoker1.getUrl()).willReturn(turl.setProtocol("mock"));
 
         invokers.add(invoker1);
         dic = new StaticDirectory<IHelloService>(url, invokers, null);
@@ -181,9 +181,9 @@ public class AbstractClusterInvokerTest {
 
     @Test
     public void testCloseAvailablecheck() {
-        LoadBalance lb = EasyMock.createMock(LoadBalance.class);
-        EasyMock.expect(lb.select(invokers, url, invocation)).andReturn(invoker1);
-        EasyMock.replay(lb);
+        LoadBalance lb = mock(LoadBalance.class);
+        given(lb.select(invokers, url, invocation)).willReturn(invoker1);
+
         initlistsize5();
 
         Invoker sinvoker = cluster_nocheck.select(lb, invocation, invokers, selectedInvokers);

--- a/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/support/FailSafeClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/support/FailSafeClusterInvokerTest.java
@@ -27,8 +27,6 @@ import com.alibaba.dubbo.rpc.cluster.Directory;
 import com.alibaba.dubbo.rpc.cluster.filter.DemoService;
 
 import junit.framework.Assert;
-import org.easymock.EasyMock;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,6 +34,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * FailfastClusterInvokerTest
@@ -45,7 +45,7 @@ import static org.junit.Assert.assertTrue;
 public class FailSafeClusterInvokerTest {
     List<Invoker<DemoService>> invokers = new ArrayList<Invoker<DemoService>>();
     URL url = URL.valueOf("test://test:11/test");
-    Invoker<DemoService> invoker = EasyMock.createMock(Invoker.class);
+    Invoker<DemoService> invoker = mock(Invoker.class);
     RpcInvocation invocation = new RpcInvocation();
     Directory<DemoService> dic;
     Result result = new RpcResult();
@@ -57,37 +57,26 @@ public class FailSafeClusterInvokerTest {
     @Before
     public void setUp() throws Exception {
 
-        dic = EasyMock.createMock(Directory.class);
+        dic = mock(Directory.class);
 
-        EasyMock.expect(dic.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(dic.list(invocation)).andReturn(invokers).anyTimes();
-        EasyMock.expect(dic.getInterface()).andReturn(DemoService.class).anyTimes();
+        given(dic.getUrl()).willReturn(url);
+        given(dic.list(invocation)).willReturn(invokers);
+        given(dic.getInterface()).willReturn(DemoService.class);
         invocation.setMethodName("method1");
-        EasyMock.replay(dic);
 
         invokers.add(invoker);
     }
 
-    @After
-    public void tearDown() {
-        EasyMock.verify(invoker, dic);
-
-    }
-
     private void resetInvokerToException() {
-        EasyMock.reset(invoker);
-        EasyMock.expect(invoker.invoke(invocation)).andThrow(new RuntimeException()).anyTimes();
-        EasyMock.expect(invoker.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker.getInterface()).andReturn(DemoService.class).anyTimes();
-        EasyMock.replay(invoker);
+        given(invoker.invoke(invocation)).willThrow(new RuntimeException());
+        given(invoker.getUrl()).willReturn(url);
+        given(invoker.getInterface()).willReturn(DemoService.class);
     }
 
     private void resetInvokerToNoException() {
-        EasyMock.reset(invoker);
-        EasyMock.expect(invoker.invoke(invocation)).andReturn(result).anyTimes();
-        EasyMock.expect(invoker.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker.getInterface()).andReturn(DemoService.class).anyTimes();
-        EasyMock.replay(invoker);
+        given(invoker.invoke(invocation)).willReturn(result);
+        given(invoker.getUrl()).willReturn(url);
+        given(invoker.getInterface()).willReturn(DemoService.class);
     }
 
     //TODO assert error log
@@ -111,14 +100,13 @@ public class FailSafeClusterInvokerTest {
 
     @Test()
     public void testNoInvoke() {
-        dic = EasyMock.createMock(Directory.class);
+        dic = mock(Directory.class);
 
-        EasyMock.expect(dic.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(dic.list(invocation)).andReturn(null).anyTimes();
-        EasyMock.expect(dic.getInterface()).andReturn(DemoService.class).anyTimes();
+        given(dic.getUrl()).willReturn(url);
+        given(dic.list(invocation)).willReturn(null);
+        given(dic.getInterface()).willReturn(DemoService.class);
 
         invocation.setMethodName("method1");
-        EasyMock.replay(dic);
 
         resetInvokerToNoException();
 

--- a/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
@@ -26,8 +26,6 @@ import com.alibaba.dubbo.rpc.RpcResult;
 import com.alibaba.dubbo.rpc.cluster.Directory;
 
 import junit.framework.Assert;
-import org.easymock.EasyMock;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,17 +33,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
-/**
- * FailbackClusterInvokerTest
- *
- */
 @SuppressWarnings("unchecked")
 public class FailbackClusterInvokerTest {
 
     List<Invoker<FailbackClusterInvokerTest>> invokers = new ArrayList<Invoker<FailbackClusterInvokerTest>>();
     URL url = URL.valueOf("test://test:11/test");
-    Invoker<FailbackClusterInvokerTest> invoker = EasyMock.createMock(Invoker.class);
+    Invoker<FailbackClusterInvokerTest> invoker = mock(Invoker.class);
     RpcInvocation invocation = new RpcInvocation();
     Directory<FailbackClusterInvokerTest> dic;
     Result result = new RpcResult();
@@ -57,37 +53,26 @@ public class FailbackClusterInvokerTest {
     @Before
     public void setUp() throws Exception {
 
-        dic = EasyMock.createMock(Directory.class);
-        EasyMock.expect(dic.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(dic.list(invocation)).andReturn(invokers).anyTimes();
-        EasyMock.expect(dic.getInterface()).andReturn(FailbackClusterInvokerTest.class).anyTimes();
+        dic = mock(Directory.class);
+        given(dic.getUrl()).willReturn(url);
+        given(dic.list(invocation)).willReturn(invokers);
+        given(dic.getInterface()).willReturn(FailbackClusterInvokerTest.class);
 
         invocation.setMethodName("method1");
-        EasyMock.replay(dic);
 
         invokers.add(invoker);
     }
 
-    @After
-    public void tearDown() {
-        EasyMock.verify(invoker, dic);
-
-    }
-
     private void resetInvokerToException() {
-        EasyMock.reset(invoker);
-        EasyMock.expect(invoker.invoke(invocation)).andThrow(new RuntimeException()).anyTimes();
-        EasyMock.expect(invoker.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker.getInterface()).andReturn(FailbackClusterInvokerTest.class).anyTimes();
-        EasyMock.replay(invoker);
+        given(invoker.invoke(invocation)).willThrow(new RuntimeException());
+        given(invoker.getUrl()).willReturn(url);
+        given(invoker.getInterface()).willReturn(FailbackClusterInvokerTest.class);
     }
 
     private void resetInvokerToNoException() {
-        EasyMock.reset(invoker);
-        EasyMock.expect(invoker.invoke(invocation)).andReturn(result).anyTimes();
-        EasyMock.expect(invoker.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker.getInterface()).andReturn(FailbackClusterInvokerTest.class).anyTimes();
-        EasyMock.replay(invoker);
+        given(invoker.invoke(invocation)).willReturn(result);
+        given(invoker.getUrl()).willReturn(url);
+        given(invoker.getInterface()).willReturn(FailbackClusterInvokerTest.class);
     }
 
     @Test
@@ -112,14 +97,13 @@ public class FailbackClusterInvokerTest {
 
     @Test()
     public void testNoInvoke() {
-        dic = EasyMock.createMock(Directory.class);
+        dic = mock(Directory.class);
 
-        EasyMock.expect(dic.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(dic.list(invocation)).andReturn(null).anyTimes();
-        EasyMock.expect(dic.getInterface()).andReturn(FailbackClusterInvokerTest.class).anyTimes();
+        given(dic.getUrl()).willReturn(url);
+        given(dic.list(invocation)).willReturn(null);
+        given(dic.getInterface()).willReturn(FailbackClusterInvokerTest.class);
 
         invocation.setMethodName("method1");
-        EasyMock.replay(dic);
 
         invokers.add(invoker);
 

--- a/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/support/FailfastClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/support/FailfastClusterInvokerTest.java
@@ -26,7 +26,6 @@ import com.alibaba.dubbo.rpc.RpcResult;
 import com.alibaba.dubbo.rpc.cluster.Directory;
 
 import junit.framework.Assert;
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,6 +35,8 @@ import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * FailfastClusterInvokerTest
@@ -45,7 +46,7 @@ import static org.junit.Assert.fail;
 public class FailfastClusterInvokerTest {
     List<Invoker<FailfastClusterInvokerTest>> invokers = new ArrayList<Invoker<FailfastClusterInvokerTest>>();
     URL url = URL.valueOf("test://test:11/test");
-    Invoker<FailfastClusterInvokerTest> invoker1 = EasyMock.createMock(Invoker.class);
+    Invoker<FailfastClusterInvokerTest> invoker1 = mock(Invoker.class);
     RpcInvocation invocation = new RpcInvocation();
     Directory<FailfastClusterInvokerTest> dic;
     Result result = new RpcResult();
@@ -57,38 +58,27 @@ public class FailfastClusterInvokerTest {
     @Before
     public void setUp() throws Exception {
 
-        dic = EasyMock.createMock(Directory.class);
+        dic = mock(Directory.class);
 
-        EasyMock.expect(dic.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(dic.list(invocation)).andReturn(invokers).anyTimes();
-        EasyMock.expect(dic.getInterface()).andReturn(FailfastClusterInvokerTest.class).anyTimes();
+        given(dic.getUrl()).willReturn(url);
+        given(dic.list(invocation)).willReturn(invokers);
+        given(dic.getInterface()).willReturn(FailfastClusterInvokerTest.class);
 
         invocation.setMethodName("method1");
-        EasyMock.replay(dic);
 
         invokers.add(invoker1);
     }
 
-    @After
-    public void tearDown() {
-        EasyMock.verify(invoker1, dic);
-
-    }
-
     private void resetInvoker1ToException() {
-        EasyMock.reset(invoker1);
-        EasyMock.expect(invoker1.invoke(invocation)).andThrow(new RuntimeException()).anyTimes();
-        EasyMock.expect(invoker1.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker1.getInterface()).andReturn(FailfastClusterInvokerTest.class).anyTimes();
-        EasyMock.replay(invoker1);
+        given(invoker1.invoke(invocation)).willThrow(new RuntimeException());
+        given(invoker1.getUrl()).willReturn(url);
+        given(invoker1.getInterface()).willReturn(FailfastClusterInvokerTest.class);
     }
 
     private void resetInvoker1ToNoException() {
-        EasyMock.reset(invoker1);
-        EasyMock.expect(invoker1.invoke(invocation)).andReturn(result).anyTimes();
-        EasyMock.expect(invoker1.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker1.getInterface()).andReturn(FailfastClusterInvokerTest.class).anyTimes();
-        EasyMock.replay(invoker1);
+        given(invoker1.invoke(invocation)).willReturn(result);
+        given(invoker1.getUrl()).willReturn(url);
+        given(invoker1.getInterface()).willReturn(FailfastClusterInvokerTest.class);
     }
 
     @Test(expected = RpcException.class)
@@ -111,14 +101,13 @@ public class FailfastClusterInvokerTest {
 
     @Test()
     public void testNoInvoke() {
-        dic = EasyMock.createMock(Directory.class);
+        dic = mock(Directory.class);
 
-        EasyMock.expect(dic.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(dic.list(invocation)).andReturn(null).anyTimes();
-        EasyMock.expect(dic.getInterface()).andReturn(FailfastClusterInvokerTest.class).anyTimes();
+        given(dic.getUrl()).willReturn(url);
+        given(dic.list(invocation)).willReturn(null);
+        given(dic.getInterface()).willReturn(FailfastClusterInvokerTest.class);
 
         invocation.setMethodName("method1");
-        EasyMock.replay(dic);
 
         invokers.add(invoker1);
 

--- a/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/support/FailoverClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/support/FailoverClusterInvokerTest.java
@@ -27,7 +27,6 @@ import com.alibaba.dubbo.rpc.cluster.Directory;
 import com.alibaba.dubbo.rpc.cluster.directory.StaticDirectory;
 import com.alibaba.dubbo.rpc.protocol.AbstractInvoker;
 
-import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,6 +39,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * FailoverClusterInvokerTest
@@ -47,14 +48,14 @@ import static org.junit.Assert.fail;
  */
 @SuppressWarnings("unchecked")
 public class FailoverClusterInvokerTest {
-    List<Invoker<FailoverClusterInvokerTest>> invokers = new ArrayList<Invoker<FailoverClusterInvokerTest>>();
-    int retries = 5;
-    URL url = URL.valueOf("test://test:11/test?retries=" + retries);
-    Invoker<FailoverClusterInvokerTest> invoker1 = EasyMock.createMock(Invoker.class);
-    Invoker<FailoverClusterInvokerTest> invoker2 = EasyMock.createMock(Invoker.class);
-    RpcInvocation invocation = new RpcInvocation();
-    Directory<FailoverClusterInvokerTest> dic;
-    Result result = new RpcResult();
+    private List<Invoker<FailoverClusterInvokerTest>> invokers = new ArrayList<Invoker<FailoverClusterInvokerTest>>();
+    private int retries = 5;
+    private URL url = URL.valueOf("test://test:11/test?retries=" + retries);
+    private Invoker<FailoverClusterInvokerTest> invoker1 = mock(Invoker.class);
+    private Invoker<FailoverClusterInvokerTest> invoker2 = mock(Invoker.class);
+    private RpcInvocation invocation = new RpcInvocation();
+    private Directory<FailoverClusterInvokerTest> dic;
+    private Result result = new RpcResult();
 
     /**
      * @throws java.lang.Exception
@@ -63,13 +64,12 @@ public class FailoverClusterInvokerTest {
     @Before
     public void setUp() throws Exception {
 
-        dic = EasyMock.createMock(Directory.class);
+        dic = mock(Directory.class);
 
-        EasyMock.expect(dic.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(dic.list(invocation)).andReturn(invokers).anyTimes();
-        EasyMock.expect(dic.getInterface()).andReturn(FailoverClusterInvokerTest.class).anyTimes();
+        given(dic.getUrl()).willReturn(url);
+        given(dic.list(invocation)).willReturn(invokers);
+        given(dic.getInterface()).willReturn(FailoverClusterInvokerTest.class);
         invocation.setMethodName("method1");
-        EasyMock.replay(dic);
 
         invokers.add(invoker1);
         invokers.add(invoker2);
@@ -78,19 +78,15 @@ public class FailoverClusterInvokerTest {
 
     @Test
     public void testInvokeWithRuntimeException() {
-        EasyMock.reset(invoker1);
-        EasyMock.expect(invoker1.invoke(invocation)).andThrow(new RuntimeException()).anyTimes();
-        EasyMock.expect(invoker1.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker1.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker1.getInterface()).andReturn(FailoverClusterInvokerTest.class).anyTimes();
-        EasyMock.replay(invoker1);
+        given(invoker1.invoke(invocation)).willThrow(new RuntimeException());
+        given(invoker1.isAvailable()).willReturn(true);
+        given(invoker1.getUrl()).willReturn(url);
+        given(invoker1.getInterface()).willReturn(FailoverClusterInvokerTest.class);
 
-        EasyMock.reset(invoker2);
-        EasyMock.expect(invoker2.invoke(invocation)).andThrow(new RuntimeException()).anyTimes();
-        EasyMock.expect(invoker2.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker2.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker2.getInterface()).andReturn(FailoverClusterInvokerTest.class).anyTimes();
-        EasyMock.replay(invoker2);
+        given(invoker2.invoke(invocation)).willThrow(new RuntimeException());
+        given(invoker2.isAvailable()).willReturn(true);
+        given(invoker2.getUrl()).willReturn(url);
+        given(invoker2.getInterface()).willReturn(FailoverClusterInvokerTest.class);
 
         FailoverClusterInvoker<FailoverClusterInvokerTest> invoker = new FailoverClusterInvoker<FailoverClusterInvokerTest>(dic);
         try {
@@ -104,20 +100,15 @@ public class FailoverClusterInvokerTest {
 
     @Test()
     public void testInvokeWithRPCException() {
+        given(invoker1.invoke(invocation)).willThrow(new RpcException());
+        given(invoker1.isAvailable()).willReturn(true);
+        given(invoker1.getUrl()).willReturn(url);
+        given(invoker1.getInterface()).willReturn(FailoverClusterInvokerTest.class);
 
-        EasyMock.reset(invoker1);
-        EasyMock.expect(invoker1.invoke(invocation)).andThrow(new RpcException()).anyTimes();
-        EasyMock.expect(invoker1.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker1.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker1.getInterface()).andReturn(FailoverClusterInvokerTest.class).anyTimes();
-        EasyMock.replay(invoker1);
-
-        EasyMock.reset(invoker2);
-        EasyMock.expect(invoker2.invoke(invocation)).andReturn(result).anyTimes();
-        EasyMock.expect(invoker2.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker2.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker2.getInterface()).andReturn(FailoverClusterInvokerTest.class).anyTimes();
-        EasyMock.replay(invoker2);
+        given(invoker2.invoke(invocation)).willReturn(result);
+        given(invoker2.isAvailable()).willReturn(true);
+        given(invoker2.getUrl()).willReturn(url);
+        given(invoker2.getInterface()).willReturn(FailoverClusterInvokerTest.class);
 
         FailoverClusterInvoker<FailoverClusterInvokerTest> invoker = new FailoverClusterInvoker<FailoverClusterInvokerTest>(dic);
         for (int i = 0; i < 100; i++) {
@@ -128,20 +119,15 @@ public class FailoverClusterInvokerTest {
 
     @Test()
     public void testInvoke_retryTimes() {
+        given(invoker1.invoke(invocation)).willThrow(new RpcException(RpcException.TIMEOUT_EXCEPTION));
+        given(invoker1.isAvailable()).willReturn(false);
+        given(invoker1.getUrl()).willReturn(url);
+        given(invoker1.getInterface()).willReturn(FailoverClusterInvokerTest.class);
 
-        EasyMock.reset(invoker1);
-        EasyMock.expect(invoker1.invoke(invocation)).andThrow(new RpcException(RpcException.TIMEOUT_EXCEPTION)).anyTimes();
-        EasyMock.expect(invoker1.isAvailable()).andReturn(false).anyTimes();
-        EasyMock.expect(invoker1.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker1.getInterface()).andReturn(FailoverClusterInvokerTest.class).anyTimes();
-        EasyMock.replay(invoker1);
-
-        EasyMock.reset(invoker2);
-        EasyMock.expect(invoker2.invoke(invocation)).andThrow(new RpcException()).anyTimes();
-        EasyMock.expect(invoker2.isAvailable()).andReturn(false).anyTimes();
-        EasyMock.expect(invoker2.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker2.getInterface()).andReturn(FailoverClusterInvokerTest.class).anyTimes();
-        EasyMock.replay(invoker2);
+        given(invoker2.invoke(invocation)).willThrow(new RpcException());
+        given(invoker2.isAvailable()).willReturn(false);
+        given(invoker2.getUrl()).willReturn(url);
+        given(invoker2.getInterface()).willReturn(FailoverClusterInvokerTest.class);
 
         FailoverClusterInvoker<FailoverClusterInvokerTest> invoker = new FailoverClusterInvoker<FailoverClusterInvokerTest>(dic);
         try {
@@ -156,13 +142,12 @@ public class FailoverClusterInvokerTest {
 
     @Test()
     public void testNoInvoke() {
-        dic = EasyMock.createMock(Directory.class);
+        dic = mock(Directory.class);
 
-        EasyMock.expect(dic.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(dic.list(invocation)).andReturn(null).anyTimes();
-        EasyMock.expect(dic.getInterface()).andReturn(FailoverClusterInvokerTest.class).anyTimes();
+        given(dic.getUrl()).willReturn(url);
+        given(dic.list(invocation)).willReturn(null);
+        given(dic.getInterface()).willReturn(FailoverClusterInvokerTest.class);
         invocation.setMethodName("method1");
-        EasyMock.replay(dic);
 
         invokers.add(invoker1);
 

--- a/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/support/ForkingClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/support/ForkingClusterInvokerTest.java
@@ -25,8 +25,6 @@ import com.alibaba.dubbo.rpc.RpcResult;
 import com.alibaba.dubbo.rpc.cluster.Directory;
 
 import junit.framework.Assert;
-import org.easymock.EasyMock;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,6 +32,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertFalse;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * ForkingClusterInvokerTest
@@ -44,9 +44,9 @@ public class ForkingClusterInvokerTest {
 
     List<Invoker<ForkingClusterInvokerTest>> invokers = new ArrayList<Invoker<ForkingClusterInvokerTest>>();
     URL url = URL.valueOf("test://test:11/test?forks=2");
-    Invoker<ForkingClusterInvokerTest> invoker1 = EasyMock.createMock(Invoker.class);
-    Invoker<ForkingClusterInvokerTest> invoker2 = EasyMock.createMock(Invoker.class);
-    Invoker<ForkingClusterInvokerTest> invoker3 = EasyMock.createMock(Invoker.class);
+    Invoker<ForkingClusterInvokerTest> invoker1 = mock(Invoker.class);
+    Invoker<ForkingClusterInvokerTest> invoker2 = mock(Invoker.class);
+    Invoker<ForkingClusterInvokerTest> invoker3 = mock(Invoker.class);
     RpcInvocation invocation = new RpcInvocation();
     Directory<ForkingClusterInvokerTest> dic;
     Result result = new RpcResult();
@@ -58,67 +58,51 @@ public class ForkingClusterInvokerTest {
     @Before
     public void setUp() throws Exception {
 
-        dic = EasyMock.createMock(Directory.class);
+        dic = mock(Directory.class);
 
-        EasyMock.expect(dic.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(dic.list(invocation)).andReturn(invokers).anyTimes();
-        EasyMock.expect(dic.getInterface()).andReturn(ForkingClusterInvokerTest.class).anyTimes();
+        given(dic.getUrl()).willReturn(url);
+        given(dic.list(invocation)).willReturn(invokers);
+        given(dic.getInterface()).willReturn(ForkingClusterInvokerTest.class);
 
         invocation.setMethodName("method1");
-        EasyMock.replay(dic);
 
         invokers.add(invoker1);
         invokers.add(invoker2);
         invokers.add(invoker3);
 
     }
-
-    @After
-    public void tearDown() {
-        EasyMock.verify(invoker1, dic);
-
-    }
-
     private void resetInvokerToException() {
-        EasyMock.reset(invoker1);
-        EasyMock.expect(invoker1.invoke(invocation)).andThrow(new RuntimeException()).anyTimes();
-        EasyMock.expect(invoker1.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker1.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker1.getInterface()).andReturn(ForkingClusterInvokerTest.class).anyTimes();
-        EasyMock.replay(invoker1);
-        EasyMock.reset(invoker2);
-        EasyMock.expect(invoker2.invoke(invocation)).andThrow(new RuntimeException()).anyTimes();
-        EasyMock.expect(invoker2.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker2.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker2.getInterface()).andReturn(ForkingClusterInvokerTest.class).anyTimes();
-        EasyMock.replay(invoker2);
-        EasyMock.reset(invoker3);
-        EasyMock.expect(invoker3.invoke(invocation)).andThrow(new RuntimeException()).anyTimes();
-        EasyMock.expect(invoker3.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker3.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker3.getInterface()).andReturn(ForkingClusterInvokerTest.class).anyTimes();
-        EasyMock.replay(invoker3);
+        given(invoker1.invoke(invocation)).willThrow(new RuntimeException());
+        given(invoker1.getUrl()).willReturn(url);
+        given(invoker1.isAvailable()).willReturn(true);
+        given(invoker1.getInterface()).willReturn(ForkingClusterInvokerTest.class);
+
+        given(invoker2.invoke(invocation)).willThrow(new RuntimeException());
+        given(invoker2.getUrl()).willReturn(url);
+        given(invoker2.isAvailable()).willReturn(true);
+        given(invoker2.getInterface()).willReturn(ForkingClusterInvokerTest.class);
+
+        given(invoker3.invoke(invocation)).willThrow(new RuntimeException());
+        given(invoker3.getUrl()).willReturn(url);
+        given(invoker3.isAvailable()).willReturn(true);
+        given(invoker3.getInterface()).willReturn(ForkingClusterInvokerTest.class);
     }
 
     private void resetInvokerToNoException() {
-        EasyMock.reset(invoker1);
-        EasyMock.expect(invoker1.invoke(invocation)).andReturn(result).anyTimes();
-        EasyMock.expect(invoker1.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker1.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker1.getInterface()).andReturn(ForkingClusterInvokerTest.class).anyTimes();
-        EasyMock.replay(invoker1);
-        EasyMock.reset(invoker2);
-        EasyMock.expect(invoker2.invoke(invocation)).andReturn(result).anyTimes();
-        EasyMock.expect(invoker2.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker2.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker2.getInterface()).andReturn(ForkingClusterInvokerTest.class).anyTimes();
-        EasyMock.replay(invoker2);
-        EasyMock.reset(invoker3);
-        EasyMock.expect(invoker3.invoke(invocation)).andReturn(result).anyTimes();
-        EasyMock.expect(invoker3.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(invoker3.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker3.getInterface()).andReturn(ForkingClusterInvokerTest.class).anyTimes();
-        EasyMock.replay(invoker3);
+        given(invoker1.invoke(invocation)).willReturn(result);
+        given(invoker1.getUrl()).willReturn(url);
+        given(invoker1.isAvailable()).willReturn(true);
+        given(invoker1.getInterface()).willReturn(ForkingClusterInvokerTest.class);
+
+        given(invoker2.invoke(invocation)).willReturn(result);
+        given(invoker2.getUrl()).willReturn(url);
+        given(invoker2.isAvailable()).willReturn(true);
+        given(invoker2.getInterface()).willReturn(ForkingClusterInvokerTest.class);
+
+        given(invoker3.invoke(invocation)).willReturn(result);
+        given(invoker3.getUrl()).willReturn(url);
+        given(invoker3.isAvailable()).willReturn(true);
+        given(invoker3.getInterface()).willReturn(ForkingClusterInvokerTest.class);
     }
 
     @Test

--- a/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/support/MergeableClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/com/alibaba/dubbo/rpc/cluster/support/MergeableClusterInvokerTest.java
@@ -24,8 +24,6 @@ import com.alibaba.dubbo.rpc.Result;
 import com.alibaba.dubbo.rpc.RpcResult;
 import com.alibaba.dubbo.rpc.cluster.Directory;
 
-import junit.framework.TestCase;
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,12 +38,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
 public class MergeableClusterInvokerTest {
 
-    private Directory directory = EasyMock.createMock(Directory.class);
-    private Invoker firstInvoker = EasyMock.createMock(Invoker.class);
-    private Invoker secondInvoker = EasyMock.createMock(Invoker.class);
-    private Invocation invocation = EasyMock.createMock(Invocation.class);
+    private Directory directory = mock(Directory.class);
+    private Invoker firstInvoker = mock(Invoker.class);
+    private Invoker secondInvoker = mock(Invoker.class);
+    private Invocation invocation = mock(Invocation.class);
 
     private MergeableClusterInvoker<MenuService> mergeableClusterInvoker;
 
@@ -87,10 +89,10 @@ public class MergeableClusterInvokerTest {
     @Before
     public void setUp() throws Exception {
 
-        directory = EasyMock.createMock(Directory.class);
-        firstInvoker = EasyMock.createMock(Invoker.class);
-        secondInvoker = EasyMock.createMock(Invoker.class);
-        invocation = EasyMock.createMock(Invocation.class);
+        directory = mock(Directory.class);
+        firstInvoker = mock(Invoker.class);
+        secondInvoker = mock(Invoker.class);
+        invocation = mock(Invocation.class);
 
     }
 
@@ -100,13 +102,12 @@ public class MergeableClusterInvokerTest {
         // setup
         url = url.addParameter(Constants.MERGER_KEY, ".merge");
 
-        EasyMock.expect(invocation.getMethodName()).andReturn("getMenu").anyTimes();
-        EasyMock.expect(invocation.getParameterTypes()).andReturn(new Class<?>[]{}).anyTimes();
-        EasyMock.expect(invocation.getArguments()).andReturn(new Object[]{}).anyTimes();
-        EasyMock.expect(invocation.getAttachments()).andReturn(new HashMap<String, String>())
-                .anyTimes();
-        EasyMock.expect(invocation.getInvoker()).andReturn(firstInvoker).anyTimes();
-        EasyMock.replay(invocation);
+        given(invocation.getMethodName()).willReturn("getMenu");
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{});
+        given(invocation.getArguments()).willReturn(new Object[]{});
+        given(invocation.getAttachments()).willReturn(new HashMap<String, String>())
+                ;
+        given(invocation.getInvoker()).willReturn(firstInvoker);
 
         firstInvoker = (Invoker) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[]{Invoker.class}, new InvocationHandler() {
 
@@ -140,16 +141,15 @@ public class MergeableClusterInvokerTest {
             }
         });
 
-        EasyMock.expect(directory.list(invocation)).andReturn(new ArrayList() {
+        given(directory.list(invocation)).willReturn(new ArrayList() {
 
             {
                 add(firstInvoker);
                 add(secondInvoker);
             }
-        }).anyTimes();
-        EasyMock.expect(directory.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(directory.getInterface()).andReturn(MenuService.class).anyTimes();
-        EasyMock.replay(directory);
+        });
+        given(directory.getUrl()).willReturn(url);
+        given(directory.getInterface()).willReturn(MenuService.class);
 
         mergeableClusterInvoker = new MergeableClusterInvoker<MenuService>(directory);
 
@@ -160,7 +160,7 @@ public class MergeableClusterInvokerTest {
         Map<String, List<String>> expected = new HashMap<String, List<String>>();
         merge(expected, firstMenuMap);
         merge(expected, secondMenuMap);
-        TestCase.assertEquals(expected.keySet(), menu.getMenus().keySet());
+        assertEquals(expected.keySet(), menu.getMenus().keySet());
         for (String key : expected.keySet()) {
             // FIXME: cannot guarantee the sequence of the merge result, check implementation in
             // MergeableClusterInvoker#invoke
@@ -168,7 +168,7 @@ public class MergeableClusterInvokerTest {
             List<String> values2 = new ArrayList<String>(menu.getMenus().get(key));
             Collections.sort(values1);
             Collections.sort(values2);
-            TestCase.assertEquals(values1, values2);
+            assertEquals(values1, values2);
         }
     }
 
@@ -183,42 +183,38 @@ public class MergeableClusterInvokerTest {
             }
         };
 
-        EasyMock.expect(invocation.getMethodName()).andReturn("addMenu").anyTimes();
-        EasyMock.expect(invocation.getParameterTypes()).andReturn(
-                new Class<?>[]{String.class, List.class}).anyTimes();
-        EasyMock.expect(invocation.getArguments()).andReturn(new Object[]{menu, menuItems})
-                .anyTimes();
-        EasyMock.expect(invocation.getAttachments()).andReturn(new HashMap<String, String>())
-                .anyTimes();
-        EasyMock.expect(invocation.getInvoker()).andReturn(firstInvoker).anyTimes();
-        EasyMock.replay(invocation);
+        given(invocation.getMethodName()).willReturn("addMenu");
+        given(invocation.getParameterTypes()).willReturn(
+                new Class<?>[]{String.class, List.class});
+        given(invocation.getArguments()).willReturn(new Object[]{menu, menuItems})
+                ;
+        given(invocation.getAttachments()).willReturn(new HashMap<String, String>())
+                ;
+        given(invocation.getInvoker()).willReturn(firstInvoker);
 
-        EasyMock.expect(firstInvoker.getUrl()).andReturn(
-                url.addParameter(Constants.GROUP_KEY, "first")).anyTimes();
-        EasyMock.expect(firstInvoker.getInterface()).andReturn(MenuService.class).anyTimes();
-        EasyMock.expect(firstInvoker.invoke(invocation)).andReturn(new RpcResult())
-                .anyTimes();
-        EasyMock.expect(firstInvoker.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.replay(firstInvoker);
+        given(firstInvoker.getUrl()).willReturn(
+                url.addParameter(Constants.GROUP_KEY, "first"));
+        given(firstInvoker.getInterface()).willReturn(MenuService.class);
+        given(firstInvoker.invoke(invocation)).willReturn(new RpcResult())
+                ;
+        given(firstInvoker.isAvailable()).willReturn(true);
 
-        EasyMock.expect(secondInvoker.getUrl()).andReturn(
-                url.addParameter(Constants.GROUP_KEY, "second")).anyTimes();
-        EasyMock.expect(secondInvoker.getInterface()).andReturn(MenuService.class).anyTimes();
-        EasyMock.expect(secondInvoker.invoke(invocation)).andReturn(new RpcResult())
-                .anyTimes();
-        EasyMock.expect(secondInvoker.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.replay(secondInvoker);
+        given(secondInvoker.getUrl()).willReturn(
+                url.addParameter(Constants.GROUP_KEY, "second"));
+        given(secondInvoker.getInterface()).willReturn(MenuService.class);
+        given(secondInvoker.invoke(invocation)).willReturn(new RpcResult())
+                ;
+        given(secondInvoker.isAvailable()).willReturn(true);
 
-        EasyMock.expect(directory.list(invocation)).andReturn(new ArrayList() {
+        given(directory.list(invocation)).willReturn(new ArrayList() {
 
             {
                 add(firstInvoker);
                 add(secondInvoker);
             }
-        }).anyTimes();
-        EasyMock.expect(directory.getUrl()).andReturn(url).anyTimes();
-        EasyMock.expect(directory.getInterface()).andReturn(MenuService.class).anyTimes();
-        EasyMock.replay(directory);
+        });
+        given(directory.getUrl()).willReturn(url);
+        given(directory.getInterface()).willReturn(MenuService.class);
 
         mergeableClusterInvoker = new MergeableClusterInvoker<MenuService>(directory);
 

--- a/dubbo-filter/dubbo-filter-cache/src/test/java/com/alibaba/dubbo/cache/filter/CacheFilterTest.java
+++ b/dubbo-filter/dubbo-filter-cache/src/test/java/com/alibaba/dubbo/cache/filter/CacheFilterTest.java
@@ -22,17 +22,19 @@ import com.alibaba.dubbo.rpc.Invoker;
 import com.alibaba.dubbo.rpc.RpcInvocation;
 import com.alibaba.dubbo.rpc.RpcResult;
 
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
 public class CacheFilterTest {
     private static RpcInvocation invocation;
     static CacheFilter cacheFilter = new CacheFilter();
-    static Invoker<?> invoker = EasyMock.createMock(Invoker.class);
-    static Invoker<?> invoker1 = EasyMock.createMock(Invoker.class);
-    static Invoker<?> invoker2 = EasyMock.createMock(Invoker.class);
+    static Invoker<?> invoker = mock(Invoker.class);
+    static Invoker<?> invoker1 = mock(Invoker.class);
+    static Invoker<?> invoker2 = mock(Invoker.class);
 
     @BeforeClass
     public static void setUp() {
@@ -41,17 +43,14 @@ public class CacheFilterTest {
 
         URL url = URL.valueOf("test://test:11/test?cache=lru");
 
-        EasyMock.expect(invoker.invoke(invocation)).andReturn(new RpcResult(new String("value"))).anyTimes();
-        EasyMock.expect(invoker.getUrl()).andReturn(url).anyTimes();
-        EasyMock.replay(invoker);
+        given(invoker.invoke(invocation)).willReturn(new RpcResult(new String("value")));
+        given(invoker.getUrl()).willReturn(url);
 
-        EasyMock.expect(invoker1.invoke(invocation)).andReturn(new RpcResult(new String("value1"))).anyTimes();
-        EasyMock.expect(invoker1.getUrl()).andReturn(url).anyTimes();
-        EasyMock.replay(invoker1);
+        given(invoker1.invoke(invocation)).willReturn(new RpcResult(new String("value1")));
+        given(invoker1.getUrl()).willReturn(url);
 
-        EasyMock.expect(invoker2.invoke(invocation)).andReturn(new RpcResult(new String("value2"))).anyTimes();
-        EasyMock.expect(invoker2.getUrl()).andReturn(url).anyTimes();
-        EasyMock.replay(invoker2);
+        given(invoker2.invoke(invocation)).willReturn(new RpcResult(new String("value2")));
+        given(invoker2.getUrl()).willReturn(url);
     }
 
     @Test

--- a/dubbo-registry/dubbo-registry-zookeeper/src/test/java/com/alibaba/dubbo/registry/zookeeper/ZookeeperRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/test/java/com/alibaba/dubbo/registry/zookeeper/ZookeeperRegistryTest.java
@@ -24,7 +24,6 @@ import com.alibaba.dubbo.registry.Registry;
 import com.alibaba.dubbo.registry.status.RegistryStatusChecker;
 import com.alibaba.dubbo.remoting.zookeeper.curator.CuratorZookeeperTransporter;
 import org.apache.curator.test.TestingServer;
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -37,6 +36,7 @@ import java.util.concurrent.CountDownLatch;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class ZookeeperRegistryTest {
     private TestingServer zkServer;
@@ -91,7 +91,7 @@ public class ZookeeperRegistryTest {
 
     @Test
     public void testSubscribe() {
-        NotifyListener listener = EasyMock.mock(NotifyListener.class);
+        NotifyListener listener = mock(NotifyListener.class);
         zookeeperRegistry.subscribe(serviceUrl, listener);
 
         Map<URL, Set<NotifyListener>> subscribed = zookeeperRegistry.getSubscribed();

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/com/alibaba/dubbo/remoting/transport/AbstractCodecTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/com/alibaba/dubbo/remoting/transport/AbstractCodecTest.java
@@ -18,26 +18,23 @@ package com.alibaba.dubbo.remoting.transport;
 
 import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.remoting.Channel;
-
 import junit.framework.TestCase;
 import org.hamcrest.CoreMatchers;
+import org.mockito.internal.verification.VerificationModeFactory;
 
 import java.io.IOException;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.junit.Assert.assertThat;
-import static org.junit.matchers.JUnitMatchers.containsString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class AbstractCodecTest extends TestCase {
 
     public void test_checkPayload_default8M() throws Exception {
-        Channel channel = createMock(Channel.class);
-        expect(channel.getUrl()).andReturn(URL.valueOf("dubbo://1.1.1.1")).anyTimes();
-        replay(channel);
+        Channel channel = mock(Channel.class);
+        given(channel.getUrl()).willReturn(URL.valueOf("dubbo://1.1.1.1"));
 
         AbstractCodec.checkPayload(channel, 1 * 1024 * 1024);
 
@@ -50,16 +47,15 @@ public class AbstractCodecTest extends TestCase {
             ));
         }
 
-        verify(channel);
+        verify(channel, VerificationModeFactory.atLeastOnce()).getUrl();
     }
 
     public void test_checkPayload_minusPayloadNoLimit() throws Exception {
-        Channel channel = createMock(Channel.class);
-        expect(channel.getUrl()).andReturn(URL.valueOf("dubbo://1.1.1.1?payload=-1")).anyTimes();
-        replay(channel);
+        Channel channel = mock(Channel.class);
+        given(channel.getUrl()).willReturn(URL.valueOf("dubbo://1.1.1.1?payload=-1"));
 
         AbstractCodec.checkPayload(channel, 15 * 1024 * 1024);
 
-        verify(channel);
+        verify(channel, VerificationModeFactory.atLeastOnce()).getUrl();
     }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/com/alibaba/dubbo/rpc/filter/CompatibleFilterFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/com/alibaba/dubbo/rpc/filter/CompatibleFilterFilterTest.java
@@ -24,145 +24,145 @@ import com.alibaba.dubbo.rpc.Result;
 import com.alibaba.dubbo.rpc.RpcResult;
 import com.alibaba.dubbo.rpc.support.DemoService;
 import com.alibaba.dubbo.rpc.support.Type;
-
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * CompatibleFilterTest.java
  */
 public class CompatibleFilterFilterTest {
-
-    Filter compatibleFilter = new CompatibleFilter();
-    Invocation invocation;
-    Invoker<DemoService> invoker;
+    private Filter compatibleFilter = new CompatibleFilter();
+    private Invocation invocation;
+    private Invoker invoker;
 
     @After
     public void tearDown() {
-        EasyMock.reset(invocation, invoker);
+        Mockito.reset(invocation, invoker);
     }
 
     @Test
     public void testInvokerGeneric() {
-        invocation = EasyMock.createMock(Invocation.class);
-        EasyMock.expect(invocation.getMethodName()).andReturn("$enumlength").anyTimes();
-        EasyMock.expect(invocation.getParameterTypes()).andReturn(new Class<?>[]{Enum.class}).anyTimes();
-        EasyMock.expect(invocation.getArguments()).andReturn(new Object[]{"hello"}).anyTimes();
-        EasyMock.replay(invocation);
-        invoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(invoker.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker.getInterface()).andReturn(DemoService.class).anyTimes();
+        invocation = mock(Invocation.class);
+        given(invocation.getMethodName()).willReturn("$enumlength");
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{Enum.class});
+        given(invocation.getArguments()).willReturn(new Object[]{"hello"});
+
+        invoker = mock(Invoker.class);
+        given(invoker.isAvailable()).willReturn(true);
+        given(invoker.getInterface()).willReturn(DemoService.class);
         RpcResult result = new RpcResult();
         result.setValue("High");
-        EasyMock.expect(invoker.invoke(invocation)).andReturn(result).anyTimes();
+        given(invoker.invoke(invocation)).willReturn(result);
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
-        EasyMock.expect(invoker.getUrl()).andReturn(url).anyTimes();
-        EasyMock.replay(invoker);
+        given(invoker.getUrl()).willReturn(url);
+
         Result filterResult = compatibleFilter.invoke(invoker, invocation);
         assertEquals(filterResult, result);
     }
 
     @Test
     public void testResulthasException() {
-        invocation = EasyMock.createMock(Invocation.class);
-        EasyMock.expect(invocation.getMethodName()).andReturn("enumlength").anyTimes();
-        EasyMock.expect(invocation.getParameterTypes()).andReturn(new Class<?>[]{Enum.class}).anyTimes();
-        EasyMock.expect(invocation.getArguments()).andReturn(new Object[]{"hello"}).anyTimes();
-        EasyMock.replay(invocation);
-        invoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(invoker.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker.getInterface()).andReturn(DemoService.class).anyTimes();
+        invocation = mock(Invocation.class);
+        given(invocation.getMethodName()).willReturn("enumlength");
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{Enum.class});
+        given(invocation.getArguments()).willReturn(new Object[]{"hello"});
+
+        invoker = mock(Invoker.class);
+        given(invoker.isAvailable()).willReturn(true);
+        given(invoker.getInterface()).willReturn(DemoService.class);
         RpcResult result = new RpcResult();
         result.setException(new RuntimeException());
         result.setValue("High");
-        EasyMock.expect(invoker.invoke(invocation)).andReturn(result).anyTimes();
+        given(invoker.invoke(invocation)).willReturn(result);
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
-        EasyMock.expect(invoker.getUrl()).andReturn(url).anyTimes();
-        EasyMock.replay(invoker);
+        given(invoker.getUrl()).willReturn(url);
+
         Result filterResult = compatibleFilter.invoke(invoker, invocation);
         assertEquals(filterResult, result);
     }
 
     @Test
     public void testInvokerJsonPojoSerialization() {
-        invocation = EasyMock.createMock(Invocation.class);
-        EasyMock.expect(invocation.getMethodName()).andReturn("enumlength").anyTimes();
-        EasyMock.expect(invocation.getParameterTypes()).andReturn(new Class<?>[]{Type[].class}).anyTimes();
-        EasyMock.expect(invocation.getArguments()).andReturn(new Object[]{"hello"}).anyTimes();
-        EasyMock.replay(invocation);
-        invoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(invoker.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker.getInterface()).andReturn(DemoService.class).anyTimes();
+        invocation = mock(Invocation.class);
+        given(invocation.getMethodName()).willReturn("enumlength");
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{Type[].class});
+        given(invocation.getArguments()).willReturn(new Object[]{"hello"});
+
+        invoker = mock(Invoker.class);
+        given(invoker.isAvailable()).willReturn(true);
+        given(invoker.getInterface()).willReturn(DemoService.class);
         RpcResult result = new RpcResult();
         result.setValue("High");
-        EasyMock.expect(invoker.invoke(invocation)).andReturn(result).anyTimes();
+        given(invoker.invoke(invocation)).willReturn(result);
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1&serialization=json");
-        EasyMock.expect(invoker.getUrl()).andReturn(url).anyTimes();
-        EasyMock.replay(invoker);
+        given(invoker.getUrl()).willReturn(url);
+
         Result filterResult = compatibleFilter.invoke(invoker, invocation);
         assertEquals(Type.High, filterResult.getValue());
     }
 
     @Test
     public void testInvokerNonJsonEnumSerialization() {
-        invocation = EasyMock.createMock(Invocation.class);
-        EasyMock.expect(invocation.getMethodName()).andReturn("enumlength").anyTimes();
-        EasyMock.expect(invocation.getParameterTypes()).andReturn(new Class<?>[]{Type[].class}).anyTimes();
-        EasyMock.expect(invocation.getArguments()).andReturn(new Object[]{"hello"}).anyTimes();
-        EasyMock.replay(invocation);
-        invoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(invoker.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker.getInterface()).andReturn(DemoService.class).anyTimes();
+        invocation = mock(Invocation.class);
+        given(invocation.getMethodName()).willReturn("enumlength");
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{Type[].class});
+        given(invocation.getArguments()).willReturn(new Object[]{"hello"});
+
+        invoker = mock(Invoker.class);
+        given(invoker.isAvailable()).willReturn(true);
+        given(invoker.getInterface()).willReturn(DemoService.class);
         RpcResult result = new RpcResult();
         result.setValue("High");
-        EasyMock.expect(invoker.invoke(invocation)).andReturn(result).anyTimes();
+        given(invoker.invoke(invocation)).willReturn(result);
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
-        EasyMock.expect(invoker.getUrl()).andReturn(url).anyTimes();
-        EasyMock.replay(invoker);
+        given(invoker.getUrl()).willReturn(url);
+
         Result filterResult = compatibleFilter.invoke(invoker, invocation);
         assertEquals(Type.High, filterResult.getValue());
     }
 
     @Test
     public void testInvokerNonJsonNonPojoSerialization() {
-        invocation = EasyMock.createMock(Invocation.class);
-        EasyMock.expect(invocation.getMethodName()).andReturn("echo").anyTimes();
-        EasyMock.expect(invocation.getParameterTypes()).andReturn(new Class<?>[]{String.class}).anyTimes();
-        EasyMock.expect(invocation.getArguments()).andReturn(new Object[]{"hello"}).anyTimes();
-        EasyMock.replay(invocation);
-        invoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(invoker.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker.getInterface()).andReturn(DemoService.class).anyTimes();
+        invocation = mock(Invocation.class);
+        given(invocation.getMethodName()).willReturn("echo");
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{String.class});
+        given(invocation.getArguments()).willReturn(new Object[]{"hello"});
+
+        invoker = mock(Invoker.class);
+        given(invoker.isAvailable()).willReturn(true);
+        given(invoker.getInterface()).willReturn(DemoService.class);
         RpcResult result = new RpcResult();
         result.setValue(new String[]{"High"});
-        EasyMock.expect(invoker.invoke(invocation)).andReturn(result).anyTimes();
+        given(invoker.invoke(invocation)).willReturn(result);
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
-        EasyMock.expect(invoker.getUrl()).andReturn(url).anyTimes();
-        EasyMock.replay(invoker);
+        given(invoker.getUrl()).willReturn(url);
+
         Result filterResult = compatibleFilter.invoke(invoker, invocation);
         assertArrayEquals(new String[]{"High"}, (String[]) filterResult.getValue());
     }
 
     @Test
     public void testInvokerNonJsonPojoSerialization() {
-        invocation = EasyMock.createMock(Invocation.class);
-        EasyMock.expect(invocation.getMethodName()).andReturn("echo").anyTimes();
-        EasyMock.expect(invocation.getParameterTypes()).andReturn(new Class<?>[]{String.class}).anyTimes();
-        EasyMock.expect(invocation.getArguments()).andReturn(new Object[]{"hello"}).anyTimes();
-        EasyMock.replay(invocation);
-        invoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(invoker.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker.getInterface()).andReturn(DemoService.class).anyTimes();
+        invocation = mock(Invocation.class);
+        given(invocation.getMethodName()).willReturn("echo");
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{String.class});
+        given(invocation.getArguments()).willReturn(new Object[]{"hello"});
+
+        invoker = mock(Invoker.class);
+        given(invoker.isAvailable()).willReturn(true);
+        given(invoker.getInterface()).willReturn(DemoService.class);
         RpcResult result = new RpcResult();
         result.setValue("hello");
-        EasyMock.expect(invoker.invoke(invocation)).andReturn(result).anyTimes();
+        given(invoker.invoke(invocation)).willReturn(result);
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
-        EasyMock.expect(invoker.getUrl()).andReturn(url).anyTimes();
-        EasyMock.replay(invoker);
+        given(invoker.getUrl()).willReturn(url);
+
         Result filterResult = compatibleFilter.invoke(invoker, invocation);
         assertEquals("hello", filterResult.getValue());
     }

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/com/alibaba/dubbo/rpc/filter/ContextFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/com/alibaba/dubbo/rpc/filter/ContextFilterTest.java
@@ -27,10 +27,11 @@ import com.alibaba.dubbo.rpc.support.DemoService;
 import com.alibaba.dubbo.rpc.support.MockInvocation;
 import com.alibaba.dubbo.rpc.support.MyInvoker;
 
-import org.easymock.EasyMock;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * ContextFilterTest.java
@@ -45,21 +46,21 @@ public class ContextFilterTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testSetContext() {
-        invocation = EasyMock.createMock(Invocation.class);
-        EasyMock.expect(invocation.getMethodName()).andReturn("$enumlength").anyTimes();
-        EasyMock.expect(invocation.getParameterTypes()).andReturn(new Class<?>[]{Enum.class}).anyTimes();
-        EasyMock.expect(invocation.getArguments()).andReturn(new Object[]{"hello"}).anyTimes();
-        EasyMock.expect(invocation.getAttachments()).andReturn(null).anyTimes();
-        EasyMock.replay(invocation);
-        invoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(invoker.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker.getInterface()).andReturn(DemoService.class).anyTimes();
+        invocation = mock(Invocation.class);
+        given(invocation.getMethodName()).willReturn("$enumlength");
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{Enum.class});
+        given(invocation.getArguments()).willReturn(new Object[]{"hello"});
+        given(invocation.getAttachments()).willReturn(null);
+
+        invoker = mock(Invoker.class);
+        given(invoker.isAvailable()).willReturn(true);
+        given(invoker.getInterface()).willReturn(DemoService.class);
         RpcResult result = new RpcResult();
         result.setValue("High");
-        EasyMock.expect(invoker.invoke(invocation)).andReturn(result).anyTimes();
+        given(invoker.invoke(invocation)).willReturn(result);
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
-        EasyMock.expect(invoker.getUrl()).andReturn(url).anyTimes();
-        EasyMock.replay(invoker);
+        given(invoker.getUrl()).willReturn(url);
+
         contextFilter.invoke(invoker, invocation);
         assertNull(RpcContext.getContext().getInvoker());
     }

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/com/alibaba/dubbo/rpc/filter/EchoFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/com/alibaba/dubbo/rpc/filter/EchoFilterTest.java
@@ -24,14 +24,12 @@ import com.alibaba.dubbo.rpc.Result;
 import com.alibaba.dubbo.rpc.RpcResult;
 import com.alibaba.dubbo.rpc.support.DemoService;
 
-import org.easymock.EasyMock;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
-/**
- * EchoFilterTest.java
- */
 public class EchoFilterTest {
 
     Filter echoFilter = new EchoFilter();
@@ -39,21 +37,21 @@ public class EchoFilterTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testEcho() {
-        Invocation invocation = EasyMock.createMock(Invocation.class);
-        EasyMock.expect(invocation.getMethodName()).andReturn("$echo").anyTimes();
-        EasyMock.expect(invocation.getParameterTypes()).andReturn(new Class<?>[]{Enum.class}).anyTimes();
-        EasyMock.expect(invocation.getArguments()).andReturn(new Object[]{"hello"}).anyTimes();
-        EasyMock.expect(invocation.getAttachments()).andReturn(null).anyTimes();
-        EasyMock.replay(invocation);
-        Invoker<DemoService> invoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(invoker.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker.getInterface()).andReturn(DemoService.class).anyTimes();
+        Invocation invocation = mock(Invocation.class);
+        given(invocation.getMethodName()).willReturn("$echo");
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{Enum.class});
+        given(invocation.getArguments()).willReturn(new Object[]{"hello"});
+        given(invocation.getAttachments()).willReturn(null);
+
+        Invoker<DemoService> invoker = mock(Invoker.class);
+        given(invoker.isAvailable()).willReturn(true);
+        given(invoker.getInterface()).willReturn(DemoService.class);
         RpcResult result = new RpcResult();
         result.setValue("High");
-        EasyMock.expect(invoker.invoke(invocation)).andReturn(result).anyTimes();
+        given(invoker.invoke(invocation)).willReturn(result);
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
-        EasyMock.expect(invoker.getUrl()).andReturn(url).anyTimes();
-        EasyMock.replay(invoker);
+        given(invoker.getUrl()).willReturn(url);
+
         Result filterResult = echoFilter.invoke(invoker, invocation);
         assertEquals("hello", filterResult.getValue());
     }
@@ -61,21 +59,21 @@ public class EchoFilterTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testNonEcho() {
-        Invocation invocation = EasyMock.createMock(Invocation.class);
-        EasyMock.expect(invocation.getMethodName()).andReturn("echo").anyTimes();
-        EasyMock.expect(invocation.getParameterTypes()).andReturn(new Class<?>[]{Enum.class}).anyTimes();
-        EasyMock.expect(invocation.getArguments()).andReturn(new Object[]{"hello"}).anyTimes();
-        EasyMock.expect(invocation.getAttachments()).andReturn(null).anyTimes();
-        EasyMock.replay(invocation);
-        Invoker<DemoService> invoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(invoker.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker.getInterface()).andReturn(DemoService.class).anyTimes();
+        Invocation invocation = mock(Invocation.class);
+        given(invocation.getMethodName()).willReturn("echo");
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{Enum.class});
+        given(invocation.getArguments()).willReturn(new Object[]{"hello"});
+        given(invocation.getAttachments()).willReturn(null);
+
+        Invoker<DemoService> invoker = mock(Invoker.class);
+        given(invoker.isAvailable()).willReturn(true);
+        given(invoker.getInterface()).willReturn(DemoService.class);
         RpcResult result = new RpcResult();
         result.setValue("High");
-        EasyMock.expect(invoker.invoke(invocation)).andReturn(result).anyTimes();
+        given(invoker.invoke(invocation)).willReturn(result);
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
-        EasyMock.expect(invoker.getUrl()).andReturn(url).anyTimes();
-        EasyMock.replay(invoker);
+        given(invoker.getUrl()).willReturn(url);
+
         Result filterResult = echoFilter.invoke(invoker, invocation);
         assertEquals("High", filterResult.getValue());
     }

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/com/alibaba/dubbo/rpc/filter/ExceptionFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/com/alibaba/dubbo/rpc/filter/ExceptionFilterTest.java
@@ -22,11 +22,13 @@ import com.alibaba.dubbo.rpc.RpcContext;
 import com.alibaba.dubbo.rpc.RpcException;
 import com.alibaba.dubbo.rpc.RpcInvocation;
 import com.alibaba.dubbo.rpc.support.DemoService;
-
-import org.easymock.EasyMock;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * ExceptionFilterTest
@@ -36,24 +38,25 @@ public class ExceptionFilterTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testRpcException() {
-        Logger logger = EasyMock.createMock(Logger.class);
+        Logger logger = mock(Logger.class);
         RpcContext.getContext().setRemoteAddress("127.0.0.1", 1234);
         RpcException exception = new RpcException("TestRpcException");
-        logger.error(EasyMock.eq("Got unchecked and undeclared exception which called by 127.0.0.1. service: " + DemoService.class.getName() + ", method: sayHello, exception: " + RpcException.class.getName() + ": TestRpcException"), EasyMock.eq(exception));
+
         ExceptionFilter exceptionFilter = new ExceptionFilter(logger);
         RpcInvocation invocation = new RpcInvocation("sayHello", new Class<?>[]{String.class}, new Object[]{"world"});
-        Invoker<DemoService> invoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(invoker.getInterface()).andReturn(DemoService.class);
-        EasyMock.expect(invoker.invoke(EasyMock.eq(invocation))).andThrow(exception);
+        Invoker<DemoService> invoker = mock(Invoker.class);
+        given(invoker.getInterface()).willReturn(DemoService.class);
+        given(invoker.invoke(eq(invocation))).willThrow(exception);
 
-        EasyMock.replay(logger, invoker);
 
         try {
             exceptionFilter.invoke(invoker, invocation);
         } catch (RpcException e) {
             assertEquals("TestRpcException", e.getMessage());
         }
-        EasyMock.verify(logger, invoker);
+        Mockito.verify(logger).error(eq("Got unchecked and undeclared exception which called by 127.0.0.1. service: "
+                + DemoService.class.getName() + ", method: sayHello, exception: "
+                + RpcException.class.getName() + ": TestRpcException"), eq(exception));
         RpcContext.removeContext();
     }
 

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/com/alibaba/dubbo/rpc/protocol/dubbo/FutureFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/com/alibaba/dubbo/rpc/protocol/dubbo/FutureFilterTest.java
@@ -27,11 +27,12 @@ import com.alibaba.dubbo.rpc.RpcResult;
 import com.alibaba.dubbo.rpc.protocol.dubbo.filter.FutureFilter;
 import com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService;
 
-import org.easymock.EasyMock;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * EventFilterTest.java
@@ -39,7 +40,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class FutureFilterTest {
     private static RpcInvocation invocation;
-    Filter eventFilter = new FutureFilter();
+    private Filter eventFilter = new FutureFilter();
 
     @BeforeClass
     public static void setUp() {
@@ -52,15 +53,15 @@ public class FutureFilterTest {
     @Test
     public void testSyncCallback() {
         @SuppressWarnings("unchecked")
-        Invoker<DemoService> invoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(invoker.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker.getInterface()).andReturn(DemoService.class).anyTimes();
+        Invoker<DemoService> invoker = mock(Invoker.class);
+        given(invoker.isAvailable()).willReturn(true);
+        given(invoker.getInterface()).willReturn(DemoService.class);
         RpcResult result = new RpcResult();
         result.setValue("High");
-        EasyMock.expect(invoker.invoke(invocation)).andReturn(result).anyTimes();
+        given(invoker.invoke(invocation)).willReturn(result);
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
-        EasyMock.expect(invoker.getUrl()).andReturn(url).anyTimes();
-        EasyMock.replay(invoker);
+        given(invoker.getUrl()).willReturn(url);
+
         Result filterResult = eventFilter.invoke(invoker, invocation);
         assertEquals("High", filterResult.getValue());
     }
@@ -68,15 +69,15 @@ public class FutureFilterTest {
     @Test(expected = RuntimeException.class)
     public void testSyncCallbackHasException() throws RpcException, Throwable {
         @SuppressWarnings("unchecked")
-        Invoker<DemoService> invoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(invoker.isAvailable()).andReturn(true).anyTimes();
-        EasyMock.expect(invoker.getInterface()).andReturn(DemoService.class).anyTimes();
+        Invoker<DemoService> invoker = mock(Invoker.class);
+        given(invoker.isAvailable()).willReturn(true);
+        given(invoker.getInterface()).willReturn(DemoService.class);
         RpcResult result = new RpcResult();
         result.setException(new RuntimeException());
-        EasyMock.expect(invoker.invoke(invocation)).andReturn(result).anyTimes();
+        given(invoker.invoke(invocation)).willReturn(result);
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1&" + Constants.ON_THROW_METHOD_KEY + "=echo");
-        EasyMock.expect(invoker.getUrl()).andReturn(url).anyTimes();
-        EasyMock.replay(invoker);
+        given(invoker.getUrl()).willReturn(url);
+
         eventFilter.invoke(invoker, invocation).recreate();
     }
 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/com/alibaba/dubbo/rpc/protocol/dubbo/telnet/ChangeTelnetHandlerTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/com/alibaba/dubbo/rpc/protocol/dubbo/telnet/ChangeTelnetHandlerTest.java
@@ -25,13 +25,15 @@ import com.alibaba.dubbo.rpc.protocol.dubbo.DubboProtocol;
 import com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService;
 import com.alibaba.dubbo.rpc.protocol.dubbo.support.ProtocolUtils;
 
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 
 /**
  * ChangeTelnetHandlerTest.java
@@ -50,26 +52,29 @@ public class ChangeTelnetHandlerTest {
     @SuppressWarnings("unchecked")
     @Before
     public void setUp() {
-        mockChannel = EasyMock.createMock(Channel.class);
-        mockInvoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(mockChannel.getAttribute("telnet.service")).andReturn("com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService").anyTimes();
+        mockChannel = mock(Channel.class);
+        mockInvoker = mock(Invoker.class);
+        given(mockChannel.getAttribute("telnet.service")).willReturn("com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService");
         mockChannel.setAttribute("telnet.service", "DemoService");
-        EasyMock.expectLastCall().anyTimes();
+        givenLastCall();
         mockChannel.setAttribute("telnet.service", "com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService");
-        EasyMock.expectLastCall().anyTimes();
+        givenLastCall();
         mockChannel.setAttribute("telnet.service", "demo");
-        EasyMock.expectLastCall().anyTimes();
+        givenLastCall();
         mockChannel.removeAttribute("telnet.service");
-        EasyMock.expectLastCall().anyTimes();
-        EasyMock.expect(mockInvoker.getInterface()).andReturn(DemoService.class).anyTimes();
-        EasyMock.expect(mockInvoker.getUrl()).andReturn(URL.valueOf("dubbo://127.0.0.1:20883/demo")).anyTimes();
-        EasyMock.replay(mockChannel, mockInvoker);
+        givenLastCall();
+        given(mockInvoker.getInterface()).willReturn(DemoService.class);
+        given(mockInvoker.getUrl()).willReturn(URL.valueOf("dubbo://127.0.0.1:20883/demo"));
+    }
+
+    private void givenLastCall() {
+
     }
 
     @After
     public void after() {
         ProtocolUtils.closeAll();
-        EasyMock.reset(mockChannel, mockInvoker);
+        reset(mockChannel, mockInvoker);
     }
 
     @Test

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/com/alibaba/dubbo/rpc/protocol/dubbo/telnet/CurrentTelnetHandlerTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/com/alibaba/dubbo/rpc/protocol/dubbo/telnet/CurrentTelnetHandlerTest.java
@@ -20,11 +20,12 @@ import com.alibaba.dubbo.remoting.Channel;
 import com.alibaba.dubbo.remoting.RemotingException;
 import com.alibaba.dubbo.remoting.telnet.TelnetHandler;
 
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * CountTelnetHandlerTest.java
@@ -34,34 +35,29 @@ public class CurrentTelnetHandlerTest {
     private static TelnetHandler count = new CurrentTelnetHandler();
     private Channel mockChannel;
 
-    @After
-    public void after() {
-        EasyMock.reset(mockChannel);
-    }
-
     @Test
     public void testService() throws RemotingException {
-        mockChannel = EasyMock.createMock(Channel.class);
-        EasyMock.expect(mockChannel.getAttribute("telnet.service")).andReturn("com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService").anyTimes();
-        EasyMock.replay(mockChannel);
+        mockChannel = mock(Channel.class);
+        given(mockChannel.getAttribute("telnet.service")).willReturn("com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService");
+
         String result = count.telnet(mockChannel, "");
         assertEquals("com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService", result);
     }
 
     @Test
     public void testSlash() throws RemotingException {
-        mockChannel = EasyMock.createMock(Channel.class);
-        EasyMock.expect(mockChannel.getAttribute("telnet.service")).andReturn(null).anyTimes();
-        EasyMock.replay(mockChannel);
+        mockChannel = mock(Channel.class);
+        given(mockChannel.getAttribute("telnet.service")).willReturn(null);
+
         String result = count.telnet(mockChannel, "");
         assertEquals("/", result);
     }
 
     @Test
     public void testMessageError() throws RemotingException {
-        mockChannel = EasyMock.createMock(Channel.class);
-        EasyMock.expect(mockChannel.getAttribute("telnet.service")).andReturn(null).anyTimes();
-        EasyMock.replay(mockChannel);
+        mockChannel = mock(Channel.class);
+        given(mockChannel.getAttribute("telnet.service")).willReturn(null);
+
         String result = count.telnet(mockChannel, "test");
         assertEquals("Unsupported parameter test for pwd.", result);
     }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/com/alibaba/dubbo/rpc/protocol/dubbo/telnet/InvokerTelnetHandlerTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/com/alibaba/dubbo/rpc/protocol/dubbo/telnet/InvokerTelnetHandlerTest.java
@@ -28,12 +28,14 @@ import com.alibaba.dubbo.rpc.protocol.dubbo.DubboProtocol;
 import com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService;
 import com.alibaba.dubbo.rpc.protocol.dubbo.support.ProtocolUtils;
 
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * CountTelnetHandlerTest.java
@@ -52,57 +54,53 @@ public class InvokerTelnetHandlerTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testInvokeDefaultSService() throws RemotingException {
-        mockInvoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(mockInvoker.getInterface()).andReturn(DemoService.class).anyTimes();
-        EasyMock.expect(mockInvoker.getUrl()).andReturn(URL.valueOf("dubbo://127.0.0.1:20883/demo")).anyTimes();
-        EasyMock.expect(mockInvoker.invoke((Invocation) EasyMock.anyObject())).andReturn(new RpcResult("ok")).anyTimes();
-        mockChannel = EasyMock.createMock(Channel.class);
-        EasyMock.expect(mockChannel.getAttribute("telnet.service")).andReturn("com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService").anyTimes();
-        EasyMock.expect(mockChannel.getLocalAddress()).andReturn(NetUtils.toAddress("127.0.0.1:5555")).anyTimes();
-        EasyMock.expect(mockChannel.getRemoteAddress()).andReturn(NetUtils.toAddress("127.0.0.1:20883")).anyTimes();
-        EasyMock.replay(mockChannel, mockInvoker);
+        mockInvoker = mock(Invoker.class);
+        given(mockInvoker.getInterface()).willReturn(DemoService.class);
+        given(mockInvoker.getUrl()).willReturn(URL.valueOf("dubbo://127.0.0.1:20883/demo"));
+        given(mockInvoker.invoke(any(Invocation.class))).willReturn(new RpcResult("ok"));
+        mockChannel = mock(Channel.class);
+        given(mockChannel.getAttribute("telnet.service")).willReturn("com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService");
+        given(mockChannel.getLocalAddress()).willReturn(NetUtils.toAddress("127.0.0.1:5555"));
+        given(mockChannel.getRemoteAddress()).willReturn(NetUtils.toAddress("127.0.0.1:20883"));
+
         DubboProtocol.getDubboProtocol().export(mockInvoker);
         String result = invoke.telnet(mockChannel, "DemoService.echo(\"ok\")");
         assertTrue(result.contains("Use default service com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService.\r\n\"ok\"\r\n"));
-        EasyMock.reset(mockChannel, mockInvoker);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testInvokeAutoFindMethod() throws RemotingException {
-        mockInvoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(mockInvoker.getInterface()).andReturn(DemoService.class).anyTimes();
-        EasyMock.expect(mockInvoker.getUrl()).andReturn(URL.valueOf("dubbo://127.0.0.1:20883/demo")).anyTimes();
-        EasyMock.expect(mockInvoker.invoke((Invocation) EasyMock.anyObject())).andReturn(new RpcResult("ok")).anyTimes();
-        mockChannel = EasyMock.createMock(Channel.class);
-        EasyMock.expect(mockChannel.getAttribute("telnet.service")).andReturn(null).anyTimes();
-        EasyMock.expect(mockChannel.getLocalAddress()).andReturn(NetUtils.toAddress("127.0.0.1:5555")).anyTimes();
-        EasyMock.expect(mockChannel.getRemoteAddress()).andReturn(NetUtils.toAddress("127.0.0.1:20883")).anyTimes();
-        EasyMock.replay(mockChannel, mockInvoker);
+        mockInvoker = mock(Invoker.class);
+        given(mockInvoker.getInterface()).willReturn(DemoService.class);
+        given(mockInvoker.getUrl()).willReturn(URL.valueOf("dubbo://127.0.0.1:20883/demo"));
+        given(mockInvoker.invoke(any(Invocation.class))).willReturn(new RpcResult("ok"));
+        mockChannel = mock(Channel.class);
+        given(mockChannel.getAttribute("telnet.service")).willReturn(null);
+        given(mockChannel.getLocalAddress()).willReturn(NetUtils.toAddress("127.0.0.1:5555"));
+        given(mockChannel.getRemoteAddress()).willReturn(NetUtils.toAddress("127.0.0.1:20883"));
+
         DubboProtocol.getDubboProtocol().export(mockInvoker);
         String result = invoke.telnet(mockChannel, "echo(\"ok\")");
         assertTrue(result.contains("ok"));
-        EasyMock.reset(mockChannel, mockInvoker);
     }
 
     @Test
     public void testMessageNull() throws RemotingException {
-        mockChannel = EasyMock.createMock(Channel.class);
-        EasyMock.expect(mockChannel.getAttribute("telnet.service")).andReturn(null).anyTimes();
-        EasyMock.replay(mockChannel);
+        mockChannel = mock(Channel.class);
+        given(mockChannel.getAttribute("telnet.service")).willReturn(null);
+
         String result = invoke.telnet(mockChannel, null);
         assertEquals("Please input method name, eg: \r\ninvoke xxxMethod(1234, \"abcd\", {\"prop\" : \"value\"})\r\ninvoke XxxService.xxxMethod(1234, \"abcd\", {\"prop\" : \"value\"})\r\ninvoke com.xxx.XxxService.xxxMethod(1234, \"abcd\", {\"prop\" : \"value\"})",
                 result);
-        EasyMock.reset(mockChannel);
     }
 
     @Test
     public void testInvaildMessage() throws RemotingException {
-        mockChannel = EasyMock.createMock(Channel.class);
-        EasyMock.expect(mockChannel.getAttribute("telnet.service")).andReturn(null).anyTimes();
-        EasyMock.replay(mockChannel);
+        mockChannel = mock(Channel.class);
+        given(mockChannel.getAttribute("telnet.service")).willReturn(null);
+
         String result = invoke.telnet(mockChannel, "(");
         assertEquals("Invalid parameters, format: service.method(args)", result);
-        EasyMock.reset(mockChannel);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/com/alibaba/dubbo/rpc/protocol/dubbo/telnet/ListTelnetHandlerTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/com/alibaba/dubbo/rpc/protocol/dubbo/telnet/ListTelnetHandlerTest.java
@@ -29,7 +29,6 @@ import com.alibaba.dubbo.rpc.protocol.dubbo.DubboProtocol;
 import com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService;
 import com.alibaba.dubbo.rpc.protocol.dubbo.support.ProtocolUtils;
 
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -37,6 +36,9 @@ import org.junit.Test;
 import java.lang.reflect.Method;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * CountTelnetHandlerTest.java
@@ -78,92 +80,86 @@ public class ListTelnetHandlerTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testListDetailService() throws RemotingException {
-        mockInvoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(mockInvoker.getInterface()).andReturn(DemoService.class).anyTimes();
-        EasyMock.expect(mockInvoker.getUrl()).andReturn(URL.valueOf("dubbo://127.0.0.1:20885/demo")).anyTimes();
-        EasyMock.expect(mockInvoker.invoke((Invocation) EasyMock.anyObject())).andReturn(new RpcResult("ok")).anyTimes();
-        mockChannel = EasyMock.createMock(Channel.class);
-        EasyMock.expect(mockChannel.getAttribute("telnet.service")).andReturn("com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService").anyTimes();
-        EasyMock.replay(mockChannel, mockInvoker);
+        mockInvoker = mock(Invoker.class);
+        given(mockInvoker.getInterface()).willReturn(DemoService.class);
+        given(mockInvoker.getUrl()).willReturn(URL.valueOf("dubbo://127.0.0.1:20885/demo"));
+        given(mockInvoker.invoke(any(Invocation.class))).willReturn(new RpcResult("ok"));
+        mockChannel = mock(Channel.class);
+        given(mockChannel.getAttribute("telnet.service")).willReturn("com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService");
+
         DubboProtocol.getDubboProtocol().export(mockInvoker);
         String result = list.telnet(mockChannel, "-l DemoService");
         assertEquals(detailMethods, result);
-        EasyMock.reset(mockChannel, mockInvoker);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testListService() throws RemotingException {
-        mockInvoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(mockInvoker.getInterface()).andReturn(DemoService.class).anyTimes();
-        EasyMock.expect(mockInvoker.getUrl()).andReturn(URL.valueOf("dubbo://127.0.0.1:20885/demo")).anyTimes();
-        EasyMock.expect(mockInvoker.invoke((Invocation) EasyMock.anyObject())).andReturn(new RpcResult("ok")).anyTimes();
-        mockChannel = EasyMock.createMock(Channel.class);
-        EasyMock.expect(mockChannel.getAttribute("telnet.service")).andReturn("com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService").anyTimes();
-        EasyMock.replay(mockChannel, mockInvoker);
+        mockInvoker = mock(Invoker.class);
+        given(mockInvoker.getInterface()).willReturn(DemoService.class);
+        given(mockInvoker.getUrl()).willReturn(URL.valueOf("dubbo://127.0.0.1:20885/demo"));
+        given(mockInvoker.invoke(any(Invocation.class))).willReturn(new RpcResult("ok"));
+        mockChannel = mock(Channel.class);
+        given(mockChannel.getAttribute("telnet.service")).willReturn("com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService");
+
         DubboProtocol.getDubboProtocol().export(mockInvoker);
         String result = list.telnet(mockChannel, "DemoService");
         assertEquals(methodsName, result);
-        EasyMock.reset(mockChannel, mockInvoker);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testList() throws RemotingException {
-        mockInvoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(mockInvoker.getInterface()).andReturn(DemoService.class).anyTimes();
-        EasyMock.expect(mockInvoker.getUrl()).andReturn(URL.valueOf("dubbo://127.0.0.1:20885/demo")).anyTimes();
-        EasyMock.expect(mockInvoker.invoke((Invocation) EasyMock.anyObject())).andReturn(new RpcResult("ok")).anyTimes();
-        mockChannel = EasyMock.createMock(Channel.class);
-        EasyMock.expect(mockChannel.getAttribute("telnet.service")).andReturn(null).anyTimes();
-        EasyMock.replay(mockChannel, mockInvoker);
+        mockInvoker = mock(Invoker.class);
+        given(mockInvoker.getInterface()).willReturn(DemoService.class);
+        given(mockInvoker.getUrl()).willReturn(URL.valueOf("dubbo://127.0.0.1:20885/demo"));
+        given(mockInvoker.invoke(any(Invocation.class))).willReturn(new RpcResult("ok"));
+        mockChannel = mock(Channel.class);
+        given(mockChannel.getAttribute("telnet.service")).willReturn(null);
+
         DubboProtocol.getDubboProtocol().export(mockInvoker);
         String result = list.telnet(mockChannel, "");
         assertEquals("com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService", result);
-        EasyMock.reset(mockChannel);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testListDetail() throws RemotingException {
         int port = NetUtils.getAvailablePort();
-        mockInvoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(mockInvoker.getInterface()).andReturn(DemoService.class).anyTimes();
-        EasyMock.expect(mockInvoker.getUrl()).andReturn(URL.valueOf("dubbo://127.0.0.1:" + port + "/demo")).anyTimes();
-        EasyMock.expect(mockInvoker.invoke((Invocation) EasyMock.anyObject())).andReturn(new RpcResult("ok")).anyTimes();
-        mockChannel = EasyMock.createMock(Channel.class);
-        EasyMock.expect(mockChannel.getAttribute("telnet.service")).andReturn(null).anyTimes();
-        EasyMock.replay(mockChannel, mockInvoker);
+        mockInvoker = mock(Invoker.class);
+        given(mockInvoker.getInterface()).willReturn(DemoService.class);
+        given(mockInvoker.getUrl()).willReturn(URL.valueOf("dubbo://127.0.0.1:" + port + "/demo"));
+        given(mockInvoker.invoke(any(Invocation.class))).willReturn(new RpcResult("ok"));
+        mockChannel = mock(Channel.class);
+        given(mockChannel.getAttribute("telnet.service")).willReturn(null);
+
         DubboProtocol.getDubboProtocol().export(mockInvoker);
         String result = list.telnet(mockChannel, "-l");
         assertEquals("com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService -> dubbo://127.0.0.1:" + port + "/demo", result);
-        EasyMock.reset(mockChannel);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testListDefault() throws RemotingException {
-        mockInvoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(mockInvoker.getInterface()).andReturn(DemoService.class).anyTimes();
-        EasyMock.expect(mockInvoker.getUrl()).andReturn(URL.valueOf("dubbo://127.0.0.1:20885/demo")).anyTimes();
-        EasyMock.expect(mockInvoker.invoke((Invocation) EasyMock.anyObject())).andReturn(new RpcResult("ok")).anyTimes();
-        mockChannel = EasyMock.createMock(Channel.class);
-        EasyMock.expect(mockChannel.getAttribute("telnet.service")).andReturn("com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService").anyTimes();
-        EasyMock.replay(mockChannel, mockInvoker);
+        mockInvoker = mock(Invoker.class);
+        given(mockInvoker.getInterface()).willReturn(DemoService.class);
+        given(mockInvoker.getUrl()).willReturn(URL.valueOf("dubbo://127.0.0.1:20885/demo"));
+        given(mockInvoker.invoke(any(Invocation.class))).willReturn(new RpcResult("ok"));
+        mockChannel = mock(Channel.class);
+        given(mockChannel.getAttribute("telnet.service")).willReturn("com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService");
+
         DubboProtocol.getDubboProtocol().export(mockInvoker);
         String result = list.telnet(mockChannel, "");
         assertEquals("Use default service com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService.\r\n\r\n"
                 + methodsName, result);
-        EasyMock.reset(mockChannel);
     }
 
     @Test
     public void testInvaildMessage() throws RemotingException {
-        mockChannel = EasyMock.createMock(Channel.class);
-        EasyMock.expect(mockChannel.getAttribute("telnet.service")).andReturn(null).anyTimes();
-        EasyMock.replay(mockChannel);
+        mockChannel = mock(Channel.class);
+        given(mockChannel.getAttribute("telnet.service")).willReturn(null);
+
         String result = list.telnet(mockChannel, "xx");
         assertEquals("No such service xx", result);
-        EasyMock.reset(mockChannel);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/com/alibaba/dubbo/rpc/protocol/dubbo/telnet/LogTelnetHandlerTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/com/alibaba/dubbo/rpc/protocol/dubbo/telnet/LogTelnetHandlerTest.java
@@ -20,10 +20,10 @@ import com.alibaba.dubbo.remoting.Channel;
 import com.alibaba.dubbo.remoting.RemotingException;
 import com.alibaba.dubbo.remoting.telnet.TelnetHandler;
 
-import org.easymock.EasyMock;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * LogTelnetHandlerTest.java
@@ -35,22 +35,20 @@ public class LogTelnetHandlerTest {
 
     @Test
     public void testChangeLogLevel() throws RemotingException {
-        mockChannel = EasyMock.createMock(Channel.class);
-        EasyMock.replay(mockChannel);
+        mockChannel = mock(Channel.class);
+
         String result = log.telnet(mockChannel, "error");
         assertTrue(result.contains("\r\nCURRENT LOG LEVEL:ERROR"));
         String result2 = log.telnet(mockChannel, "warn");
         assertTrue(result2.contains("\r\nCURRENT LOG LEVEL:WARN"));
-        EasyMock.reset(mockChannel);
     }
 
     @Test
     public void testPrintLog() throws RemotingException {
-        mockChannel = EasyMock.createMock(Channel.class);
-        EasyMock.replay(mockChannel);
+        mockChannel = mock(Channel.class);
+
         String result = log.telnet(mockChannel, "100");
         assertTrue(result.contains("CURRENT LOG APPENDER"));
-        EasyMock.reset(mockChannel);
     }
 
 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/com/alibaba/dubbo/rpc/protocol/dubbo/telnet/PortTelnetHandlerTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/com/alibaba/dubbo/rpc/protocol/dubbo/telnet/PortTelnetHandlerTest.java
@@ -26,13 +26,14 @@ import com.alibaba.dubbo.rpc.protocol.dubbo.DubboProtocol;
 import com.alibaba.dubbo.rpc.protocol.dubbo.support.DemoService;
 import com.alibaba.dubbo.rpc.protocol.dubbo.support.ProtocolUtils;
 
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * PortTelnetHandlerTest.java
@@ -45,16 +46,15 @@ public class PortTelnetHandlerTest {
     @SuppressWarnings("unchecked")
     @Before
     public void before() {
-        mockInvoker = EasyMock.createMock(Invoker.class);
-        EasyMock.expect(mockInvoker.getInterface()).andReturn(DemoService.class).anyTimes();
-        EasyMock.expect(mockInvoker.getUrl()).andReturn(URL.valueOf("dubbo://127.0.0.1:20887/demo")).anyTimes();
-        EasyMock.replay(mockInvoker);
+        mockInvoker = mock(Invoker.class);
+        given(mockInvoker.getInterface()).willReturn(DemoService.class);
+        given(mockInvoker.getUrl()).willReturn(URL.valueOf("dubbo://127.0.0.1:20887/demo"));
+
         DubboProtocol.getDubboProtocol().export(mockInvoker);
     }
 
     @After
     public void after() {
-        EasyMock.reset(mockInvoker);
         ProtocolUtils.closeAll();
     }
 
@@ -75,7 +75,6 @@ public class PortTelnetHandlerTest {
         System.out.printf("Client 2 Address %s %n", client2Addr);
         assertTrue(result.contains(String.valueOf(client1.getLocalAddress().getPort())));
         assertTrue(result.contains(String.valueOf(client2.getLocalAddress().getPort())));
-
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -89,9 +89,8 @@
     <properties>
         <!-- Test libs -->
         <junit_version>4.12</junit_version>
-        <easymock_version>3.4</easymock_version>
-        <jmockit_version>1.33</jmockit_version>
         <cglib_version>2.2</cglib_version>
+        <mockito_version>2.18.3</mockito_version>
         <!-- Build args -->
         <argline>-server -Xms256m -Xmx512m -XX:PermSize=64m -XX:MaxPermSize=128m -Dfile.encoding=UTF-8
             -Djava.net.preferIPv4Stack=true
@@ -157,15 +156,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <version>${easymock_version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jmockit</groupId>
-            <artifactId>jmockit</artifactId>
-            <version>${jmockit_version}</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito_version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## What is the purpose of the change

use mockito to replace easymock

## Brief changelog

Remove dependency for easymock and jmockit
Add dependency for mockito
Migrate easymock test to mockito test base on mockito doc (https://github.com/mockito/mockito/wiki/Mockito-vs-EasyMock)

## Verifying this change

CI Pass (https://travis-ci.org/diamondblack/incubator-dubbo/builds/371112027)
