### PR TITLE
fixed start.sh ps -f cannot find any process#1879

### DIFF
--- a/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh
+++ b/dubbo-container/dubbo-container-api/src/main/resources/META-INF/assembly/bin/start.sh
@@ -79,7 +79,7 @@ while [ $COUNT -lt 1 ]; do
             COUNT=`netstat -an | grep $SERVER_PORT | wc -l`
         fi
     else
-    	COUNT=`ps -f | grep java | grep -v grep | grep "$DEPLOY_DIR" | awk '{print $2}' | wc -l`
+    	COUNT=`ps -ef | grep java | grep -v grep | grep "$DEPLOY_DIR" | awk '{print $2}' | wc -l`
     fi
     if [ $COUNT -gt 0 ]; then
         break
@@ -87,6 +87,6 @@ while [ $COUNT -lt 1 ]; do
 done
 
 echo "OK!"
-PIDS=`ps -f | grep java | grep -v grep | grep "$DEPLOY_DIR" | awk '{print $2}'`
+PIDS=`ps -ef | grep java | grep -v grep | grep "$DEPLOY_DIR" | awk '{print $2}'`
 echo "PID: $PIDS"
 echo "STDOUT: $STDOUT_FILE"


### PR DESCRIPTION
## What is the purpose of the change

fixed #1879 

## Brief changelog

change `ps -f` to `ps -ef`, Because ps -f channot find any process。



