### PR TITLE
improve InvokerInvocationHandler branch prediction optimization and a…

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/proxy/InvokerInvocationHandler.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/proxy/InvokerInvocationHandler.java
@@ -35,20 +35,23 @@ public class InvokerInvocationHandler implements InvocationHandler {
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-        String methodName = method.getName();
-        Class<?>[] parameterTypes = method.getParameterTypes();
         if (method.getDeclaringClass() == Object.class) {
             return method.invoke(invoker, args);
         }
-        if ("toString".equals(methodName) && parameterTypes.length == 0) {
-            return invoker.toString();
-        }
-        if ("hashCode".equals(methodName) && parameterTypes.length == 0) {
-            return invoker.hashCode();
-        }
-        if ("equals".equals(methodName) && parameterTypes.length == 1) {
+        String methodName = method.getName();
+        int parameterCount = method.getParameterCount();
+        if (parameterCount > 1) {
+            return invoker.invoke(new RpcInvocation(method, args)).recreate();
+        } else if (parameterCount == 1 && "equals".equals(methodName)) {
             return invoker.equals(args[0]);
+        } else if (parameterCount == 0) {
+            if ("toString".equals(methodName)) {
+                return invoker.toString();
+            } else if ("hashCode".equals(methodName)) {
+                return invoker.hashCode();
+            }
         }
+
         return invoker.invoke(new RpcInvocation(method, args)).recreate();
     }
 


### PR DESCRIPTION
improve InvokerInvocationHandler branch prediction optimization and avoid method parameterTypes clone.

## What is the purpose of the change

* improve InvokerInvocationHandler branch prediction optimization
* avoid call `java.lang.reflect.Method#getParameterTypes()`, which will clone parameterTypes.

## Brief changelog



## Verifying this change



Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
