### PR TITLE
issue#1447: NettyHelper in netty extension populated Logger "InternalLogger" in netty.

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/logger/LoggerFactory.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/logger/LoggerFactory.java
@@ -119,6 +119,15 @@ public class LoggerFactory {
         return logger;
     }
 
+    public static Logger getLogger(String key, boolean appendContext) {
+        FailsafeLogger logger = LOGGERS.get(key);
+        if (logger == null) {
+            LOGGERS.putIfAbsent(key, new FailsafeLogger(LOGGER_ADAPTER.getLogger(key), appendContext));
+            logger = LOGGERS.get(key);
+        }
+        return logger;
+    }
+
     /**
      * Get logging level
      *

--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/logger/support/FailsafeLogger.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/logger/support/FailsafeLogger.java
@@ -23,9 +23,15 @@ import com.alibaba.dubbo.common.utils.NetUtils;
 public class FailsafeLogger implements Logger {
 
     private Logger logger;
+    private boolean append = true;
 
     public FailsafeLogger(Logger logger) {
         this.logger = logger;
+    }
+
+    public FailsafeLogger(Logger logger, boolean append) {
+        this.logger = logger;
+        this.append = append;
     }
 
     public Logger getLogger() {
@@ -37,7 +43,8 @@ public class FailsafeLogger implements Logger {
     }
 
     private String appendContextMessage(String msg) {
-        return " [DUBBO] " + msg + ", dubbo version: " + Version.getVersion() + ", current host: " + NetUtils.getLocalHost();
+        return append ? " [DUBBO] " + msg + ", dubbo version: " + Version.getVersion() + ", current host: " +
+                NetUtils.getLocalHost() : msg;
     }
 
     @Override

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/logging/NettyHelper.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/logging/NettyHelper.java
@@ -35,7 +35,7 @@ public class NettyHelper {
 
         @Override
         public InternalLogger newInstance(String name) {
-            return new DubboLogger(LoggerFactory.getLogger(name));
+            return new DubboLogger(LoggerFactory.getLogger(name, name.startsWith("com.alibaba.dubbo.")));
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

to fix issue reported by #1447: NettyHelper in netty extension populated Logger "InternalLogger" in netty.

## Brief changelog

don't log context info if it's not from dubbo code base

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).