### PR TITLE
optimize_zk_create

### DIFF
--- a/dubbo-remoting/dubbo-remoting-zookeeper/src/main/java/com/alibaba/dubbo/remoting/zookeeper/support/AbstractZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/src/main/java/com/alibaba/dubbo/remoting/zookeeper/support/AbstractZookeeperClient.java
@@ -52,12 +52,14 @@ public abstract class AbstractZookeeperClient<TargetChildListener> implements Zo
 
     @Override
     public void create(String path, boolean ephemeral) {
+        if (!ephemeral) {
+            if (checkExists(path)) {
+                return;
+            }
+        }
         int i = path.lastIndexOf('/');
         if (i > 0) {
-            String parentPath = path.substring(0, i);
-            if (!checkExists(parentPath)) {
-                create(parentPath, false);
-            }
+            create(path.substring(0, i), false);
         }
         if (ephemeral) {
             createEphemeral(path);


### PR DESCRIPTION
## What is the purpose of the change

optimize zk create method.

if we create path /dubbo/XxxService/providers/dubbo....
we should check it's parent path exist or not first.

but when we create path  /dubbo/XxxService/providers
we should check the path exist or not first.

doSubscribe method invoke this every time.

Can reduce the number,  access to zk.

## Brief changelog

AbstractZookeeperClient create.

## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
