### PR TITLE
[Dubbo-issue-2184] Fix Return the hanging client requests ASAP. when connection is broken unexpectedly. #2184

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
@@ -248,6 +248,10 @@ public class Constants {
 
     public static final String HEARTBEAT_TIMEOUT_KEY = "heartbeat.timeout";
 
+    public static final String HEARTBEAT_RECONNECT = "heartbeat.reconnect";
+
+    public static final Boolean DEFAULT_HEARTBEAT_RECONNECT = true;
+
     public static final String CONNECT_TIMEOUT_KEY = "connect.timeout";
 
     public static final String TIMEOUT_KEY = "timeout";

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeartBeatTask.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeartBeatTask.java
@@ -17,6 +17,7 @@
 
 package org.apache.dubbo.remoting.exchange.support.header;
 
+import org.apache.dubbo.common.Constants;
 import org.apache.dubbo.common.Version;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
@@ -70,7 +71,8 @@ final class HeartBeatTask implements Runnable {
                     if (lastRead != null && now - lastRead > heartbeatTimeout) {
                         logger.warn("Close channel " + channel
                                 + ", because heartbeat read idle time out: " + heartbeatTimeout + "ms");
-                        if (channel instanceof Client) {
+
+                        if (channel instanceof Client && channel.getUrl().getParameter(Constants.HEARTBEAT_RECONNECT, Constants.DEFAULT_HEARTBEAT_RECONNECT)) {
                             try {
                                 ((Client) channel).reconnect();
                             } catch (Exception e) {


### PR DESCRIPTION
## What is the purpose of the change

Fix Return the hanging client requests ASAP. when connection is broken unexpectedly. #2184

## Brief changelog

add the configuration of heartbeat reconnect, default true, if set false, when heartbeat timeout, consumer disconnect

## Verifying this change

org.apache.dubbo.common.Constants
org.apache.dubbo.remoting.exchange.support.header.HeartBeatTask

From Baiji, Term 268, Team 3, Issue #2184, Q3-5
