### PR TITLE
Remove pom element linkXRef

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,6 @@
                                     <configLocation>codestyle/checkstyle.xml</configLocation>
                                     <suppressionsLocation>codestyle/checkstyle-suppressions.xml</suppressionsLocation>
                                     <headerLocation>codestyle/checkstyle-header.txt</headerLocation>
-                                    <linkXRef>false</linkXRef>
                                     <encoding>UTF-8</encoding>
                                     <consoleOutput>true</consoleOutput>
                                     <failOnViolation>true</failOnViolation>


### PR DESCRIPTION
## What is the purpose of the change

Fix the error "Element linkXRef is not allowed here" reported by Intellij IDEA  2018.1.6 (Utimate Edition).

The  linkXRef element isn't defined as parameter in the "check" goal but in the "checkstyle" goal and the "checkstyle-aggregate" goal,  according to the plugin.xml of  maven-checkstyle-plugin:3.0.0.

 See https://maven.apache.org/plugins/maven-checkstyle-plugin/plugin-info.html  for details.

## Brief changelog

Remove the  linkXRef element in root pom.

## Verifying this change

CI passed

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
