### PR TITLE
[Dubbo-SPI] Spring spi support inject by type

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/extension/SpringExtensionFactory.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/extension/SpringExtensionFactory.java
@@ -43,6 +43,11 @@ public class SpringExtensionFactory implements ExtensionFactory {
         contexts.remove(context);
     }
 
+    // currently for test purpose
+    public static void clearContexts() {
+        contexts.clear();
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getExtension(Class<T> type, String name) {

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/extension/SpringExtensionFactory.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/extension/SpringExtensionFactory.java
@@ -17,7 +17,11 @@
 package com.alibaba.dubbo.config.spring.extension;
 
 import com.alibaba.dubbo.common.extension.ExtensionFactory;
+import com.alibaba.dubbo.common.logger.Logger;
+import com.alibaba.dubbo.common.logger.LoggerFactory;
 import com.alibaba.dubbo.common.utils.ConcurrentHashSet;
+
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 
 import java.util.Set;
@@ -26,6 +30,7 @@ import java.util.Set;
  * SpringExtensionFactory
  */
 public class SpringExtensionFactory implements ExtensionFactory {
+    private static final Logger logger = LoggerFactory.getLogger(SpringExtensionFactory.class);
 
     private static final Set<ApplicationContext> contexts = new ConcurrentHashSet<ApplicationContext>();
 
@@ -47,7 +52,19 @@ public class SpringExtensionFactory implements ExtensionFactory {
                     return (T) bean;
                 }
             }
+            try {
+                return context.getBean(type);
+            } catch (NoSuchBeanDefinitionException noBeanExe) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Error when get spring extension(bean) for type:" + type.getName(), noBeanExe);
+                }
+            }
         }
+
+        if (logger.isInfoEnabled()) {
+            logger.info("No spring extension(bean) named:" + name + ", type:" + type.getName() + " found, stop get bean.");
+        }
+
         return null;
     }
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/extension/SpringExtensionFactory.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/extension/SpringExtensionFactory.java
@@ -22,6 +22,7 @@ import com.alibaba.dubbo.common.logger.LoggerFactory;
 import com.alibaba.dubbo.common.utils.ConcurrentHashSet;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 
 import java.util.Set;
@@ -52,8 +53,15 @@ public class SpringExtensionFactory implements ExtensionFactory {
                     return (T) bean;
                 }
             }
+        }
+
+        logger.warn("No spring extension(bean) named:" + name + ", try to find an extension(bean) of type " + type.getName());
+
+        for (ApplicationContext context : contexts) {
             try {
                 return context.getBean(type);
+            } catch (NoUniqueBeanDefinitionException multiBeanExe) {
+                throw multiBeanExe;
             } catch (NoSuchBeanDefinitionException noBeanExe) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Error when get spring extension(bean) for type:" + type.getName(), noBeanExe);
@@ -61,9 +69,7 @@ public class SpringExtensionFactory implements ExtensionFactory {
             }
         }
 
-        if (logger.isInfoEnabled()) {
-            logger.info("No spring extension(bean) named:" + name + ", type:" + type.getName() + " found, stop get bean.");
-        }
+        logger.warn("No spring extension(bean) named:" + name + ", type:" + type.getName() + " found, stop get bean.");
 
         return null;
     }

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/extension/BeanForContext2.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/extension/BeanForContext2.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.config.spring.extension;
+
+import com.alibaba.dubbo.config.spring.api.DemoService;
+import com.alibaba.dubbo.config.spring.impl.DemoServiceImpl;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BeanForContext2 {
+    @Bean("bean1")
+    public DemoService context2Bean() {
+        return new DemoServiceImpl();
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/extension/SpringExtensionFactoryTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/extension/SpringExtensionFactoryTest.java
@@ -60,6 +60,7 @@ public class SpringExtensionFactoryTest {
         try {
             springExtensionFactory.getExtension(DemoService.class, "beanname-not-exist");
         } catch (Exception e) {
+            e.printStackTrace();
             Assert.assertTrue(e instanceof NoUniqueBeanDefinitionException);
         }
     }

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/extension/SpringExtensionFactoryTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/extension/SpringExtensionFactoryTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.config.spring.extension;
+
+import com.alibaba.dubbo.config.spring.api.DemoService;
+import com.alibaba.dubbo.config.spring.api.HelloService;
+import com.alibaba.dubbo.config.spring.impl.DemoServiceImpl;
+import com.alibaba.dubbo.config.spring.impl.HelloServiceImpl;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SpringExtensionFactoryTest {
+
+    private SpringExtensionFactory springExtensionFactory = new SpringExtensionFactory();
+    private AnnotationConfigApplicationContext context1;
+    private AnnotationConfigApplicationContext context2;
+
+    @Before
+    public void init() {
+        context1 = new AnnotationConfigApplicationContext();
+        context1.register(getClass());
+        context1.refresh();
+        context2 = new AnnotationConfigApplicationContext();
+        context2.register(BeanForContext2.class);
+        context2.refresh();
+        SpringExtensionFactory.addApplicationContext(context1);
+        SpringExtensionFactory.addApplicationContext(context2);
+    }
+
+    @Test
+    public void testGetExtensionByName() {
+        DemoService bean = springExtensionFactory.getExtension(DemoService.class, "bean1");
+        Assert.assertNotNull(bean);
+    }
+
+    @Test
+    public void testGetExtensionByTypeMultiple() {
+        try {
+            springExtensionFactory.getExtension(DemoService.class, "beanname-not-exist");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof NoUniqueBeanDefinitionException);
+        }
+    }
+
+    @Test
+    public void testGetExtensionByType() {
+        HelloService bean = springExtensionFactory.getExtension(HelloService.class, "beanname-not-exist");
+        Assert.assertNotNull(bean);
+    }
+
+    @After
+    public void destroy() {
+        SpringExtensionFactory.removeApplicationContext(context1);
+        SpringExtensionFactory.removeApplicationContext(context2);
+        context1.close();
+        context2.close();
+    }
+
+    @Bean("bean1")
+    public DemoService bean1() {
+        return new DemoServiceImpl();
+    }
+
+    @Bean("bean2")
+    public DemoService bean2() {
+        return new DemoServiceImpl();
+    }
+
+    @Bean("hello")
+    public HelloService helloService() {
+        return new HelloServiceImpl();
+    }
+}

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/extension/SpringExtensionFactoryTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/extension/SpringExtensionFactoryTest.java
@@ -73,8 +73,7 @@ public class SpringExtensionFactoryTest {
 
     @After
     public void destroy() {
-        SpringExtensionFactory.removeApplicationContext(context1);
-        SpringExtensionFactory.removeApplicationContext(context2);
+        SpringExtensionFactory.clearContexts();
         context1.close();
         context2.close();
     }


### PR DESCRIPTION
## What is the purpose of the change
also see #1456 .
Spring spi support inject by type. Not necessary to support spring 2.5 or lower.

## Brief changelog

SpringExtensionFactory:
1. getBean by name
2. getBean by type

## Verifying this change

SpringExtensionFactoryTest

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
