### PR TITLE
解析用户定义的URL时，当前太过粗暴，做下优雅调整

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/UrlUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/UrlUtils.java
@@ -39,7 +39,7 @@ public class UrlUtils {
         String url;
         if (address.contains("://") || address.contains(URL_PARAM_STARTING_SYMBOL)) {
             url = address;
-        }else {
+        } else {
             String[] addresses = Constants.COMMA_SPLIT_PATTERN.split(address);
             url = addresses[0];
             if (addresses.length > 1) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/UrlUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/UrlUtils.java
@@ -27,14 +27,19 @@ import java.util.Set;
 
 public class UrlUtils {
 
+    /**
+     *  in the url string,mark the param begin
+     */
+    private final static String URL_PARAM_STARTING_SYMBOL = "?";
+
     public static URL parseURL(String address, Map<String, String> defaults) {
         if (address == null || address.length() == 0) {
             return null;
         }
         String url;
-        if (address.indexOf("://") >= 0) {
+        if (address.contains("://") || address.contains(URL_PARAM_STARTING_SYMBOL)) {
             url = address;
-        } else {
+        }else {
             String[] addresses = Constants.COMMA_SPLIT_PATTERN.split(address);
             url = addresses[0];
             if (addresses.length > 1) {
@@ -45,7 +50,7 @@ public class UrlUtils {
                     }
                     backup.append(addresses[i]);
                 }
-                url += "?" + Constants.BACKUP_KEY + "=" + backup.toString();
+                url += URL_PARAM_STARTING_SYMBOL + Constants.BACKUP_KEY + "=" + backup.toString();
             }
         }
         String defaultProtocol = defaults == null ? null : defaults.get("protocol");
@@ -335,7 +340,7 @@ public class UrlUtils {
             version = service.substring(i + 1);
             service = service.substring(0, i);
         }
-        return URL.valueOf(Constants.EMPTY_PROTOCOL + "://0.0.0.0/" + service + "?"
+        return URL.valueOf(Constants.EMPTY_PROTOCOL + "://0.0.0.0/" + service + URL_PARAM_STARTING_SYMBOL
                 + Constants.CATEGORY_KEY + "=" + category
                 + (group == null ? "" : "&" + Constants.GROUP_KEY + "=" + group)
                 + (version == null ? "" : "&" + Constants.VERSION_KEY + "=" + version));

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/UrlUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/UrlUtilsTest.java
@@ -57,6 +57,12 @@ public class UrlUtilsTest {
     }
 
     @Test
+    public void testParseURLWithSpecial() {
+        String address = "127.0.0.1:2181?backup=127.0.0.1:2182,127.0.0.1:2183";
+        assertEquals("dubbo://" + address,UrlUtils.parseURL(address, null).toString());
+    }
+
+    @Test
     public void testDefaultUrl() {
         String address = "127.0.0.1";
         URL url = UrlUtils.parseURL(address, null);


### PR DESCRIPTION
目前程序支持配置不包含协议头的地址。

问题场景：有时候url已经配置好了‘?backup’，只是没有写协议头。此时如果再一次按照原方案解析，会多拼接出来backup这样的错误信息，而且报的错误不明显，根本不知道哪里做了如上配置，需要查看dubbo实现逻辑才能推断该怎么配置这一段。

本次升级建议：如果在url中，有程序处理拼接的url参数‘?’的，直接不做任何处理。(‘?’在当前逻辑里是拼接backup用的特殊符号。)

问题示例：
127.0.0.1:2181?backup=127.0.0.1:2182,127.0.0.1:2183   --> 127.0.0.1:2181?backup=127.0.0.1:2182?backup=127.0.0.1:2183