### PR TITLE
[Dubbo-1254] Upgrade tomcat version to 8.5.31 #1254

### DIFF
--- a/dependencies-bom/pom.xml
+++ b/dependencies-bom/pom.xml
@@ -99,7 +99,7 @@
 
         <rs_api_version>2.0</rs_api_version>
         <resteasy_version>3.0.19.Final</resteasy_version>
-        <tomcat_embed_version>8.0.11</tomcat_embed_version>
+        <tomcat_embed_version>8.5.31</tomcat_embed_version>
         <!-- Log libs -->
         <slf4j_version>1.7.25</slf4j_version>
         <jcl_version>1.2</jcl_version>

--- a/dubbo-remoting/dubbo-remoting-http/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-http/pom.xml
@@ -50,10 +50,6 @@
             <artifactId>tomcat-embed-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-logging-juli</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
             <version>4.5.5</version>


### PR DESCRIPTION
## What is the purpose of the change

Upgrade tomcat version to 8.5.31, which fix #1254 

## Brief changelog

* Upgrade tomcat version to 8.5.31
* Remove dependency to tomcat-embed-logging-juli since it is no longer needed.

## Verifying this change

Unit test passed.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
