### PR TITLE
Increase availability, make @Adaptive try default extension when the specified one couldn't be found.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -757,6 +757,9 @@ public class ExtensionLoader<T> {
         codeBuilder.append("\nimport ").append(ExtensionLoader.class.getName()).append(";");
         codeBuilder.append("\npublic class ").append(type.getSimpleName()).append("$Adaptive").append(" implements ").append(type.getCanonicalName()).append(" {");
 
+        codeBuilder.append("\nprivate static final org.apache.dubbo.common.logger.Logger logger = org.apache.dubbo.common.logger.LoggerFactory.getLogger(ExtensionLoader.class);");
+        codeBuilder.append("\nprivate java.util.concurrent.atomic.AtomicInteger count = new java.util.concurrent.atomic.AtomicInteger(0);\n");
+
         for (Method method : methods) {
             Class<?> rt = method.getReturnType();
             Class<?>[] pts = method.getParameterTypes();
@@ -895,6 +898,8 @@ public class ExtensionLoader<T> {
 
                 s = String.format("\n%s extension = null;\n try {\nextension = (%<s)%s.getExtensionLoader(%s.class).getExtension(extName);\n}catch(Exception e){\n",
                         type.getName(), ExtensionLoader.class.getSimpleName(), type.getName());
+                s += String.format("if (count.incrementAndGet() == 1) {\nlogger.warn(\"Failed to find extension named \" + extName + \" for type %s, will use default extension %s instead.\", e);\n}\n",
+                        type.getName(), defaultExtName);
                 s += String.format("extension = (%s)%s.getExtensionLoader(%s.class).getExtension(\"%s\");\n}",
                         type.getName(), ExtensionLoader.class.getSimpleName(), type.getName(), defaultExtName);
                 code.append(s);

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -893,8 +893,10 @@ public class ExtensionLoader<T> {
                         type.getName(), Arrays.toString(value));
                 code.append(s);
 
-                s = String.format("\n%s extension = (%<s)%s.getExtensionLoader(%s.class).getExtension(extName);",
+                s = String.format("\n%s extension = null;\n try {\nextension = (%<s)%s.getExtensionLoader(%s.class).getExtension(extName);\n}catch(Exception e){\n",
                         type.getName(), ExtensionLoader.class.getSimpleName(), type.getName());
+                s += String.format("extension = (%s)%s.getExtensionLoader(%s.class).getExtension(\"%s\");\n}",
+                        type.getName(), ExtensionLoader.class.getSimpleName(), type.getName(), defaultExtName);
                 code.append(s);
 
                 // return statement

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -896,13 +896,12 @@ public class ExtensionLoader<T> {
                         type.getName(), Arrays.toString(value));
                 code.append(s);
 
-                s = String.format("\n%s extension = null;\n try {\nextension = (%<s)%s.getExtensionLoader(%s.class).getExtension(extName);\n}catch(Exception e){\n",
-                        type.getName(), ExtensionLoader.class.getSimpleName(), type.getName());
-                s += String.format("if (count.incrementAndGet() == 1) {\nlogger.warn(\"Failed to find extension named \" + extName + \" for type %s, will use default extension %s instead.\", e);\n}\n",
-                        type.getName(), defaultExtName);
-                s += String.format("extension = (%s)%s.getExtensionLoader(%s.class).getExtension(\"%s\");\n}",
-                        type.getName(), ExtensionLoader.class.getSimpleName(), type.getName(), defaultExtName);
-                code.append(s);
+                code.append(String.format("\n%s extension = null;\n try {\nextension = (%<s)%s.getExtensionLoader(%s.class).getExtension(extName);\n}catch(Exception e){\n",
+                        type.getName(), ExtensionLoader.class.getSimpleName(), type.getName()));
+                code.append(String.format("if (count.incrementAndGet() == 1) {\nlogger.warn(\"Failed to find extension named \" + extName + \" for type %s, will use default extension %s instead.\", e);\n}\n",
+                        type.getName(), defaultExtName));
+                code.append(String.format("extension = (%s)%s.getExtensionLoader(%s.class).getExtension(\"%s\");\n}",
+                        type.getName(), ExtensionLoader.class.getSimpleName(), type.getName(), defaultExtName));
 
                 // return statement
                 if (!rt.equals(void.class)) {


### PR DESCRIPTION
Take the following case:
```java
@SPI("nop")
public interface DynamicConfigurationFactory {
    @Adaptive({"key1", "key2"})
    DynamicConfiguration getDynamicConfiguration(URL url);
}
```

```properties
zookeeper=org.apache.dubbo.config.dynamic.support.archaius.ArchaiusDynamicConfigurationFactory
archaius=org.apache.dubbo.config.dynamic.support.archaius.ArchaiusDynamicConfigurationFactory
apollo=org.apache.dubbo.config.dynamic.support.apollo.ApolloDynamicConfigurationFactory
nop=org.apache.dubbo.config.dynamic.support.nop.NopDynamicConfigurationFactory
```

1. Give a URL:
```
dubbo://0.0.0.0/xxx.DemoService?key2=notexists
```
There is no extension named `notexists`, so it will throw an IllegalStateException. But with this PR, getAdaptiveExtension() will return the `nop` extension by default.