### PR TITLE
[Dubbo-199] Remove duplicate call to setProvider/setConsumer. #199

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/AnnotationBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/AnnotationBean.java
@@ -174,9 +174,6 @@ public class AnnotationBean extends AbstractConfig implements DisposableBean, Be
                 if (service.module().length() > 0) {
                     serviceConfig.setModule(applicationContext.getBean(service.module(), ModuleConfig.class));
                 }
-                if (service.provider().length() > 0) {
-                    serviceConfig.setProvider(applicationContext.getBean(service.provider(), ProviderConfig.class));
-                }
                 if (service.protocol().length > 0) {
                     List<ProtocolConfig> protocolConfigs = new ArrayList<ProtocolConfig>();
                     for (String protocolId : service.protocol()) {
@@ -288,9 +285,6 @@ public class AnnotationBean extends AbstractConfig implements DisposableBean, Be
                 }
                 if (reference.module().length() > 0) {
                     referenceConfig.setModule(applicationContext.getBean(reference.module(), ModuleConfig.class));
-                }
-                if (reference.consumer().length() > 0) {
-                    referenceConfig.setConsumer(applicationContext.getBean(reference.consumer(), ConsumerConfig.class));
                 }
                 try {
                     referenceConfig.afterPropertiesSet();


### PR DESCRIPTION
## What is the purpose of the change

Fix #199. Remove duplicate call to setProvider/setConsumer.

## Brief changelog

Remove duplicate call to setProvider/setConsumer.

## Verifying this change

Remove duplicate call to setProvider/setConsumer.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
