### PR TITLE
[Dubbo-2017]Fix redis auth problem for RedisProtocol(merge to 2.6.x PR)

### DIFF
--- a/dubbo-registry/dubbo-registry-redis/src/main/java/com/alibaba/dubbo/registry/redis/RedisRegistry.java
+++ b/dubbo-registry/dubbo-registry-redis/src/main/java/com/alibaba/dubbo/registry/redis/RedisRegistry.java
@@ -120,7 +120,6 @@ public class RedisRegistry extends FailbackRegistry {
             addresses.addAll(Arrays.asList(backups));
         }
 
-        String password = url.getPassword();
         for (String address : addresses) {
             int i = address.indexOf(':');
             String host;
@@ -132,15 +131,9 @@ public class RedisRegistry extends FailbackRegistry {
                 host = address;
                 port = DEFAULT_REDIS_PORT;
             }
-            if (StringUtils.isEmpty(password)) {
-                this.jedisPools.put(address, new JedisPool(config, host, port,
-                        url.getParameter(Constants.TIMEOUT_KEY, Constants.DEFAULT_TIMEOUT), null,
-                        url.getParameter("db.index", 0)));
-            } else {
-                this.jedisPools.put(address, new JedisPool(config, host, port,
-                        url.getParameter(Constants.TIMEOUT_KEY, Constants.DEFAULT_TIMEOUT), password,
-                        url.getParameter("db.index", 0)));
-            }
+            this.jedisPools.put(address, new JedisPool(config, host, port,
+                    url.getParameter(Constants.TIMEOUT_KEY, Constants.DEFAULT_TIMEOUT), StringUtils.isEmpty(url.getPassword()) ? null : url.getPassword(),
+                    url.getParameter("db.index", 0)));
         }
 
         this.reconnectPeriod = url.getParameter(Constants.REGISTRY_RECONNECT_PERIOD_KEY, Constants.DEFAULT_REGISTRY_RECONNECT_PERIOD);

--- a/dubbo-rpc/dubbo-rpc-redis/src/main/java/com/alibaba/dubbo/rpc/protocol/redis/RedisProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-redis/src/main/java/com/alibaba/dubbo/rpc/protocol/redis/RedisProtocol.java
@@ -22,6 +22,7 @@ import com.alibaba.dubbo.common.extension.ExtensionLoader;
 import com.alibaba.dubbo.common.serialize.ObjectInput;
 import com.alibaba.dubbo.common.serialize.ObjectOutput;
 import com.alibaba.dubbo.common.serialize.Serialization;
+import com.alibaba.dubbo.common.utils.StringUtils;
 import com.alibaba.dubbo.rpc.Exporter;
 import com.alibaba.dubbo.rpc.Invocation;
 import com.alibaba.dubbo.rpc.Invoker;
@@ -90,7 +91,9 @@ public class RedisProtocol extends AbstractProtocol {
             if (url.getParameter("min.evictable.idle.time.millis", 0) > 0)
                 config.setMinEvictableIdleTimeMillis(url.getParameter("min.evictable.idle.time.millis", 0));
             final JedisPool jedisPool = new JedisPool(config, url.getHost(), url.getPort(DEFAULT_PORT),
-                    url.getParameter(Constants.TIMEOUT_KEY, Constants.DEFAULT_TIMEOUT));
+                    url.getParameter(Constants.TIMEOUT_KEY, Constants.DEFAULT_TIMEOUT),
+                    StringUtils.isBlank(url.getPassword()) ? null : url.getPassword(),
+                    url.getParameter("db.index", 0));
             final int expiry = url.getParameter("expiry", 0);
             final String get = url.getParameter("get", "get");
             final String set = url.getParameter("set", Map.class.equals(type) ? "put" : "set");

--- a/dubbo-rpc/dubbo-rpc-redis/src/test/java/com/alibaba/dubbo/rpc/protocol/redis/RedisProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-redis/src/test/java/com/alibaba/dubbo/rpc/protocol/redis/RedisProtocolTest.java
@@ -16,17 +16,31 @@
  */
 package com.alibaba.dubbo.rpc.protocol.redis;
 
+import com.alibaba.dubbo.common.Constants;
 import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.common.extension.ExtensionLoader;
+import com.alibaba.dubbo.common.serialize.ObjectInput;
+import com.alibaba.dubbo.common.serialize.Serialization;
 import com.alibaba.dubbo.common.utils.NetUtils;
 import com.alibaba.dubbo.rpc.Invoker;
 import com.alibaba.dubbo.rpc.Protocol;
 import com.alibaba.dubbo.rpc.ProxyFactory;
 import com.alibaba.dubbo.rpc.RpcException;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisDataException;
 import redis.embedded.RedisServer;
