### PR TITLE
[Dubbo-1697] add test for dubbo-rpc-redis & dubbo-rpc-rest

### DIFF
--- a/dubbo-rpc/dubbo-rpc-memcached/src/test/java/com/alibaba/dubbo/rpc/protocol/memcached/MemcachedProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-memcached/src/test/java/com/alibaba/dubbo/rpc/protocol/memcached/MemcachedProtocolTest.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.rpc.protocol.memcached;
+
+public class MemcachedProtocolTest {
+
+}

--- a/dubbo-rpc/dubbo-rpc-redis/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-redis/pom.xml
@@ -39,5 +39,16 @@
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.kstyrc</groupId>
+            <artifactId>embedded-redis</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-serialization-jdk</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-rpc/dubbo-rpc-redis/src/test/java/com/alibaba/dubbo/rpc/protocol/redis/IDemoService.java
+++ b/dubbo-rpc/dubbo-rpc-redis/src/test/java/com/alibaba/dubbo/rpc/protocol/redis/IDemoService.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.rpc.protocol.redis;
+
+public interface IDemoService {
+    void set(String key, String value);
+
+    String get(String key);
+
+    void delete(String key);
+
+    String unsupported(String wrong);
+
+    String set(String key, String value, String extraArg);
+}

--- a/dubbo-rpc/dubbo-rpc-redis/src/test/java/com/alibaba/dubbo/rpc/protocol/redis/RedisProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-redis/src/test/java/com/alibaba/dubbo/rpc/protocol/redis/RedisProtocolTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.rpc.protocol.redis;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.common.extension.ExtensionLoader;
+import com.alibaba.dubbo.common.utils.NetUtils;
+import com.alibaba.dubbo.rpc.Invoker;
+import com.alibaba.dubbo.rpc.Protocol;
+import com.alibaba.dubbo.rpc.ProxyFactory;
+import com.alibaba.dubbo.rpc.RpcException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import redis.embedded.RedisServer;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class RedisProtocolTest {
+    private Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
+    private ProxyFactory proxy = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
+    private RedisServer redisServer;
+    private URL registryUrl;
+
+    @Before
+    public void setUp() throws Exception {
+        int redisPort = NetUtils.getAvailablePort();
+        this.redisServer = new RedisServer(redisPort);
+        this.redisServer.start();
+        this.registryUrl = URL.valueOf("redis://localhost:" + redisPort);
+    }
+
+    @After
+    public void tearDown() {
+        this.redisServer.stop();
+    }
+
+    @Test
+    public void testReferClass() {
+        Invoker<IDemoService> refer = protocol.refer(IDemoService.class, registryUrl);
+
+        Class<IDemoService> serviceClass = refer.getInterface();
+        assertThat(serviceClass.getName(), is("com.alibaba.dubbo.rpc.protocol.redis.IDemoService"));
+    }
+
+    @Test
+    public void testInvocation() {
+        Invoker<IDemoService> refer = protocol.refer(IDemoService.class,
+                registryUrl
+                        .addParameter("max.idle", 10)
+                        .addParameter("max.active", 20));
+        IDemoService demoService = this.proxy.getProxy(refer);
+
+        String value = demoService.get("key");
+        assertThat(value, is(nullValue()));
+
+        demoService.set("key", "newValue");
+        value = demoService.get("key");
+        assertThat(value, is("newValue"));
+
+        demoService.delete("key");
+        value = demoService.get("key");
+        assertThat(value, is(nullValue()));
+
+        refer.destroy();
+    }
+
+    @Test(expected = RpcException.class)
+    public void testUnsupportedMethod() {
+        Invoker<IDemoService> refer = protocol.refer(IDemoService.class, registryUrl);
+        IDemoService demoService = this.proxy.getProxy(refer);
+
+        demoService.unsupported(null);
+    }
+
+    @Test(expected = RpcException.class)
+    public void testWrongParameters() {
+        Invoker<IDemoService> refer = protocol.refer(IDemoService.class, registryUrl);
+        IDemoService demoService = this.proxy.getProxy(refer);
+
+        demoService.set("key", "value", "wrongValue");
+    }
+
+    @Test(expected = RpcException.class)
+    public void testWrongRedis() {
+        Invoker<IDemoService> refer = protocol.refer(IDemoService.class, URL.valueOf("redis://localhost:1"));
+        IDemoService demoService = this.proxy.getProxy(refer);
+
+        demoService.get("key");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testExport() {
+        protocol.export(protocol.refer(IDemoService.class, registryUrl));
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-redis/src/test/resources/META-INF/dubbo/internal/com.alibaba.dubbo.common.serialize.Serialization
+++ b/dubbo-rpc/dubbo-rpc-redis/src/test/resources/META-INF/dubbo/internal/com.alibaba.dubbo.common.serialize.Serialization
@@ -1,0 +1,1 @@
+java=com.alibaba.dubbo.common.serialize.java.JavaSerialization

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/com/alibaba/dubbo/rpc/protocol/rest/DemoService.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/com/alibaba/dubbo/rpc/protocol/rest/DemoService.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.rpc.protocol.rest;
+
+
+public class DemoService implements IDemoService {
+    @Override
+    public Integer hello(Integer a, Integer b) {
+        return a + b;
+    }
+
+    @Override
+    public String error() {
+        throw new RuntimeException();
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/com/alibaba/dubbo/rpc/protocol/rest/IDemoService.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/com/alibaba/dubbo/rpc/protocol/rest/IDemoService.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.rpc.protocol.rest;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+@Path("/demoService")
+public interface IDemoService {
+    @GET
+    @Path("/hello")
+    Integer hello(@QueryParam("a") Integer a, @QueryParam("b") Integer b);
+
+    @GET
+    @Path("/error")
+    String error();
+}

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/com/alibaba/dubbo/rpc/protocol/rest/RestProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/com/alibaba/dubbo/rpc/protocol/rest/RestProtocolTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.rpc.protocol.rest;
+
+import com.alibaba.dubbo.common.Constants;
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.common.extension.ExtensionLoader;
+import com.alibaba.dubbo.common.utils.NetUtils;
+import com.alibaba.dubbo.rpc.Exporter;
+import com.alibaba.dubbo.rpc.Protocol;
+import com.alibaba.dubbo.rpc.ProxyFactory;
+import com.alibaba.dubbo.rpc.Result;
+import com.alibaba.dubbo.rpc.RpcContext;
+import com.alibaba.dubbo.rpc.RpcException;
+import com.alibaba.dubbo.rpc.RpcInvocation;
+import com.alibaba.dubbo.rpc.ServiceClassHolder;
+import org.hamcrest.CoreMatchers;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class RestProtocolTest {
+    private Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getExtension("rest");
+    private ProxyFactory proxy = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
+    private final int availablePort = NetUtils.getAvailablePort();
+    private final URL exportUrl = URL.valueOf("rest://127.0.0.1:" + availablePort + "/rest");
+
+    @After
+    public void tearDown() {
+        protocol.destroy();
+    }
+
+    @Test
+    public void testExport() {
+        ServiceClassHolder.getInstance().pushServiceClass(DemoService.class);
+
+
+        RpcContext.getContext().setAttachment("timeout", "200");
+        Exporter<IDemoService> exporter = protocol.export(proxy.getInvoker(new DemoService(), IDemoService.class, exportUrl));
+
+        IDemoService demoService = this.proxy.getProxy(protocol.refer(IDemoService.class, exportUrl));
+
+        Integer echoString = demoService.hello(1, 2);
+        assertThat(echoString, is(3));
+
+        exporter.unexport();
+    }
+
+    @Test
+    public void testNettyServer() {
+        ServiceClassHolder.getInstance().pushServiceClass(DemoService.class);
+
+        URL nettyUrl = exportUrl.addParameter(Constants.SERVER_KEY, "netty");
+        Exporter<IDemoService> exporter = protocol.export(proxy.getInvoker(new DemoService(), IDemoService.class, nettyUrl));
+
+        IDemoService demoService = this.proxy.getProxy(protocol.refer(IDemoService.class, nettyUrl));
+
+        Integer echoString = demoService.hello(10, 10);
+        assertThat(echoString, is(20));
+
+        exporter.unexport();
+    }
+
+    @Test(expected = RpcException.class)
+    public void testServletWithoutWebConfig() {
+        ServiceClassHolder.getInstance().pushServiceClass(DemoService.class);
+
+        URL servletUrl = exportUrl.addParameter(Constants.SERVER_KEY, "servlet");
+
+        protocol.export(proxy.getInvoker(new DemoService(), IDemoService.class, servletUrl));
+    }
+
+    @Test(expected = RpcException.class)
+    public void testErrorHandler() {
+        ServiceClassHolder.getInstance().pushServiceClass(DemoService.class);
+
+        URL nettyUrl = exportUrl.addParameter(Constants.SERVER_KEY, "netty");
+        Exporter<IDemoService> exporter = protocol.export(proxy.getInvoker(new DemoService(), IDemoService.class, nettyUrl));
+
+        IDemoService demoService = this.proxy.getProxy(protocol.refer(IDemoService.class, nettyUrl));
+
+        demoService.error();
+    }
+
+    @Test
+    public void testInvoke() {
+        ServiceClassHolder.getInstance().pushServiceClass(DemoService.class);
+
+
+        Exporter<IDemoService> exporter = protocol.export(proxy.getInvoker(new DemoService(), IDemoService.class, exportUrl));
+
+        RpcInvocation rpcInvocation = new RpcInvocation("hello", new Class[]{Integer.class, Integer.class}, new Integer[]{2, 3});
+
+        Result result = exporter.getInvoker().invoke(rpcInvocation);
+        assertThat(result.getValue(), CoreMatchers.<Object>is(5));
+    }
+
+    @Test
+    public void testFilter() {
+        ServiceClassHolder.getInstance().pushServiceClass(DemoService.class);
+
+        URL nettyUrl = exportUrl.addParameter(Constants.SERVER_KEY, "netty")
+                .addParameter(Constants.EXTENSION_KEY, "com.alibaba.dubbo.rpc.protocol.rest.support.LoggingFilter");
+        Exporter<IDemoService> exporter = protocol.export(proxy.getInvoker(new DemoService(), IDemoService.class, nettyUrl));
+
+        IDemoService demoService = this.proxy.getProxy(protocol.refer(IDemoService.class, nettyUrl));
+
+        Integer result = demoService.hello(1, 2);
+
+        assertThat(result, is(3));
+
+        exporter.unexport();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testRegFail() {
+        ServiceClassHolder.getInstance().pushServiceClass(DemoService.class);
+
+        URL nettyUrl = exportUrl.addParameter(Constants.EXTENSION_KEY, "com.not.existing.Filter");
+        protocol.export(proxy.getInvoker(new DemoService(), IDemoService.class, nettyUrl));
+    }
+
+    @Test
+    public void testDefaultPort() {
+        assertThat(protocol.getDefaultPort(), is(80));
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/com/alibaba/dubbo/rpc/protocol/rest/RpcExceptionMapperTest.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/com/alibaba/dubbo/rpc/protocol/rest/RpcExceptionMapperTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.dubbo.rpc.protocol.rest;
+
+import com.alibaba.dubbo.rpc.RpcException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.internal.util.collections.Sets;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.core.Response;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+public class RpcExceptionMapperTest {
+
+    private RpcExceptionMapper exceptionMapper;
+
+    @Before
+    public void setUp() {
+        this.exceptionMapper = new RpcExceptionMapper();
+    }
+
+    @Test
+    public void testConstraintViolationException() {
+        ConstraintViolationException violationException = mock(ConstraintViolationException.class);
+        ConstraintViolation violation = mock(ConstraintViolation.class, Answers.RETURNS_DEEP_STUBS);
+        given(violationException.getConstraintViolations()).willReturn(Sets.<ConstraintViolation<?>>newSet(violation));
+        RpcException rpcException = new RpcException("violation", violationException);
+
+        Response response = exceptionMapper.toResponse(rpcException);
+
+        assertThat(response, not(nullValue()));
+        assertThat(response.getEntity(), instanceOf(ViolationReport.class));
+    }
+
+    @Test
+    public void testNormalException() {
+        RpcException rpcException = new RpcException();
+        Response response = exceptionMapper.toResponse(rpcException);
+
+
+        assertThat(response, not(nullValue()));
+        assertThat(response.getEntity(), instanceOf(String.class));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

add test for dubbo-rpc-redis & dubbo-rpc-rest

## Brief changelog

For #1697 
there is one module dubbo-rpc-memcached still in progress, I'm trying to find a solution to mock memcached.

## Verifying this change

CI Pass

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
