### PR TITLE
[Dubbo-2136] Replace hard coded version number of hessian-lite with unified property variable

### DIFF
--- a/dubbo-common/pom.xml
+++ b/dubbo-common/pom.xml
@@ -28,6 +28,7 @@
     <description>The common module of dubbo project</description>
     <properties>
         <skip_maven_deploy>false</skip_maven_deploy>
+        <hessian_lite_version>3.2.3</hessian_lite_version>
     </properties>
     <dependencies>
         <dependency>
@@ -50,7 +51,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>hessian-lite</artifactId>
-            <version>3.2.3</version>
+            <version>${hessian_lite_version}</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>


### PR DESCRIPTION
Signed-off-by: Woody Huang <woody1573@163.com>

## What is the purpose of the change

Solve Issue #2136, Replace hard coded version number of hessian-lite with unified property variable

## Brief changelog

- Modified `dubbo-common/pom.xml` file, add `hessian_lite_version` variable to represent hessian lite version

## Verifying this change

- Exsiting unit-test and intergration-test passed

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
