### PR TITLE
Judge null for key and value in attachment in RpcContextFilter.

### DIFF
--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/RpcContextFilter.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/RpcContextFilter.java
@@ -70,25 +70,20 @@ public class RpcContextFilter implements ContainerRequestFilter, ClientRequestFi
         int size = 0;
         for (Map.Entry<String, String> entry : RpcContext.getContext().getAttachments().entrySet()) {
             String key = entry.getKey();
-            String value = entry.getValue();
-            if (StringUtils.isNotEmpty(key)) {
-                if (illegalForRest(key)) {
-                    throw new IllegalArgumentException("The attachments of " + RpcContext.class.getSimpleName() + " must not contain ',' or '=' when using rest protocol");
-                }
-            }
-            if (StringUtils.isNotEmpty(value)) {
-                if (illegalForRest(value)) {
-                    throw new IllegalArgumentException("The attachments of " + RpcContext.class.getSimpleName() + " must not contain ',' or '=' when using rest protocol");
-                }
+            String value = entry.getKey();
+            if (illegalForRest(key) || illegalForRest(value)) {
+                throw new IllegalArgumentException("The attachments of " + RpcContext.class.getSimpleName() + " must not contain ',' or '=' when using rest protocol");
             }
 
             // TODO for now we don't consider the differences of encoding and server limit
-            size += entry.getValue().getBytes("UTF-8").length;
+            if (value != null) {
+                size += value.getBytes("UTF-8").length;
+            }
             if (size > MAX_HEADER_SIZE) {
                 throw new IllegalArgumentException("The attachments of " + RpcContext.class.getSimpleName() + " is too big");
             }
 
-            String attachments = entry.getKey() + "=" + entry.getValue();
+            String attachments = key + "=" + value;
             requestContext.getHeaders().add(DUBBO_ATTACHMENT_HEADER, attachments);
         }
     }
@@ -100,6 +95,9 @@ public class RpcContextFilter implements ContainerRequestFilter, ClientRequestFi
      * @return true for illegal
      */
     private boolean illegalForRest(String v) {
-        return v.contains(",") || v.contains("=");
+        if (StringUtils.isNotEmpty(v)) {
+            return v.contains(",") || v.contains("=");
+        }
+        return false;
     }
 }

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/RestProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/RestProtocolTest.java
@@ -128,6 +128,27 @@ public class RestProtocolTest {
         exporter.unexport();
     }
 
+    @Test
+    public void testRpcContextFilter() {
+        ServiceClassHolder.getInstance().pushServiceClass(DemoService.class);
+
+        // use RpcContextFilter
+        URL nettyUrl = exportUrl.addParameter(Constants.SERVER_KEY, "netty")
+                .addParameter(Constants.EXTENSION_KEY, "org.apache.dubbo.rpc.protocol.rest.RpcContextFilter");
+        Exporter<IDemoService> exporter = protocol.export(proxy.getInvoker(new DemoService(), IDemoService.class, nettyUrl));
+
+        IDemoService demoService = this.proxy.getProxy(protocol.refer(IDemoService.class, nettyUrl));
+
+        String value = null;
+        // put a null value into attachment.
+        RpcContext.getContext().setAttachment("key", value);
+        Integer result = demoService.hello(1, 2);
+
+        assertThat(result, is(3));
+
+        exporter.unexport();
+    }
+
     @Test(expected = RuntimeException.class)
     public void testRegFail() {
         ServiceClassHolder.getInstance().pushServiceClass(DemoService.class);


### PR DESCRIPTION
Judge null for key and value in attachment in RpcContextFilter.
If not, NullPointerException will be thrown in RpcContextFilter in some case.

Fix #2127 : https://github.com/apache/incubator-dubbo/issues/2127#issuecomment-408344327