### PR TITLE
Add test coverage check for pull request and set threshold as 0.1%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,8 @@
+coverage:
+  status:
+    # pull-requests only
+    patch:
+      default:
+        threshold: 0.1%
 ignore:
   - "dubbo-demo/.*"


### PR DESCRIPTION
## What is the purpose of the change

Add test coverage check for pull request

## Brief changelog

+ modify codecov configuration for pull request only
+ set threshold as 0.1%
+ reviewed https://codecov.io/gh/apache/incubator-dubbo/pulls. for small change, the coverage change is round 0.01%--0.06%. As discussed in mail list, considering small change, I put threshold as 0.1%


## Verifying this change

Codecov config is valid.
![image](https://user-images.githubusercontent.com/659135/39284500-30d6fbba-4946-11e8-991a-d759b8235c4e.png)
