### PR TITLE
Fix a bug when client reconnect

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/AbstractClient.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/AbstractClient.java
@@ -53,12 +53,6 @@ public abstract class AbstractClient extends AbstractEndpoint implements Client 
     private static final AtomicInteger CLIENT_THREAD_POOL_ID = new AtomicInteger();
     private static final ScheduledThreadPoolExecutor reconnectExecutorService = new ScheduledThreadPoolExecutor(2, new NamedThreadFactory("DubboClientReconnectTimer", true));
     private final Lock connectLock = new ReentrantLock();
-
-    /**
-     * reConnectLock
-     */
-    private final Lock reConnectLock = new ReentrantLock();
-
     private final boolean send_reconnect;
     private final AtomicInteger reconnect_count = new AtomicInteger(0);
     // Reconnection error log has been called before?
@@ -328,14 +322,14 @@ public abstract class AbstractClient extends AbstractEndpoint implements Client 
     @Override
     public void reconnect() throws RemotingException {
         if (!isConnected()) {
-            reConnectLock.lock();
+            connectLock.lock();
             try {
                 if (!isConnected()) {
                     disconnect();
                     connect();
                 }
             } finally {
-                reConnectLock.unlock();
+                connectLock.unlock();
             }
         }
     }


### PR DESCRIPTION
Add reconnection lock to control only one thread can can reconnect method.
This will avoid problem in this case:
Thread A reconnecting, and success, then send msg.
Thread B reconnecting but invoke disconnect. Then the Thread A will send msg fail because of Thread B's disconnecting call.

The issue is here:
https://github.com/apache/incubator-dubbo/issues/944