### PR TITLE
[Dubbo-2031] Fix hessian2 serialization infinit recursion(StackOverflowError) when object's writeReplace method returns the object itself

### DIFF
--- a/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/JavaSerializer.java
+++ b/hessian-lite/src/main/java/com/alibaba/com/caucho/hessian/io/JavaSerializer.java
@@ -218,13 +218,17 @@ public class JavaSerializer extends AbstractSerializer {
                 else
                     repl = _writeReplace.invoke(obj);
 
-                out.removeRef(obj);
+                //Some class would return itself for wrapReplace, which would cause infinite recursion
+                //In this case, we could just write the object just like normal cases
+                if (repl != obj) {
+                    out.removeRef(obj);
 
-                out.writeObject(repl);
+                    out.writeObject(repl);
 
-                out.replaceRef(repl, obj);
+                    out.replaceRef(repl, obj);
 
-                return;
+                    return;
+                }
             }
         } catch (RuntimeException e) {
             throw e;

--- a/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/writereplace/Hessian2WriteReplaceTest.java
+++ b/hessian-lite/src/test/java/com/alibaba/com/caucho/hessian/io/writereplace/Hessian2WriteReplaceTest.java
@@ -1,0 +1,115 @@
+package com.alibaba.com.caucho.hessian.io.writereplace;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.Serializable;
+import org.junit.Test;
+
+import com.alibaba.com.caucho.hessian.io.base.SerializeTestBase;
+
+public class Hessian2WriteReplaceTest extends SerializeTestBase {
+
+  @Test
+  public void testWriteReplaceReturningItself() throws Exception {
+    String someName = "some name";
+    WriteReplaceReturningItself object = new WriteReplaceReturningItself(someName);
+
+    WriteReplaceReturningItself result = baseHession2Serialize(object);
+
+    assertEquals(someName, result.getName());
+  }
+
+  @Test
+  public void testNormalWriteReplace() throws Exception {
+    String someFirstName = "first";
+    String someLastName = "last";
+    String someAddress = "some address";
+
+    NormalWriteReplace object = new NormalWriteReplace(someFirstName, someLastName, someAddress);
+
+    NormalWriteReplace result = baseHession2Serialize(object);
+
+    assertEquals(someFirstName, result.getFirstName());
+    assertEquals(someLastName, result.getLastName());
+    assertEquals(someAddress, result.getAddress());
+  }
+
+  static class WriteReplaceReturningItself implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String name;
+
+    WriteReplaceReturningItself(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    /**
+     * Some object may return itself for wrapReplace, e.g.
+     * https://github.com/FasterXML/jackson-databind/blob/master/src/main/java/com/fasterxml/jackson/databind/JsonMappingException.java#L173
+     */
+    Object writeReplace() {
+      //do some extra things
+
+      return this;
+    }
+  }
+
+  static class NormalWriteReplace implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String firstName;
+    private String lastName;
+    private String address;
+
+    public NormalWriteReplace(String firstName, String lastName, String address) {
+      this.firstName = firstName;
+      this.lastName = lastName;
+      this.address = address;
+    }
+
+    public String getFirstName() {
+      return firstName;
+    }
+
+    public String getLastName() {
+      return lastName;
+    }
+
+    public String getAddress() {
+      return address;
+    }
+
+    //return a proxy to save space for serialization
+    Object writeReplace() {
+      return new NormalWriteReplaceProxy(this);
+    }
+  }
+
+  static class NormalWriteReplaceProxy implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String data;
+
+    //empty constructor for deserialization
+    public NormalWriteReplaceProxy() {
+    }
+
+    public NormalWriteReplaceProxy(NormalWriteReplace normalWriteReplace) {
+      this.data = normalWriteReplace.getFirstName() + "," + normalWriteReplace.getLastName() + "," + normalWriteReplace
+          .getAddress();
+    }
+
+    //construct the actual object
+    Object readResolve() {
+      String[] parts = data.split(",");
+
+      return new NormalWriteReplace(parts[0], parts[1], parts[2]);
+    }
+  }
+}
+


### PR DESCRIPTION
## What is the purpose of the change

Fix #2031

## Brief changelog

When the object's writeReplace return itself, then just serialize it as the normal object. No need to do another recursive call, which will cause infinite recursion.

## Verifying this change

Check the newly added unit test case: Hessian2WriteReplaceTest.java

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
