### PR TITLE
support placeholders in properties.

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/util/PropertySourcesUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/util/PropertySourcesUtils.java
@@ -19,6 +19,7 @@ package com.alibaba.dubbo.config.spring.util;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.PropertySources;
+import org.springframework.core.env.PropertySourcesPropertyResolver;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -46,13 +47,15 @@ public abstract class PropertySourcesUtils {
 
         String normalizedPrefix = normalizePrefix(prefix);
 
+        PropertySourcesPropertyResolver propertyResolver = new PropertySourcesPropertyResolver((PropertySources) propertySources);
+
         for (PropertySource<?> source : propertySources) {
             if (source instanceof EnumerablePropertySource) {
                 for (String name : ((EnumerablePropertySource<?>) source).getPropertyNames()) {
                     if (name.startsWith(normalizedPrefix)) {
                         String subName = name.substring(normalizedPrefix.length());
-                        Object value = source.getProperty(name);
-                        subProperties.put(subName, String.valueOf(value));
+                        String value = propertyResolver.getProperty(name);
+                        subProperties.put(subName, value);
                     }
                 }
             }

--- a/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/util/PropertySourcesUtilsTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/com/alibaba/dubbo/config/spring/util/PropertySourcesUtilsTest.java
@@ -69,6 +69,15 @@ public class PropertySourcesUtilsTest {
 
         Assert.assertEquals(Collections.emptyMap(), result);
 
+        source.put(KEY_PREFIX + ".app.name", "${info.name}");
+        source.put("info.name", "Hello app");
+
+        result = PropertySourcesUtils.getSubProperties(propertySources, KEY_PREFIX);
+
+        String appName = result.get("app.name");
+
+        Assert.assertEquals("Hello app", appName);
+
     }
 
 }


### PR DESCRIPTION
## What is the purpose of the change
In the case of spring boot.

https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config-placeholders-in-properties

```properties
app.name=MyApp
app.description=${app.name} is a Spring Boot application

## this configuration  is failure
dubbo.application.name=${app.name}
```

```java
Caused by: java.lang.IllegalStateException: ApplicationConfig.application == null
	at com.alibaba.dubbo.config.AbstractConfig.appendParameters(AbstractConfig.java:245)
	at com.alibaba.dubbo.config.AbstractConfig.appendParameters(AbstractConfig.java:180)
	at com.alibaba.dubbo.config.ReferenceConfig.init(ReferenceConfig.java:303)
	at com.alibaba.dubbo.config.ReferenceConfig.get(ReferenceConfig.java:163)
	at com.alibaba.dubbo.config.spring.beans.factory.annotation.ReferenceAnnotationBeanPostProcessor.buildReferenceBean(ReferenceAnnotationBeanPostProcessor.java:352)
	at com.alibaba.dubbo.config.spring.beans.factory.annotation.ReferenceAnnotationBeanPostProcessor.access$100(ReferenceAnnotationBeanPostProcessor.java:61)
	at com.alibaba.dubbo.config.spring.beans.factory.annotation.ReferenceAnnotationBeanPostProcessor$ReferenceFieldElement.inject(ReferenceAnnotationBeanPostProcessor.java:323)
	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:88)
	at com.alibaba.dubbo.config.spring.beans.factory.annotation.ReferenceAnnotationBeanPostProcessor.postProcessPropertyValues(ReferenceAnnotationBeanPostProcessor.java:88)
	... 26 more
Caused by: java.lang.IllegalStateException: ApplicationConfig.application == null
	at com.alibaba.dubbo.config.AbstractConfig.appendParameters(AbstractConfig.java:230)
```
