### PR TITLE
[Dubbo-1687]Add unit tests for dubbo-filter-validation module

### DIFF
--- a/dubbo-filter/dubbo-filter-validation/pom.xml
+++ b/dubbo-filter/dubbo-filter-validation/pom.xml
@@ -39,5 +39,17 @@
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <scope>test</scope>
+            <version>${hibernate_validator_version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.el</groupId>
+            <artifactId>javax.el-api</artifactId>
+            <scope>test</scope>
+            <version>${el_api_version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-filter/dubbo-filter-validation/pom.xml
+++ b/dubbo-filter/dubbo-filter-validation/pom.xml
@@ -51,5 +51,23 @@
             <scope>test</scope>
             <version>${el_api_version}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <scope>test</scope>
+            <version>${jaxb_api_version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <scope>test</scope>
+            <version>${jaxb_api_version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <scope>test</scope>
+            <version>${jaxb_api_version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-filter/dubbo-filter-validation/src/test/java/com/alibaba/dubbo/validation/filter/ValidationFilterTest.java
+++ b/dubbo-filter/dubbo-filter-validation/src/test/java/com/alibaba/dubbo/validation/filter/ValidationFilterTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.validation.filter;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.rpc.*;
+import com.alibaba.dubbo.validation.Validation;
+import com.alibaba.dubbo.validation.Validator;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+public class ValidationFilterTest {
+    private Invoker<?> invoker = mock(Invoker.class);
+    private Validation validation = mock(Validation.class);
+    private Validator validator = mock(Validator.class);
+    private RpcInvocation invocation = mock(RpcInvocation.class);
+
+    private ValidationFilter validationFilter;
+
+    @Before
+    public void setUp() throws Exception {
+        this.validationFilter = new ValidationFilter();
+    }
+
+    @Test
+    public void testItWithNotExistClass() throws Exception {
+        URL url = URL.valueOf("test://test:11/test?default.validation=true");
+
+        given(validation.getValidator(url)).willThrow(new IllegalStateException("Not found class test, cause: test"));
+        given(invoker.invoke(invocation)).willReturn(new RpcResult("success"));
+        given(invoker.getUrl()).willReturn(url);
+        given(invocation.getMethodName()).willReturn("echo1");
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{String.class});
+        given(invocation.getArguments()).willReturn(new Object[]{"arg1"});
+
+        validationFilter.setValidation(validation);
+        Result result = validationFilter.invoke(invoker, invocation);
+
+        assertThat(result.getException().getMessage(), is("Not found class test, cause: test"));
+
+    }
+
+    @Test
+    public void testItWithExistClass() throws Exception {
+        URL url = URL.valueOf("test://test:11/test?default.validation=true");
+
+        given(validation.getValidator(url)).willReturn(validator);
+        given(invoker.invoke(invocation)).willReturn(new RpcResult("success"));
+        given(invoker.getUrl()).willReturn(url);
+        given(invocation.getMethodName()).willReturn("echo1");
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{String.class});
+        given(invocation.getArguments()).willReturn(new Object[]{"arg1"});
+
+        validationFilter.setValidation(validation);
+        Result result = validationFilter.invoke(invoker, invocation);
+
+        assertThat(String.valueOf(result.getValue()), is("success"));
+    }
+
+    @Test
+    public void testItWithoutUrlParameters() throws Exception {
+        URL url = URL.valueOf("test://test:11/test");
+
+        given(validation.getValidator(url)).willReturn(validator);
+        given(invoker.invoke(invocation)).willReturn(new RpcResult("success"));
+        given(invoker.getUrl()).willReturn(url);
+        given(invocation.getMethodName()).willReturn("echo1");
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{String.class});
+        given(invocation.getArguments()).willReturn(new Object[]{"arg1"});
+
+        validationFilter.setValidation(validation);
+        Result result = validationFilter.invoke(invoker, invocation);
+
+        assertThat(String.valueOf(result.getValue()), is("success"));
+    }
+
+    @Test
+    public void testItWhileMethodNameStartWithDollar() throws Exception {
+        URL url = URL.valueOf("test://test:11/test");
+
+        given(validation.getValidator(url)).willReturn(validator);
+        given(invoker.invoke(invocation)).willReturn(new RpcResult("success"));
+        given(invoker.getUrl()).willReturn(url);
+        given(invocation.getMethodName()).willReturn("$echo1");
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{String.class});
+        given(invocation.getArguments()).willReturn(new Object[]{"arg1"});
+
+        validationFilter.setValidation(validation);
+        Result result = validationFilter.invoke(invoker, invocation);
+
+        assertThat(String.valueOf(result.getValue()), is("success"));
+
+    }
+
+
+    @Test(expected = RpcException.class)
+    public void testItWhileThrowoutRpcException() throws Exception {
+        URL url = URL.valueOf("test://test:11/test?default.validation=true");
+
+        given(validation.getValidator(url)).willThrow(new RpcException("rpc exception"));
+        given(invoker.invoke(invocation)).willReturn(new RpcResult("success"));
+        given(invoker.getUrl()).willReturn(url);
+        given(invocation.getMethodName()).willReturn("echo1");
+        given(invocation.getParameterTypes()).willReturn(new Class<?>[]{String.class});
+        given(invocation.getArguments()).willReturn(new Object[]{"arg1"});
+
+        validationFilter.setValidation(validation);
+        validationFilter.invoke(invoker, invocation);
+    }
+}

--- a/dubbo-filter/dubbo-filter-validation/src/test/java/com/alibaba/dubbo/validation/support/jvalidation/JValidationTest.java
+++ b/dubbo-filter/dubbo-filter-validation/src/test/java/com/alibaba/dubbo/validation/support/jvalidation/JValidationTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.validation.support.jvalidation;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.validation.Validation;
+import com.alibaba.dubbo.validation.Validator;
+import org.junit.Test;
+
+import javax.validation.ValidationException;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class JValidationTest {
+    @Test(expected = ValidationException.class)
+    public void testReturnTypeWithInvalidValidationProvider() throws Exception {
+        Validation jValidation = new JValidation();
+        URL url = URL.valueOf("test://test:11/com.alibaba.dubbo.validation.support.jvalidation.JValidation?" +
+                "jvalidation=com.alibaba.dubbo.validation.Validation");
+        jValidation.getValidator(url);
+    }
+
+    @Test
+    public void testReturnTypeWithDefaultValidatorProvider() throws Exception {
+        Validation jValidation = new JValidation();
+        URL url = URL.valueOf("test://test:11/com.alibaba.dubbo.validation.support.jvalidation.JValidation");
+        Validator validator = jValidation.getValidator(url);
+        assertThat(validator instanceof JValidator, is(true));
+    }
+}

--- a/dubbo-filter/dubbo-filter-validation/src/test/java/com/alibaba/dubbo/validation/support/jvalidation/JValidatorTest.java
+++ b/dubbo-filter/dubbo-filter-validation/src/test/java/com/alibaba/dubbo/validation/support/jvalidation/JValidatorTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.validation.support.jvalidation;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.validation.support.jvalidation.mock.ValidationParameter;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolationException;
+
+public class JValidatorTest {
+    @Test(expected = NoSuchMethodException.class)
+    public void testItWithNonExistMethod() throws Exception {
+        URL url = URL.valueOf("test://test:11/com.alibaba.dubbo.validation.support.jvalidation.mock.JValidatorTestTarget");
+        JValidator jValidator = new JValidator(url);
+        jValidator.validate("nonExistingMethod", new Class<?>[]{String.class}, new Object[]{"arg1"});
+    }
+
+    @Test
+    public void testItWithExistMethod() throws Exception {
+        URL url = URL.valueOf("test://test:11/com.alibaba.dubbo.validation.support.jvalidation.mock.JValidatorTestTarget");
+        JValidator jValidator = new JValidator(url);
+        jValidator.validate("someMethod1", new Class<?>[]{String.class}, new Object[]{"anything"});
+    }
+
+    @Test(expected = ConstraintViolationException.class)
+    public void testItWhenItViolatedConstraint() throws Exception {
+        URL url = URL.valueOf("test://test:11/com.alibaba.dubbo.validation.support.jvalidation.mock.JValidatorTestTarget");
+        JValidator jValidator = new JValidator(url);
+        jValidator.validate("someMethod2", new Class<?>[]{ValidationParameter.class}, new Object[]{new ValidationParameter()});
+    }
+
+    @Test
+    public void testItWhenItMeetsConstraint() throws Exception {
+        URL url = URL.valueOf("test://test:11/com.alibaba.dubbo.validation.support.jvalidation.mock.JValidatorTestTarget");
+        JValidator jValidator = new JValidator(url);
+        jValidator.validate("someMethod2", new Class<?>[]{ValidationParameter.class}, new Object[]{new ValidationParameter("NotBeNull")});
+    }
+}

--- a/dubbo-filter/dubbo-filter-validation/src/test/java/com/alibaba/dubbo/validation/support/jvalidation/mock/JValidatorTestTarget.java
+++ b/dubbo-filter/dubbo-filter-validation/src/test/java/com/alibaba/dubbo/validation/support/jvalidation/mock/JValidatorTestTarget.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.validation.support.jvalidation.mock;
+
+import com.alibaba.dubbo.validation.MethodValidated;
+
+import javax.validation.constraints.NotNull;
+
+public interface JValidatorTestTarget {
+    @MethodValidated
+    public void someMethod1(String anything);
+
+    @MethodValidated(Test2.class)
+    public void someMethod2(@NotNull ValidationParameter validationParameter);
+
+    @interface Test2 {
+    }
+
+}

--- a/dubbo-filter/dubbo-filter-validation/src/test/java/com/alibaba/dubbo/validation/support/jvalidation/mock/ValidationParameter.java
+++ b/dubbo-filter/dubbo-filter-validation/src/test/java/com/alibaba/dubbo/validation/support/jvalidation/mock/ValidationParameter.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.validation.support.jvalidation.mock;
+
+import javax.validation.constraints.NotNull;
+
+public class ValidationParameter {
+    @NotNull
+    private String parameter;
+
+    public ValidationParameter() {
+    }
+
+    public ValidationParameter(String parameter) {
+        this.parameter = parameter;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,8 @@
         <junit_version>4.12</junit_version>
         <hazelcast_version>3.9-EA</hazelcast_version>
         <hamcrest_version>1.3</hamcrest_version>
+        <hibernate_validator_version>5.2.4.Final</hibernate_validator_version>
+        <el_api_version>2.2.4</el_api_version>
         <cglib_version>2.2</cglib_version>
         <mockito_version>2.18.3</mockito_version>
         <!-- Build args -->

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <hamcrest_version>1.3</hamcrest_version>
         <hibernate_validator_version>5.2.4.Final</hibernate_validator_version>
         <el_api_version>2.2.4</el_api_version>
+        <jaxb_api_version>2.2.7</jaxb_api_version>
         <cglib_version>2.2</cglib_version>
         <mockito_version>2.18.3</mockito_version>
         <!-- Build args -->


### PR DESCRIPTION
## What is the purpose of the change

Add unit tests for dubbo-filter-validation module, in order to increase the overall test coverage.

more details, please refer to #1687
