### PR TITLE
[Dubbo-1962] Resolving inconsistent parameter validation rules

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -538,6 +538,7 @@ public class ReferenceConfig<T> extends AbstractReferenceConfig {
     }
 
     public void setProtocol(String protocol) {
+        checkName("protocol", protocol);
         this.protocol = protocol;
     }
 

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/RegistryConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/RegistryConfig.java
@@ -293,6 +293,7 @@ public class RegistryConfig extends AbstractConfig {
     }
 
     public void setGroup(String group) {
+        checkKey("group", group);
         this.group = group;
     }
 
@@ -301,6 +302,7 @@ public class RegistryConfig extends AbstractConfig {
     }
 
     public void setVersion(String version) {
+        checkKey("version", version);
         this.version = version;
     }
 

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
@@ -49,6 +49,7 @@ public class ReferenceConfigTest {
         rc.setRegistry(registry);
         rc.setInterface(DemoService.class.getName());
         rc.setInjvm(false);
+        rc.setProtocol("dubbo");
 
         try {
             demoService.export();
@@ -58,6 +59,17 @@ public class ReferenceConfigTest {
         } finally {
             demoService.unexport();
         }
+    }
+
+    @Test
+    public void testProtocol() throws Exception {
+        ReferenceConfig<DemoService> rc = new ReferenceConfig<DemoService>();
+        try {
+            rc.setProtocol("dubbo://");
+        } catch (IllegalStateException e) {
+            Assert.assertEquals(e.getMessage(), "Invalid protocol=\"dubbo://\" contains illegal character, only digit, letter, '-', '_' or '.' is legal.");
+        }
+        Assert.assertNull(rc.getProtocol());
     }
 
 }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/RegistryConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/RegistryConfigTest.java
@@ -18,6 +18,7 @@
 package org.apache.dubbo.config;
 
 import org.apache.dubbo.common.Constants;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -153,10 +154,32 @@ public class RegistryConfigTest {
     }
 
     @Test
+    public void testGroupIllegalCharacter() throws Exception {
+        RegistryConfig registry = new RegistryConfig();
+        try {
+            registry.setGroup("dubbo/TEST");
+        } catch (IllegalStateException e) {
+            Assert.assertEquals(e.getMessage(), "Invalid group=\"dubbo/TEST\" contains illegal character, only digit, letter, '-', '_' or '.' is legal.");
+        }
+        Assert.assertNull(registry.getGroup());
+    }
+
+    @Test
     public void testVersion() throws Exception {
         RegistryConfig registry = new RegistryConfig();
         registry.setVersion("1.0.0");
         assertThat(registry.getVersion(), equalTo("1.0.0"));
+    }
+
+    @Test
+    public void testVersionIllegalCharacter() throws Exception {
+        RegistryConfig registry = new RegistryConfig();
+        try {
+            registry.setVersion("1.0/0");
+        } catch (IllegalStateException e) {
+            Assert.assertEquals(e.getMessage(), "Invalid version=\"1.0/0\" contains illegal character, only digit, letter, '-', '_' or '.' is legal.");
+        }
+        Assert.assertNull(registry.getVersion());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Resolving inconsistent parameter validation rules. #1962 

## Brief changelog

ReferenceConfig.java#setProtocol(String protocol)
RegistryConfig.java#setGroup(String group)
RegistryConfig.java#setVersion(String version)

## Verifying this change

Unit test passed.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
