### PR TITLE
fix a compile error about file EagerThreadPoolExecutor.java

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/eager/EagerThreadPoolExecutor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/eager/EagerThreadPoolExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.dubbo.common.threadpool.support.eager;
 
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -79,7 +80,7 @@ public class EagerThreadPoolExecutor extends ThreadPoolExecutor {
         } catch (Throwable t) {
             // decrease any way
             submittedTaskCount.decrementAndGet();
-            throw t;
+            throw new CompletionException(t);
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

early version:  last line
```
@Override
    public void execute(Runnable command) {
        if (command == null) {
            throw new NullPointerException();
        }
        // do not increment in method beforeExecute!
        submittedTaskCount.incrementAndGet();
        try {
            super.execute(command);
        } catch (RejectedExecutionException rx) {
            // retry to offer the task into queue.
            final TaskQueue queue = (TaskQueue) super.getQueue();
            try {
                if (!queue.retryOffer(command, 0, TimeUnit.MILLISECONDS)) {
                    submittedTaskCount.decrementAndGet();
                    throw new RejectedExecutionException("Queue capacity is full.", rx);
                }
            } catch (InterruptedException x) {
                submittedTaskCount.decrementAndGet();
                throw new RejectedExecutionException(x);
            }
        } catch (Throwable t) {
            // decrease any way
            submittedTaskCount.decrementAndGet();
            throw t;
        }
    }
```
cannot throw Throwable object directly without declared


## Brief changelog

cannot throw Throwable object directly without declared in file EagerThreadPoolExecutor.java