+
+import java.io.ByteArrayInputStream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -38,12 +52,21 @@ public class RedisProtocolTest {
     private RedisServer redisServer;
     private URL registryUrl;
 
+    @Rule
+    public TestName name = new TestName();
+
     @Before
     public void setUp() throws Exception {
         int redisPort = NetUtils.getAvailablePort();
-        this.redisServer = new RedisServer(redisPort);
+        if (name.getMethodName().equals("testAuthRedis") || name.getMethodName().equals("testWrongAuthRedis")) {
+            String password = "123456";
+            this.redisServer = RedisServer.builder().port(redisPort).setting("requirepass " + password).build();
+            this.registryUrl = URL.valueOf("redis://username:"+password+"@localhost:"+redisPort+"?db.index=0");
+        } else {
+            this.redisServer = RedisServer.builder().port(redisPort).build();
+            this.registryUrl = URL.valueOf("redis://localhost:" + redisPort);
+        }
         this.redisServer.start();
-        this.registryUrl = URL.valueOf("redis://localhost:" + redisPort);
     }
 
     @After
@@ -108,5 +131,91 @@ public class RedisProtocolTest {
     @Test(expected = UnsupportedOperationException.class)
     public void testExport() {
         protocol.export(protocol.refer(IDemoService.class, registryUrl));
+    }
+
+    @Test
+    public void testAuthRedis() {
+        // default db.index=0
+        Invoker<IDemoService> refer = protocol.refer(IDemoService.class,
+                registryUrl
+                        .addParameter("max.idle", 10)
+                        .addParameter("max.active", 20));
+        IDemoService demoService = this.proxy.getProxy(refer);
+
+        String value = demoService.get("key");
+        assertThat(value, is(nullValue()));
+
+        demoService.set("key", "newValue");
+        value = demoService.get("key");
+        assertThat(value, is("newValue"));
+
+        demoService.delete("key");
+        value = demoService.get("key");
+        assertThat(value, is(nullValue()));
+
+        refer.destroy();
+
+        //change db.index=1
+        String password = "123456";
+        int database = 1;
+        this.registryUrl = this.registryUrl.setPassword(password).addParameter("db.index", database);
+        refer = protocol.refer(IDemoService.class,
+                registryUrl
+                        .addParameter("max.idle", 10)
+                        .addParameter("max.active", 20));
+        demoService = this.proxy.getProxy(refer);
+
+        demoService.set("key", "newValue");
+        value = demoService.get("key");
+        assertThat(value, is("newValue"));
+
+        // jedis gets the result comparison
+        JedisPool pool = new JedisPool(new GenericObjectPoolConfig(), "localhost", registryUrl.getPort(), 2000, password, database, (String)null);
+        Jedis jedis = null;
+        try {
+            jedis = pool.getResource();
+            byte[] valueByte = jedis.get("key".getBytes());
+            Serialization serialization = ExtensionLoader.getExtensionLoader(Serialization.class).getExtension(this.registryUrl.getParameter(Constants.SERIALIZATION_KEY, "java"));
+            ObjectInput oin = serialization.deserialize(this.registryUrl, new ByteArrayInputStream(valueByte));
+            String actual = (String) oin.readObject();
+            assertThat(value, is(actual));
+        } catch(Exception e) {
+            Assert.fail("jedis gets the result comparison is error!");
+        } finally {
+            if (jedis != null) {
+                jedis.close();
+            }
+            pool.destroy();
+        }
+
+        demoService.delete("key");
+        value = demoService.get("key");
+        assertThat(value, is(nullValue()));
+
+        refer.destroy();
+    }
+
+    @Test
+    public void testWrongAuthRedis() {
+        String password = "1234567";
+        this.registryUrl = this.registryUrl.setPassword(password);
+        Invoker<IDemoService> refer = protocol.refer(IDemoService.class,
+                registryUrl
+                        .addParameter("max.idle", 10)
+                        .addParameter("max.active", 20));
+        IDemoService demoService = this.proxy.getProxy(refer);
+
+        try {
+            String value = demoService.get("key");
+            assertThat(value, is(nullValue()));
+        } catch (RpcException e) {
+            if (e.getCause() instanceof JedisConnectionException && e.getCause().getCause() instanceof JedisDataException) {
+                Assert.assertEquals("ERR invalid password" , e.getCause().getCause().getMessage());
+            } else {
+                Assert.fail("no invalid password exception!");
+            }
+        }
+
+        refer.destroy();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Access redis using a password. #2017 
merge to 2.6.x PR

## Brief changelog

Fix redis auth problem for RedisProtocol, add parameter db.index for url.

## Verifying this change

modify: RedisProtocol.java
modify: RedisRegistry.java
add UT: RedisProtocolTest.testAuthRedis
add UT: RedisProtocolTest.testWrongAuthRedis

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
