### PR TITLE
Update the method to fetch dubbo version from dubboVersion.properties filled by pom.xml

### DIFF
--- a/dubbo-common/pom.xml
+++ b/dubbo-common/pom.xml
@@ -70,4 +70,12 @@
             <artifactId>fst</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources/</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
 </project>

--- a/dubbo-common/src/main/resources/dubboVersion.properties
+++ b/dubbo-common/src/main/resources/dubboVersion.properties
@@ -1,0 +1,1 @@
+dubbo.version=${project.version}

--- a/dubbo-common/src/test/java/com/alibaba/dubbo/common/VersionTest.java
+++ b/dubbo-common/src/test/java/com/alibaba/dubbo/common/VersionTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class VersionTest {
 
     public static final String DEFAULT_VERSION = "2.0.0";
-
+    
     @Test
     public void testGetVersion() {
         String version = Version.getVersion();

--- a/dubbo-common/src/test/java/com/alibaba/dubbo/common/VersionTest.java
+++ b/dubbo-common/src/test/java/com/alibaba/dubbo/common/VersionTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * version test
+ */
+public class VersionTest {
+
+    public static final String DEFAULT_VERSION = "2.0.0";
+
+    @Test
+    public void testGetVersion() {
+        String version = Version.getVersion();
+        Assert.assertNotNull(version);
+        Assert.assertNotEquals(version, DEFAULT_VERSION);
+    }
+
+    @Test
+    public void testGetClassVersion() {
+        String version = Version.getVersion(this.getClass(), DEFAULT_VERSION);
+        Assert.assertNotNull(version);
+        Assert.assertNotEquals(version, DEFAULT_VERSION);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

#1466 https://github.com/apache/incubator-dubbo/issues/1524  get dubbo version from dubboVersion.properties filled by pom.xml

## Brief changelog

dubbo-common/src/main/java/com/alibaba/dubbo/common/Version.java  is modified

## Verifying this change
CI pass（unit test pass）
