### PR TITLE
Optimize leastActiveSelect and weight test case

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/LeastActiveLoadBalance.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/LeastActiveLoadBalance.java
@@ -37,8 +37,8 @@ public class LeastActiveLoadBalance extends AbstractLoadBalance {
         int leastActive = -1; // The least active value of all invokers
         int leastCount = 0; // The number of invokers having the same least active value (leastActive)
         int[] leastIndexes = new int[length]; // The index of invokers having the same least active value (leastActive)
-        int totalWeightAfterWarmUp = 0; // The sum of after warmup weights
-        int firstWeightAfterWarmUp = 0; // Initial value, used for comparision
+        int taotalWeightWithWarmUp = 0; // The sum of with warmup weights
+        int firstWeightWithWarmUp = 0; // Initial value, used for comparision
         boolean sameWeight = true; // Every invoker has the same weight value?
         for (int i = 0; i < length; i++) {
             Invoker<T> invoker = invokers.get(i);
@@ -48,15 +48,15 @@ public class LeastActiveLoadBalance extends AbstractLoadBalance {
                 leastActive = active; // Record the current least active value
                 leastCount = 1; // Reset leastCount, count again based on current leastCount
                 leastIndexes[0] = i; // Reset
-                totalWeightAfterWarmUp = afterWarmup; // Reset
-                firstWeightAfterWarmUp = afterWarmup; // Record the weight the first invoker
+                taotalWeightWithWarmUp = afterWarmup; // Reset
+                firstWeightWithWarmUp = afterWarmup; // Record the weight the first invoker
                 sameWeight = true; // Reset, every invoker has the same weight value?
             } else if (active == leastActive) { // If current invoker's active value equals with leaseActive, then accumulating.
                 leastIndexes[leastCount++] = i; // Record index number of this invoker
-                totalWeightAfterWarmUp += afterWarmup; // Add this invoker's after warmup weight to totalWeightAfterWarmUp.
+                taotalWeightWithWarmUp += afterWarmup; // Add this invoker's with warmup weight to totalWeightWithWarmUp.
                 // If every invoker has the same weight?
                 if (sameWeight && i > 0
-                        && afterWarmup != firstWeightAfterWarmUp) {
+                        && afterWarmup != firstWeightWithWarmUp) {
                     sameWeight = false;
                 }
             }
@@ -66,9 +66,9 @@ public class LeastActiveLoadBalance extends AbstractLoadBalance {
             // If we got exactly one invoker having the least active value, return this invoker directly.
             return invokers.get(leastIndexes[0]);
         }
-        if (!sameWeight && totalWeightAfterWarmUp > 0) {
-            // If (not every invoker has the same weight & at least one invoker's weight>0), select randomly based on totalWeightAfterWarmUp.
-            int offsetWeight = ThreadLocalRandom.current().nextInt(totalWeightAfterWarmUp) + 1;
+        if (!sameWeight && taotalWeightWithWarmUp > 0) {
+            // If (not every invoker has the same weight & at least one invoker's weight>0), select randomly based on totalWeightWithWarmUp.
+            int offsetWeight = ThreadLocalRandom.current().nextInt(taotalWeightWithWarmUp) + 1;
             // Return a invoker based on the random value.
             for (int i = 0; i < leastCount; i++) {
                 int leastIndex = leastIndexes[i];
@@ -77,7 +77,7 @@ public class LeastActiveLoadBalance extends AbstractLoadBalance {
                     return invokers.get(leastIndex);
             }
         }
-        // If all invokers have the same weight value or totalWeightAfterWarmUp=0, return evenly.
+        // If all invokers have the same weight value or totalWeightWithWarmUp=0, return evenly.
         return invokers.get(leastIndexes[ThreadLocalRandom.current().nextInt(leastCount)]);
     }
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/LeastActiveLoadBalance.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/LeastActiveLoadBalance.java
@@ -37,8 +37,8 @@ public class LeastActiveLoadBalance extends AbstractLoadBalance {
         int leastActive = -1; // The least active value of all invokers
         int leastCount = 0; // The number of invokers having the same least active value (leastActive)
         int[] leastIndexes = new int[length]; // The index of invokers having the same least active value (leastActive)
-        int taotalWeightWithWarmUp = 0; // The sum of with warmup weights
-        int firstWeightWithWarmUp = 0; // Initial value, used for comparision
+        int totalWeight = 0; // The sum of with warmup weights
+        int firstWeight = 0; // Initial value, used for comparision
         boolean sameWeight = true; // Every invoker has the same weight value?
         for (int i = 0; i < length; i++) {
             Invoker<T> invoker = invokers.get(i);
@@ -48,15 +48,15 @@ public class LeastActiveLoadBalance extends AbstractLoadBalance {
                 leastActive = active; // Record the current least active value
                 leastCount = 1; // Reset leastCount, count again based on current leastCount
                 leastIndexes[0] = i; // Reset
-                taotalWeightWithWarmUp = afterWarmup; // Reset
-                firstWeightWithWarmUp = afterWarmup; // Record the weight the first invoker
+                totalWeight = afterWarmup; // Reset
+                firstWeight = afterWarmup; // Record the weight the first invoker
                 sameWeight = true; // Reset, every invoker has the same weight value?
             } else if (active == leastActive) { // If current invoker's active value equals with leaseActive, then accumulating.
                 leastIndexes[leastCount++] = i; // Record index number of this invoker
-                taotalWeightWithWarmUp += afterWarmup; // Add this invoker's with warmup weight to totalWeightWithWarmUp.
+                totalWeight += afterWarmup; // Add this invoker's with warmup weight to totalWeight.
                 // If every invoker has the same weight?
                 if (sameWeight && i > 0
-                        && afterWarmup != firstWeightWithWarmUp) {
+                        && afterWarmup != firstWeight) {
                     sameWeight = false;
                 }
             }
@@ -66,9 +66,9 @@ public class LeastActiveLoadBalance extends AbstractLoadBalance {
             // If we got exactly one invoker having the least active value, return this invoker directly.
             return invokers.get(leastIndexes[0]);
         }
-        if (!sameWeight && taotalWeightWithWarmUp > 0) {
-            // If (not every invoker has the same weight & at least one invoker's weight>0), select randomly based on totalWeightWithWarmUp.
-            int offsetWeight = ThreadLocalRandom.current().nextInt(taotalWeightWithWarmUp) + 1;
+        if (!sameWeight && totalWeight > 0) {
+            // If (not every invoker has the same weight & at least one invoker's weight>0), select randomly based on totalWeight.
+            int offsetWeight = ThreadLocalRandom.current().nextInt(totalWeight) + 1;
             // Return a invoker based on the random value.
             for (int i = 0; i < leastCount; i++) {
                 int leastIndex = leastIndexes[i];
@@ -77,7 +77,7 @@ public class LeastActiveLoadBalance extends AbstractLoadBalance {
                     return invokers.get(leastIndex);
             }
         }
-        // If all invokers have the same weight value or totalWeightWithWarmUp=0, return evenly.
+        // If all invokers have the same weight value or totalWeight=0, return evenly.
         return invokers.get(leastIndexes[ThreadLocalRandom.current().nextInt(leastCount)]);
     }
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/LeastActiveLoadBalance.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/LeastActiveLoadBalance.java
@@ -16,7 +16,6 @@
  */
 package org.apache.dubbo.rpc.cluster.loadbalance;
 
-import org.apache.dubbo.common.Constants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
@@ -27,7 +26,6 @@ import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * LeastActiveLoadBalance
- *
  */
 public class LeastActiveLoadBalance extends AbstractLoadBalance {
 
@@ -39,26 +37,26 @@ public class LeastActiveLoadBalance extends AbstractLoadBalance {
         int leastActive = -1; // The least active value of all invokers
         int leastCount = 0; // The number of invokers having the same least active value (leastActive)
         int[] leastIndexes = new int[length]; // The index of invokers having the same least active value (leastActive)
-        int totalWeight = 0; // The sum of weights
-        int firstWeight = 0; // Initial value, used for comparision
+        int totalWeightAfterWarmUp = 0; // The sum of after warmup weights
+        int firstWeightAfterWarmUp = 0; // Initial value, used for comparision
         boolean sameWeight = true; // Every invoker has the same weight value?
         for (int i = 0; i < length; i++) {
             Invoker<T> invoker = invokers.get(i);
             int active = RpcStatus.getStatus(invoker.getUrl(), invocation.getMethodName()).getActive(); // Active number
-            int weight = invoker.getUrl().getMethodParameter(invocation.getMethodName(), Constants.WEIGHT_KEY, Constants.DEFAULT_WEIGHT); // Weight
+            int afterWarmup = getWeight(invoker, invocation);
             if (leastActive == -1 || active < leastActive) { // Restart, when find a invoker having smaller least active value.
                 leastActive = active; // Record the current least active value
                 leastCount = 1; // Reset leastCount, count again based on current leastCount
                 leastIndexes[0] = i; // Reset
-                totalWeight = weight; // Reset
-                firstWeight = weight; // Record the weight the first invoker
+                totalWeightAfterWarmUp = afterWarmup; // Reset
+                firstWeightAfterWarmUp = afterWarmup; // Record the weight the first invoker
                 sameWeight = true; // Reset, every invoker has the same weight value?
             } else if (active == leastActive) { // If current invoker's active value equals with leaseActive, then accumulating.
                 leastIndexes[leastCount++] = i; // Record index number of this invoker
-                totalWeight += weight; // Add this invoker's weight to totalWeight.
+                totalWeightAfterWarmUp += afterWarmup; // Add this invoker's after warmup weight to totalWeightAfterWarmUp.
                 // If every invoker has the same weight?
                 if (sameWeight && i > 0
-                        && weight != firstWeight) {
+                        && afterWarmup != firstWeightAfterWarmUp) {
                     sameWeight = false;
                 }
             }
@@ -68,9 +66,9 @@ public class LeastActiveLoadBalance extends AbstractLoadBalance {
             // If we got exactly one invoker having the least active value, return this invoker directly.
             return invokers.get(leastIndexes[0]);
         }
-        if (!sameWeight && totalWeight > 0) {
-            // If (not every invoker has the same weight & at least one invoker's weight>0), select randomly based on totalWeight.
-            int offsetWeight = ThreadLocalRandom.current().nextInt(totalWeight);
+        if (!sameWeight && totalWeightAfterWarmUp > 0) {
+            // If (not every invoker has the same weight & at least one invoker's weight>0), select randomly based on totalWeightAfterWarmUp.
+            int offsetWeight = ThreadLocalRandom.current().nextInt(totalWeightAfterWarmUp) + 1;
             // Return a invoker based on the random value.
             for (int i = 0; i < leastCount; i++) {
                 int leastIndex = leastIndexes[i];
@@ -79,7 +77,7 @@ public class LeastActiveLoadBalance extends AbstractLoadBalance {
                     return invokers.get(leastIndex);
             }
         }
-        // If all invokers have the same weight value or totalWeight=0, return evenly.
+        // If all invokers have the same weight value or totalWeightAfterWarmUp=0, return evenly.
         return invokers.get(leastIndexes[ThreadLocalRandom.current().nextInt(leastCount)]);
     }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/LeastActiveBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/LeastActiveBalanceTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.rpc.cluster.loadbalance;
 
+import org.apache.dubbo.common.Constants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
@@ -86,11 +87,10 @@ public class LeastActiveBalanceTest extends LoadBalanceBaseTest {
             for (int i = 0; i < length; i++) {
                 Invoker<T> invoker = invokers.get(i);
 
-                // mock active is invoker's url.getHost
-                int active = Integer.valueOf(invoker.getUrl().getHost()); // Active number
+                // Active number
+                int active = invoker.getUrl().getParameter("active", Constants.DEFAULT_WEIGHT);
 
-                // mock weight is invoker's url.getPort
-                int afterWarmup = invoker.getUrl().getPort();
+                int afterWarmup = invoker.getUrl().getParameter(Constants.WEIGHT_KEY, Constants.DEFAULT_WEIGHT);
 
                 if (leastActive == -1 || active < leastActive) { // Restart, when find a invoker having smaller least active value.
                     leastActive = active; // Record the current least active value
@@ -121,8 +121,8 @@ public class LeastActiveBalanceTest extends LoadBalanceBaseTest {
                 for (int i = 0; i < leastCount; i++) {
                     int leastIndex = leastIndexs[i];
 
-                    // mock weight is invoker's url.getPort
-                    offsetWeight -= invokers.get(leastIndex).getUrl().getPort();
+                    offsetWeight -= invokers.get(leastIndex).getUrl().getParameter(Constants.WEIGHT_KEY, Constants.DEFAULT_WEIGHT);
+
                     if (offsetWeight <= 0)
                         return invokers.get(leastIndex);
                 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/LeastActiveBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/LeastActiveBalanceTest.java
@@ -19,20 +19,14 @@ package org.apache.dubbo.rpc.cluster.loadbalance;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
-
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
-
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 
 public class LeastActiveBalanceTest extends LoadBalanceBaseTest {
     @Ignore
@@ -48,41 +42,15 @@ public class LeastActiveBalanceTest extends LoadBalanceBaseTest {
         }
     }
 
-    private List<Invoker<LoadBalanceBaseTest>> invokers = new ArrayList<Invoker<LoadBalanceBaseTest>>();
-    private Invoker<LoadBalanceBaseTest> invoker1;
-    private Invoker<LoadBalanceBaseTest> invoker2;
-
-    @Before
-    public void before() throws Exception {
-        invoker1 = mock(Invoker.class);
-        invoker2 = mock(Invoker.class);
-        invoker3 = mock(Invoker.class);
-
-        URL url1 = URL.valueOf("test1://0:1/DemoService");
-        URL url2 = URL.valueOf("test2://0:9/DemoService");
-        URL url3 = URL.valueOf("test3://1:6/DemoService");
-
-        given(invoker1.isAvailable()).willReturn(true);
-        given(invoker1.getUrl()).willReturn(url1);
-
-        given(invoker2.isAvailable()).willReturn(true);
-        given(invoker2.getUrl()).willReturn(url2);
-
-        given(invoker3.isAvailable()).willReturn(true);
-        given(invoker3.getUrl()).willReturn(url3);
-
-        invokers.add(invoker1);
-        invokers.add(invoker2);
-        invokers.add(invoker3);
-    }
-
     @Test
-    public void testSelect() {
+    public void testSelectByWeight() {
         int sumInvoker1 = 0;
         int sumInvoker2 = 0;
+        int loop = 100000;
+
+        MyLeastActiveLoadBalance lb = new MyLeastActiveLoadBalance();
         for (int i = 0; i < 100000; i++) {
-            MyLeastActiveLoadBalance lb = new MyLeastActiveLoadBalance();
-            Invoker selected = lb.select(invokers, null, null);
+            Invoker selected = lb.select(weightInvokers, null, null);
 
             if (selected.getUrl().getProtocol().equals("test1")) {
                 sumInvoker1++;
@@ -98,6 +66,8 @@ public class LeastActiveBalanceTest extends LoadBalanceBaseTest {
         // the sumInvoker1 : sumInvoker2 approximately equal to 1: 9
         System.out.println(sumInvoker1);
         System.out.println(sumInvoker2);
+
+        Assert.assertEquals("select failed!", sumInvoker1 + sumInvoker2, loop);
     }
 
     class MyLeastActiveLoadBalance extends AbstractLoadBalance {

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/LeastActiveBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/LeastActiveBalanceTest.java
@@ -42,10 +42,10 @@ public class LeastActiveBalanceTest extends LoadBalanceBaseTest {
     public void testSelectByWeight() {
         int sumInvoker1 = 0;
         int sumInvoker2 = 0;
-        int loop = 100000;
+        int loop = 10000;
 
         LeastActiveLoadBalance lb = new LeastActiveLoadBalance();
-        for (int i = 0; i < 100000; i++) {
+        for (int i = 0; i < loop; i++) {
             Invoker selected = lb.select(weightInvokers, null, weightTestInvocation);
 
             if (selected.getUrl().getProtocol().equals("test1")) {

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/LoadBalanceBaseTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/LoadBalanceBaseTest.java
@@ -21,8 +21,9 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.RpcInvocation;
+import org.apache.dubbo.rpc.RpcStatus;
 import org.apache.dubbo.rpc.cluster.LoadBalance;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -49,6 +50,12 @@ public class LoadBalanceBaseTest {
     Invoker<LoadBalanceBaseTest> invoker3;
     Invoker<LoadBalanceBaseTest> invoker4;
     Invoker<LoadBalanceBaseTest> invoker5;
+
+    RpcStatus weightTestRpcStatus1;
+    RpcStatus weightTestRpcStatus2;
+    RpcStatus weightTestRpcStatus3;
+
+    RpcInvocation weightTestInvocation;
 
     /**
      * @throws java.lang.Exception
@@ -158,14 +165,22 @@ public class LoadBalanceBaseTest {
         weightInvoker2 = mock(Invoker.class);
         weightInvoker3 = mock(Invoker.class);
 
+        weightTestInvocation = new RpcInvocation();
+        weightTestInvocation.setMethodName("test");
+
         URL url1 = URL.valueOf("test1://0:1/DemoService");
         url1 = url1.addParameter(Constants.WEIGHT_KEY, 1);
+        url1 = url1.addParameter(weightTestInvocation.getMethodName() + "." + Constants.WEIGHT_KEY, 1);
         url1 = url1.addParameter("active", 0);
+
         URL url2 = URL.valueOf("test2://0:9/DemoService");
         url2 = url2.addParameter(Constants.WEIGHT_KEY, 9);
+        url2 = url2.addParameter(weightTestInvocation.getMethodName() + "." + Constants.WEIGHT_KEY, 9);
         url2 = url2.addParameter("active", 0);
+
         URL url3 = URL.valueOf("test3://1:6/DemoService");
         url3 = url3.addParameter(Constants.WEIGHT_KEY, 6);
+        url3 = url3.addParameter(weightTestInvocation.getMethodName() + "." + Constants.WEIGHT_KEY, 6);
         url3 = url3.addParameter("active", 1);
 
         given(weightInvoker1.isAvailable()).willReturn(true);
@@ -180,5 +195,12 @@ public class LoadBalanceBaseTest {
         weightInvokers.add(weightInvoker1);
         weightInvokers.add(weightInvoker2);
         weightInvokers.add(weightInvoker3);
+
+        weightTestRpcStatus1 = RpcStatus.getStatus(weightInvoker1.getUrl(), weightTestInvocation.getMethodName());
+        weightTestRpcStatus2 = RpcStatus.getStatus(weightInvoker2.getUrl(), weightTestInvocation.getMethodName());
+        weightTestRpcStatus3 = RpcStatus.getStatus(weightInvoker3.getUrl(), weightTestInvocation.getMethodName());
+
+        // weightTestRpcStatus3 active is 1
+        RpcStatus.beginCount(weightInvoker3.getUrl(), weightTestInvocation.getMethodName());
     }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/LoadBalanceBaseTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/LoadBalanceBaseTest.java
@@ -145,4 +145,34 @@ public class LoadBalanceBaseTest {
         return AbstractLoadBalance.calculateWarmupWeight(uptime, Constants.DEFAULT_WARMUP, Constants.DEFAULT_WEIGHT);
     }
 
+    /*------------------------------------test invokers for weight---------------------------------------*/
+
+    protected List<Invoker<LoadBalanceBaseTest>> weightInvokers = new ArrayList<Invoker<LoadBalanceBaseTest>>();
+    protected Invoker<LoadBalanceBaseTest> weightInvoker1;
+    protected Invoker<LoadBalanceBaseTest> weightInvoker2;
+    protected Invoker<LoadBalanceBaseTest> weightInvoker3;
+
+    @Before
+    public void before() throws Exception {
+        weightInvoker1 = mock(Invoker.class);
+        weightInvoker2 = mock(Invoker.class);
+        weightInvoker3 = mock(Invoker.class);
+
+        URL url1 = URL.valueOf("test1://0:1/DemoService");
+        URL url2 = URL.valueOf("test2://0:9/DemoService");
+        URL url3 = URL.valueOf("test3://1:6/DemoService");
+
+        given(weightInvoker1.isAvailable()).willReturn(true);
+        given(weightInvoker1.getUrl()).willReturn(url1);
+
+        given(weightInvoker2.isAvailable()).willReturn(true);
+        given(weightInvoker2.getUrl()).willReturn(url2);
+
+        given(weightInvoker3.isAvailable()).willReturn(true);
+        given(weightInvoker3.getUrl()).willReturn(url3);
+
+        weightInvokers.add(weightInvoker1);
+        weightInvokers.add(weightInvoker2);
+        weightInvokers.add(weightInvoker3);
+    }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/LoadBalanceBaseTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/LoadBalanceBaseTest.java
@@ -159,8 +159,14 @@ public class LoadBalanceBaseTest {
         weightInvoker3 = mock(Invoker.class);
 
         URL url1 = URL.valueOf("test1://0:1/DemoService");
+        url1 = url1.addParameter(Constants.WEIGHT_KEY, 1);
+        url1 = url1.addParameter("active", 0);
         URL url2 = URL.valueOf("test2://0:9/DemoService");
+        url2 = url2.addParameter(Constants.WEIGHT_KEY, 9);
+        url2 = url2.addParameter("active", 0);
         URL url3 = URL.valueOf("test3://1:6/DemoService");
+        url3 = url3.addParameter(Constants.WEIGHT_KEY, 6);
+        url3 = url3.addParameter("active", 1);
 
         given(weightInvoker1.isAvailable()).willReturn(true);
         given(weightInvoker1.getUrl()).willReturn(url1);

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RandomLoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RandomLoadBalanceTest.java
@@ -16,13 +16,17 @@
  */
 package org.apache.dubbo.rpc.cluster.loadbalance;
 
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcStatus;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -52,6 +56,75 @@ public class RandomLoadBalanceTest extends LoadBalanceBaseTest {
         Assert.assertEquals(0, counter.get(invoker3).intValue());
         Assert.assertEquals(0, counter.get(invoker4).intValue());
         Assert.assertEquals(0, counter.get(invoker5).intValue());
+    }
+
+    @Test
+    public void testSelectByWeight() {
+        int sumInvoker1 = 0;
+        int sumInvoker2 = 0;
+        int sumInvoker3 = 0;
+        int loop = 100000;
+
+        MyRandomLoadBalance lb = new MyRandomLoadBalance();
+        for (int i = 0; i < loop; i++) {
+            Invoker selected = lb.select(weightInvokers, null, null);
+
+            if (selected.getUrl().getProtocol().equals("test1")) {
+                sumInvoker1++;
+            }
+
+            if (selected.getUrl().getProtocol().equals("test2")) {
+                sumInvoker2++;
+            }
+
+            if (selected.getUrl().getProtocol().equals("test3")) {
+                sumInvoker3++;
+            }
+        }
+
+        // 1 : 9 : 6
+        System.out.println(sumInvoker1);
+        System.out.println(sumInvoker2);
+        System.out.println(sumInvoker3);
+        Assert.assertEquals("select failed!", sumInvoker1 + sumInvoker2 + sumInvoker3, loop);
+    }
+
+    class MyRandomLoadBalance extends AbstractLoadBalance {
+
+        public static final String NAME = "random";
+
+        private final Random random = new Random();
+
+        @Override
+        protected <T> Invoker<T> doSelect(List<Invoker<T>> invokers, URL url, Invocation invocation) {
+            int length = invokers.size(); // Number of invokers
+            int totalWeight = 0; // The sum of weights
+            boolean sameWeight = true; // Every invoker has the same weight?
+            for (int i = 0; i < length; i++) {
+
+                // mock weight
+                int weight = invokers.get(i).getUrl().getPort();
+
+                totalWeight += weight; // Sum
+                if (sameWeight && i > 0
+                        && weight != invokers.get(i - 1).getUrl().getPort()) {
+                    sameWeight = false;
+                }
+            }
+            if (totalWeight > 0 && !sameWeight) {
+                // If (not every invoker has the same weight & at least one invoker's weight>0), select randomly based on totalWeight.
+                int offset = random.nextInt(totalWeight);
+                // Return a invoker based on the random value.
+                for (int i = 0; i < length; i++) {
+                    offset -= invokers.get(i).getUrl().getPort();
+                    if (offset < 0) {
+                        return invokers.get(i);
+                    }
+                }
+            }
+            // If all invokers have the same weight value or totalWeight=0, return evenly.
+            return invokers.get(random.nextInt(length));
+        }
     }
 
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RandomLoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RandomLoadBalanceTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.rpc.cluster.loadbalance;
 
+import org.apache.dubbo.common.Constants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
@@ -103,11 +104,11 @@ public class RandomLoadBalanceTest extends LoadBalanceBaseTest {
             for (int i = 0; i < length; i++) {
 
                 // mock weight
-                int weight = invokers.get(i).getUrl().getPort();
+                int weight = invokers.get(i).getUrl().getParameter(Constants.WEIGHT_KEY, Constants.DEFAULT_WEIGHT);
 
                 totalWeight += weight; // Sum
                 if (sameWeight && i > 0
-                        && weight != invokers.get(i - 1).getUrl().getPort()) {
+                        && weight != invokers.get(i - 1).getUrl().getParameter(Constants.WEIGHT_KEY, Constants.DEFAULT_WEIGHT)) {
                     sameWeight = false;
                 }
             }
@@ -116,7 +117,7 @@ public class RandomLoadBalanceTest extends LoadBalanceBaseTest {
                 int offset = random.nextInt(totalWeight);
                 // Return a invoker based on the random value.
                 for (int i = 0; i < length; i++) {
-                    offset -= invokers.get(i).getUrl().getPort();
+                    offset -= invokers.get(i).getUrl().getParameter(Constants.WEIGHT_KEY, Constants.DEFAULT_WEIGHT);
                     if (offset < 0) {
                         return invokers.get(i);
                     }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RandomLoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RandomLoadBalanceTest.java
@@ -16,18 +16,12 @@
  */
 package org.apache.dubbo.rpc.cluster.loadbalance;
 
-import org.apache.dubbo.common.Constants;
-import org.apache.dubbo.common.URL;
-import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcStatus;
-
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -66,9 +60,9 @@ public class RandomLoadBalanceTest extends LoadBalanceBaseTest {
         int sumInvoker3 = 0;
         int loop = 100000;
 
-        MyRandomLoadBalance lb = new MyRandomLoadBalance();
+        RandomLoadBalance lb = new RandomLoadBalance();
         for (int i = 0; i < loop; i++) {
-            Invoker selected = lb.select(weightInvokers, null, null);
+            Invoker selected = lb.select(weightInvokers, null, weightTestInvocation);
 
             if (selected.getUrl().getProtocol().equals("test1")) {
                 sumInvoker1++;
@@ -88,44 +82,6 @@ public class RandomLoadBalanceTest extends LoadBalanceBaseTest {
         System.out.println(sumInvoker2);
         System.out.println(sumInvoker3);
         Assert.assertEquals("select failed!", sumInvoker1 + sumInvoker2 + sumInvoker3, loop);
-    }
-
-    class MyRandomLoadBalance extends AbstractLoadBalance {
-
-        public static final String NAME = "random";
-
-        private final Random random = new Random();
-
-        @Override
-        protected <T> Invoker<T> doSelect(List<Invoker<T>> invokers, URL url, Invocation invocation) {
-            int length = invokers.size(); // Number of invokers
-            int totalWeight = 0; // The sum of weights
-            boolean sameWeight = true; // Every invoker has the same weight?
-            for (int i = 0; i < length; i++) {
-
-                // mock weight
-                int weight = invokers.get(i).getUrl().getParameter(Constants.WEIGHT_KEY, Constants.DEFAULT_WEIGHT);
-
-                totalWeight += weight; // Sum
-                if (sameWeight && i > 0
-                        && weight != invokers.get(i - 1).getUrl().getParameter(Constants.WEIGHT_KEY, Constants.DEFAULT_WEIGHT)) {
-                    sameWeight = false;
-                }
-            }
-            if (totalWeight > 0 && !sameWeight) {
-                // If (not every invoker has the same weight & at least one invoker's weight>0), select randomly based on totalWeight.
-                int offset = random.nextInt(totalWeight);
-                // Return a invoker based on the random value.
-                for (int i = 0; i < length; i++) {
-                    offset -= invokers.get(i).getUrl().getParameter(Constants.WEIGHT_KEY, Constants.DEFAULT_WEIGHT);
-                    if (offset < 0) {
-                        return invokers.get(i);
-                    }
-                }
-            }
-            // If all invokers have the same weight value or totalWeight=0, return evenly.
-            return invokers.get(random.nextInt(length));
-        }
     }
 
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RandomLoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RandomLoadBalanceTest.java
@@ -58,7 +58,7 @@ public class RandomLoadBalanceTest extends LoadBalanceBaseTest {
         int sumInvoker1 = 0;
         int sumInvoker2 = 0;
         int sumInvoker3 = 0;
-        int loop = 100000;
+        int loop = 10000;
 
         RandomLoadBalance lb = new RandomLoadBalance();
         for (int i = 0; i < loop; i++) {

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RoundRobinLoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RoundRobinLoadBalanceTest.java
@@ -16,12 +16,19 @@
  */
 package org.apache.dubbo.rpc.cluster.loadbalance;
 
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.AtomicPositiveInteger;
+import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class RoundRobinLoadBalanceTest extends LoadBalanceBaseTest {
@@ -32,6 +39,109 @@ public class RoundRobinLoadBalanceTest extends LoadBalanceBaseTest {
         for (Invoker minvoker : counter.keySet()) {
             Long count = counter.get(minvoker).get();
             Assert.assertTrue("abs diff should < 1", Math.abs(count - runs / (0f + invokers.size())) < 1f);
+        }
+    }
+
+    @Test
+    public void testSelectByWeight() {
+        int sumInvoker1 = 0;
+        int sumInvoker2 = 0;
+        int sumInvoker3 = 0;
+        int loop = 100000;
+
+        MyRoundRobinLoadBalance lb = new MyRoundRobinLoadBalance();
+        for (int i = 0; i < loop; i++) {
+            Invoker selected = lb.select(weightInvokers, null, null);
+
+            if (selected.getUrl().getProtocol().equals("test1")) {
+                sumInvoker1++;
+            }
+
+            if (selected.getUrl().getProtocol().equals("test2")) {
+                sumInvoker2++;
+            }
+
+            if (selected.getUrl().getProtocol().equals("test3")) {
+                sumInvoker3++;
+            }
+        }
+
+        // 1 : 9 : 6
+        System.out.println(sumInvoker1);
+        System.out.println(sumInvoker2);
+        System.out.println(sumInvoker3);
+        Assert.assertEquals("select failed!", sumInvoker1 + sumInvoker2 + sumInvoker3, loop);
+    }
+
+    class MyRoundRobinLoadBalance extends AbstractLoadBalance {
+
+        public static final String NAME = "roundrobin";
+
+        private final ConcurrentMap<String, AtomicPositiveInteger> sequences = new ConcurrentHashMap<String, AtomicPositiveInteger>();
+
+        @Override
+        protected <T> Invoker<T> doSelect(List<Invoker<T>> invokers, URL url, Invocation invocation) {
+            String key = "method1";
+            int length = invokers.size(); // Number of invokers
+            int maxWeight = 0; // The maximum weight
+            int minWeight = Integer.MAX_VALUE; // The minimum weight
+            final LinkedHashMap<Invoker<T>, IntegerWrapper> invokerToWeightMap = new LinkedHashMap<Invoker<T>, IntegerWrapper>();
+            int weightSum = 0;
+            for (int i = 0; i < length; i++) {
+
+                int weight = invokers.get(i).getUrl().getPort();
+
+                maxWeight = Math.max(maxWeight, weight); // Choose the maximum weight
+                minWeight = Math.min(minWeight, weight); // Choose the minimum weight
+                if (weight > 0) {
+                    invokerToWeightMap.put(invokers.get(i), new IntegerWrapper(weight));
+                    weightSum += weight;
+                }
+            }
+            AtomicPositiveInteger sequence = sequences.get(key);
+            if (sequence == null) {
+                sequences.putIfAbsent(key, new AtomicPositiveInteger());
+                sequence = sequences.get(key);
+            }
+            int currentSequence = sequence.getAndIncrement();
+            if (maxWeight > 0 && minWeight < maxWeight) {
+                int mod = currentSequence % weightSum;
+                for (int i = 0; i < maxWeight; i++) {
+                    for (Map.Entry<Invoker<T>, IntegerWrapper> each : invokerToWeightMap.entrySet()) {
+                        final Invoker<T> k = each.getKey();
+                        final IntegerWrapper v = each.getValue();
+                        if (mod == 0 && v.getValue() > 0) {
+                            return k;
+                        }
+                        if (v.getValue() > 0) {
+                            v.decrement();
+                            mod--;
+                        }
+                    }
+                }
+            }
+            // Round robin
+            return invokers.get(currentSequence % length);
+        }
+
+        private final class IntegerWrapper {
+            private int value;
+
+            public IntegerWrapper(int value) {
+                this.value = value;
+            }
+
+            public int getValue() {
+                return value;
+            }
+
+            public void setValue(int value) {
+                this.value = value;
+            }
+
+            public void decrement() {
+                this.value--;
+            }
         }
     }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RoundRobinLoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RoundRobinLoadBalanceTest.java
@@ -39,7 +39,7 @@ public class RoundRobinLoadBalanceTest extends LoadBalanceBaseTest {
         int sumInvoker1 = 0;
         int sumInvoker2 = 0;
         int sumInvoker3 = 0;
-        int loop = 100000;
+        int loop = 10000;
 
         RoundRobinLoadBalance lb = new RoundRobinLoadBalance();
         for (int i = 0; i < loop; i++) {

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RoundRobinLoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RoundRobinLoadBalanceTest.java
@@ -16,20 +16,11 @@
  */
 package org.apache.dubbo.rpc.cluster.loadbalance;
 
-import org.apache.dubbo.common.Constants;
-import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.utils.AtomicPositiveInteger;
-import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
-
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class RoundRobinLoadBalanceTest extends LoadBalanceBaseTest {
@@ -50,9 +41,9 @@ public class RoundRobinLoadBalanceTest extends LoadBalanceBaseTest {
         int sumInvoker3 = 0;
         int loop = 100000;
 
-        MyRoundRobinLoadBalance lb = new MyRoundRobinLoadBalance();
+        RoundRobinLoadBalance lb = new RoundRobinLoadBalance();
         for (int i = 0; i < loop; i++) {
-            Invoker selected = lb.select(weightInvokers, null, null);
+            Invoker selected = lb.select(weightInvokers, null, weightTestInvocation);
 
             if (selected.getUrl().getProtocol().equals("test1")) {
                 sumInvoker1++;
@@ -74,75 +65,4 @@ public class RoundRobinLoadBalanceTest extends LoadBalanceBaseTest {
         Assert.assertEquals("select failed!", sumInvoker1 + sumInvoker2 + sumInvoker3, loop);
     }
 
-    class MyRoundRobinLoadBalance extends AbstractLoadBalance {
-
-        public static final String NAME = "roundrobin";
-
-        private final ConcurrentMap<String, AtomicPositiveInteger> sequences = new ConcurrentHashMap<String, AtomicPositiveInteger>();
-
-        @Override
-        protected <T> Invoker<T> doSelect(List<Invoker<T>> invokers, URL url, Invocation invocation) {
-            String key = "method1";
-            int length = invokers.size(); // Number of invokers
-            int maxWeight = 0; // The maximum weight
-            int minWeight = Integer.MAX_VALUE; // The minimum weight
-            final LinkedHashMap<Invoker<T>, IntegerWrapper> invokerToWeightMap = new LinkedHashMap<Invoker<T>, IntegerWrapper>();
-            int weightSum = 0;
-            for (int i = 0; i < length; i++) {
-
-                int weight = invokers.get(i).getUrl().getParameter(Constants.WEIGHT_KEY, Constants.DEFAULT_WEIGHT);
-
-                maxWeight = Math.max(maxWeight, weight); // Choose the maximum weight
-                minWeight = Math.min(minWeight, weight); // Choose the minimum weight
-                if (weight > 0) {
-                    invokerToWeightMap.put(invokers.get(i), new IntegerWrapper(weight));
-                    weightSum += weight;
-                }
-            }
-            AtomicPositiveInteger sequence = sequences.get(key);
-            if (sequence == null) {
-                sequences.putIfAbsent(key, new AtomicPositiveInteger());
-                sequence = sequences.get(key);
-            }
-            int currentSequence = sequence.getAndIncrement();
-            if (maxWeight > 0 && minWeight < maxWeight) {
-                int mod = currentSequence % weightSum;
-                for (int i = 0; i < maxWeight; i++) {
-                    for (Map.Entry<Invoker<T>, IntegerWrapper> each : invokerToWeightMap.entrySet()) {
-                        final Invoker<T> k = each.getKey();
-                        final IntegerWrapper v = each.getValue();
-                        if (mod == 0 && v.getValue() > 0) {
-                            return k;
-                        }
-                        if (v.getValue() > 0) {
-                            v.decrement();
-                            mod--;
-                        }
-                    }
-                }
-            }
-            // Round robin
-            return invokers.get(currentSequence % length);
-        }
-
-        private final class IntegerWrapper {
-            private int value;
-
-            public IntegerWrapper(int value) {
-                this.value = value;
-            }
-
-            public int getValue() {
-                return value;
-            }
-
-            public void setValue(int value) {
-                this.value = value;
-            }
-
-            public void decrement() {
-                this.value--;
-            }
-        }
-    }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RoundRobinLoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RoundRobinLoadBalanceTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.rpc.cluster.loadbalance;
 
+import org.apache.dubbo.common.Constants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.utils.AtomicPositiveInteger;
 import org.apache.dubbo.rpc.Invocation;
@@ -89,7 +90,7 @@ public class RoundRobinLoadBalanceTest extends LoadBalanceBaseTest {
             int weightSum = 0;
             for (int i = 0; i < length; i++) {
 
-                int weight = invokers.get(i).getUrl().getPort();
+                int weight = invokers.get(i).getUrl().getParameter(Constants.WEIGHT_KEY, Constants.DEFAULT_WEIGHT);
 
                 maxWeight = Math.max(maxWeight, weight); // Choose the maximum weight
                 minWeight = Math.min(minWeight, weight); // Choose the minimum weight


### PR DESCRIPTION
Now the select is select a random one when there are several least active invokers and all of them are in warm up.
After this pr, it will select also by weight and warm up.

And fix a bug when two invoker's active is same and weight not same.

issue:
https://github.com/apache/incubator-dubbo/issues/904