### PR TITLE
[Dubbo-1431] here is a StackOverflow bug? dubbo version 2.5.9, FailsafeLogger.appendContextMessage() > NetUtils.getLocalAddress()

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/NetUtils.java
@@ -190,7 +190,7 @@ public class NetUtils {
                 return localAddress;
             }
         } catch (Throwable e) {
-            logger.warn("Failed to retrieving ip address, " + e.getMessage(), e);
+            logger.warn(e);
         }
         try {
             Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
@@ -207,19 +207,18 @@ public class NetUtils {
                                         return address;
                                     }
                                 } catch (Throwable e) {
-                                    logger.warn("Failed to retrieving ip address, " + e.getMessage(), e);
+                                    logger.warn(e);
                                 }
                             }
                         }
                     } catch (Throwable e) {
-                        logger.warn("Failed to retrieving ip address, " + e.getMessage(), e);
+                        logger.warn(e);
                     }
                 }
             }
         } catch (Throwable e) {
-            logger.warn("Failed to retrieving ip address, " + e.getMessage(), e);
+            logger.warn(e);
         }
-        logger.error("Could not get local host ip address, will use 127.0.0.1 instead.");
         return localAddress;
     }
 


### PR DESCRIPTION

## What is the purpose of the change

issue#1431: here is a StackOverflow bug? dubbo version 2.5.9, FailsafeLogger.appendContextMessage() > NetUtils.getLocalAddress()

## Brief changelog

dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/NetUtils.java

## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).