### PR TITLE
[Dubbo- unit test class not found] fix class not found "hi"

### DIFF
--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvokerAvilableTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvokerAvilableTest.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.common.Constants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.utils.ConfigUtils;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.remoting.exchange.ExchangeClient;
 import org.apache.dubbo.rpc.Exporter;
 import org.apache.dubbo.rpc.ProxyFactory;
@@ -78,7 +79,8 @@ public class DubboInvokerAvilableTest {
 
     @Test
     public void test_normal_channel_close_wait_gracefully() throws Exception {
-        URL url = URL.valueOf("dubbo://127.0.0.1:20883/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?scope=true&lazy=false");
+        int testPort = NetUtils.getAvailablePort();
+        URL url = URL.valueOf("dubbo://127.0.0.1:" + testPort + "/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?scope=true&lazy=false");
         Exporter<IDemoService> exporter = ProtocolUtils.export(new DemoServiceImpl(), IDemoService.class, url);
         Exporter<IDemoService> exporter0 = ProtocolUtils.export(new DemoServiceImpl0(), IDemoService.class, url);
 

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvokerAvilableTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvokerAvilableTest.java
@@ -22,15 +22,12 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.utils.ConfigUtils;
 import org.apache.dubbo.remoting.exchange.ExchangeClient;
-import org.apache.dubbo.remoting.exchange.support.header.HeaderExchangeServer;
 import org.apache.dubbo.rpc.Exporter;
 import org.apache.dubbo.rpc.ProxyFactory;
 import org.apache.dubbo.rpc.protocol.dubbo.support.ProtocolUtils;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
@@ -54,7 +51,7 @@ public class DubboInvokerAvilableTest {
 
     @Test
     public void test_Normal_available() {
-        URL url = URL.valueOf("dubbo://127.0.0.1:20883/hi");
+        URL url = URL.valueOf("dubbo://127.0.0.1:20883/org.apache.dubbo.rpc.protocol.dubbo.IDemoService");
         ProtocolUtils.export(new DemoServiceImpl(), IDemoService.class, url);
 
         DubboInvoker<?> invoker = (DubboInvoker<?>) protocol.refer(IDemoService.class, url);
@@ -65,7 +62,7 @@ public class DubboInvokerAvilableTest {
 
     @Test
     public void test_Normal_ChannelReadOnly() throws Exception {
-        URL url = URL.valueOf("dubbo://127.0.0.1:20883/hi");
+        URL url = URL.valueOf("dubbo://127.0.0.1:20883/org.apache.dubbo.rpc.protocol.dubbo.IDemoService");
         ProtocolUtils.export(new DemoServiceImpl(), IDemoService.class, url);
 
         DubboInvoker<?> invoker = (DubboInvoker<?>) protocol.refer(IDemoService.class, url);
@@ -81,7 +78,7 @@ public class DubboInvokerAvilableTest {
 
     @Test
     public void test_normal_channel_close_wait_gracefully() throws Exception {
-        URL url = URL.valueOf("dubbo://127.0.0.1:20883/hi?scope=true&lazy=false");
+        URL url = URL.valueOf("dubbo://127.0.0.1:20883/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?scope=true&lazy=false");
         Exporter<IDemoService> exporter = ProtocolUtils.export(new DemoServiceImpl(), IDemoService.class, url);
         Exporter<IDemoService> exporter0 = ProtocolUtils.export(new DemoServiceImpl0(), IDemoService.class, url);
 
@@ -105,7 +102,7 @@ public class DubboInvokerAvilableTest {
 
     @Test
     public void test_NoInvokers() throws Exception {
-        URL url = URL.valueOf("dubbo://127.0.0.1:20883/hi?connections=1");
+        URL url = URL.valueOf("dubbo://127.0.0.1:20883/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?connections=1");
         ProtocolUtils.export(new DemoServiceImpl(), IDemoService.class, url);
 
         DubboInvoker<?> invoker = (DubboInvoker<?>) protocol.refer(IDemoService.class, url);
@@ -118,7 +115,7 @@ public class DubboInvokerAvilableTest {
 
     @Test
     public void test_Lazy_ChannelReadOnly() throws Exception {
-        URL url = URL.valueOf("dubbo://127.0.0.1:20883/hi?lazy=true&connections=1");
+        URL url = URL.valueOf("dubbo://127.0.0.1:20883/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?lazy=true&connections=1&timeout=10000");
         ProtocolUtils.export(new DemoServiceImpl(), IDemoService.class, url);
 
         DubboInvoker<?> invoker = (DubboInvoker<?>) protocol.refer(IDemoService.class, url);
@@ -146,10 +143,6 @@ public class DubboInvokerAvilableTest {
         ExchangeClient[] clients = (ExchangeClient[]) field.get(invoker);
         Assert.assertEquals(1, clients.length);
         return clients;
-    }
-
-    public interface IDemoService {
-        public String get();
     }
 
     public class DemoServiceImpl implements IDemoService {

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboLazyConnectTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboLazyConnectTest.java
@@ -22,7 +22,6 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.rpc.RpcException;
 import org.apache.dubbo.rpc.protocol.dubbo.support.ProtocolUtils;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -43,19 +42,19 @@ public class DubboLazyConnectTest {
 
     @Test(expected = RpcException.class)
     public void testSticky1() {
-        URL url = URL.valueOf("dubbo://127.0.0.1:9090/hi");
+        URL url = URL.valueOf("dubbo://127.0.0.1:9090/org.apache.dubbo.rpc.protocol.dubbo.IDemoService");
         ProtocolUtils.refer(IDemoService.class, url);
     }
 
     @Test
     public void testSticky2() {
-        URL url = URL.valueOf("dubbo://127.0.0.1:9090/hi?" + Constants.LAZY_CONNECT_KEY + "=true");
+        URL url = URL.valueOf("dubbo://127.0.0.1:9090/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?" + Constants.LAZY_CONNECT_KEY + "=true");
         ProtocolUtils.refer(IDemoService.class, url);
     }
 
     @Test(expected = RpcException.class)
     public void testSticky3() {
-        URL url = URL.valueOf("dubbo://127.0.0.1:9090/hi?" + Constants.LAZY_CONNECT_KEY + "=true");
+        URL url = URL.valueOf("dubbo://127.0.0.1:9090/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?" + Constants.LAZY_CONNECT_KEY + "=true");
         IDemoService service = (IDemoService) ProtocolUtils.refer(IDemoService.class, url);
         service.get();
     }
@@ -63,16 +62,12 @@ public class DubboLazyConnectTest {
     @Test
     public void testSticky4() {
         int port = NetUtils.getAvailablePort();
-        URL url = URL.valueOf("dubbo://127.0.0.1:" + port + "/hi?" + Constants.LAZY_CONNECT_KEY + "=true");
+        URL url = URL.valueOf("dubbo://127.0.0.1:" + port + "/org.apache.dubbo.rpc.protocol.dubbo.IDemoService?" + Constants.LAZY_CONNECT_KEY + "=true&timeout=20000");
 
         ProtocolUtils.export(new DemoServiceImpl(), IDemoService.class, url);
 
         IDemoService service = (IDemoService) ProtocolUtils.refer(IDemoService.class, url);
         Assert.assertEquals("ok", service.get());
-    }
-
-    public interface IDemoService {
-        public String get();
     }
 
     public class DemoServiceImpl implements IDemoService {

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/IDemoService.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/IDemoService.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.protocol.dubbo;
+
+public interface IDemoService {
+    public String get();
+}


### PR DESCRIPTION
## What is the purpose of the change

fix  unit test `DubboInvokerAvilableTest & DubboLazyConnectTest` class not found "hi"

## Brief changelog

1. Replace url path "hi" to "org.apache.dubbo.rpc.protocol.dubbo.IDemoService"
2. Move "org.apache.dubbo.rpc.protocol.dubbo.IDemoService" to the top

## Verifying this change

unit test passed

Follow this checklist to help us incorporate your contribution quickly and easily:

- [] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
