### PR TITLE
[Dubbo-2178] Supporting Java 8 Date/Time type when serializing with Kryo #2178 

### DIFF
--- a/dubbo-serialization/dubbo-serialization-kryo/src/main/java/org/apache/dubbo/common/serialize/kryo/ExtensionKryo.java
+++ b/dubbo-serialization/dubbo-serialization-kryo/src/main/java/org/apache/dubbo/common/serialize/kryo/ExtensionKryo.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.serialize.kryo;
+
+import com.esotericsoftware.kryo.Serializer;
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.serialize.kryo.serializer.CommonJavaSerializer;
+import org.apache.dubbo.common.serialize.kryo.utils.ReflectionUtils;
+import sun.reflect.ReflectionFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ExtensionKryo extends CompatibleKryo {
+
+    private static ReflectionFactory reflectionFactory = ReflectionFactory
+            .getReflectionFactory();
+
+    private static final Logger logger = LoggerFactory.getLogger(ExtensionKryo.class);
+
+    private static ConcurrentHashMap<Class<?>, Constructor<?>> constructorCache = new ConcurrentHashMap<>();
+
+    @Override
+    public Serializer getDefaultSerializer(Class type) {
+        if (type == null) {
+            throw new IllegalArgumentException("type cannot be null.");
+        }
+
+        // 对于这些类型的  ：array 、enum、没有默认构造器的类
+        if (!type.isArray() && !type.isEnum() && !ReflectionUtils.checkZeroArgConstructor(type)) {
+            return new CommonJavaSerializer();
+        }
+        return super.getDefaultSerializer(type);
+    }
+
+    @Override
+    public <T> T newInstance(Class<T> type) {
+        try {
+            return super.newInstance(type);
+        } catch (Exception e) {
+            return newInstanceByReflection(type);
+        }
+    }
+
+    @SuppressWarnings("all")
+    private <T> T newInstanceByReflection(Class<T> type) {
+        Object instance = null;
+        try {
+            Constructor<?> constructor = constructorCache.get(type);
+            if (constructor == null) {
+                constructor = reflectionFactory.newConstructorForSerialization(type,
+                        Object.class.getDeclaredConstructor());
+                constructorCache.putIfAbsent(type, constructor);
+                // in order to improve reflection performance
+                constructor.setAccessible(true);
+            }
+            instance = constructor.newInstance();
+            return (T) instance;
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            logger.error(type.getName() + "unable to be serialized", e);
+            e.printStackTrace();
+        }
+        return (T) instance;
+    }
+}

--- a/dubbo-serialization/dubbo-serialization-kryo/src/main/java/org/apache/dubbo/common/serialize/kryo/serializer/CommonJavaSerializer.java
+++ b/dubbo-serialization/dubbo-serialization-kryo/src/main/java/org/apache/dubbo/common/serialize/kryo/serializer/CommonJavaSerializer.java
@@ -1,0 +1,21 @@
+package org.apache.dubbo.common.serialize.kryo.serializer;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.JavaSerializer;
+import org.apache.dubbo.common.serialize.kryo.CompatibleKryo;
+
+public class CommonJavaSerializer extends JavaSerializer {
+    private Kryo kryo = new CompatibleKryo();
+
+    @Override
+    public void write(Kryo kryo, Output output, Object object) {
+        super.write(this.kryo, output, object);
+    }
+
+    @Override
+    public Object read(Kryo kryo, Input input, Class type) {
+        return super.read(this.kryo, input, type);
+    }
+}

--- a/dubbo-serialization/dubbo-serialization-kryo/src/main/java/org/apache/dubbo/common/serialize/kryo/serializer/CommonJavaSerializer.java
+++ b/dubbo-serialization/dubbo-serialization-kryo/src/main/java/org/apache/dubbo/common/serialize/kryo/serializer/CommonJavaSerializer.java
@@ -4,10 +4,10 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.JavaSerializer;
-import org.apache.dubbo.common.serialize.kryo.CompatibleKryo;
+import org.apache.dubbo.common.serialize.kryo.ExtensionKryo;
 
 public class CommonJavaSerializer extends JavaSerializer {
-    private Kryo kryo = new CompatibleKryo();
+    private Kryo kryo = new ExtensionKryo();
 
     @Override
     public void write(Kryo kryo, Output output, Object object) {

--- a/dubbo-serialization/dubbo-serialization-kryo/src/main/java/org/apache/dubbo/common/serialize/kryo/utils/AbstractKryoFactory.java
+++ b/dubbo-serialization/dubbo-serialization-kryo/src/main/java/org/apache/dubbo/common/serialize/kryo/utils/AbstractKryoFactory.java
@@ -16,42 +16,19 @@
  */
 package org.apache.dubbo.common.serialize.kryo.utils;
 
-import org.apache.dubbo.common.serialize.kryo.CompatibleKryo;
-import org.apache.dubbo.common.serialize.support.SerializableClassRegistry;
-
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.pool.KryoFactory;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers;
-import de.javakaffee.kryoserializers.ArraysAsListSerializer;
-import de.javakaffee.kryoserializers.BitSetSerializer;
-import de.javakaffee.kryoserializers.GregorianCalendarSerializer;
-import de.javakaffee.kryoserializers.JdkProxySerializer;
-import de.javakaffee.kryoserializers.RegexSerializer;
-import de.javakaffee.kryoserializers.SynchronizedCollectionsSerializer;
-import de.javakaffee.kryoserializers.URISerializer;
-import de.javakaffee.kryoserializers.UUIDSerializer;
-import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer;
+import de.javakaffee.kryoserializers.*;
+import org.apache.dubbo.common.serialize.kryo.ExtensionKryo;
+import org.apache.dubbo.common.serialize.support.SerializableClassRegistry;
 
 import java.lang.reflect.InvocationHandler;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.BitSet;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Hashtable;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.UUID;
-import java.util.Vector;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
@@ -86,7 +63,7 @@ public abstract class AbstractKryoFactory implements KryoFactory {
             kryoCreated = true;
         }
 
-        Kryo kryo = new CompatibleKryo();
+        Kryo kryo = new ExtensionKryo();
 
         // TODO
 //        kryo.setReferences(false);

--- a/dubbo-serialization/dubbo-serialization-kryo/src/test/java/org/apache/dubbo/common/serialize/kryo/CompatibleKryoTest.java
+++ b/dubbo-serialization/dubbo-serialization-kryo/src/test/java/org/apache/dubbo/common/serialize/kryo/CompatibleKryoTest.java
@@ -1,0 +1,42 @@
+package org.apache.dubbo.common.serialize.kryo;
+
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.serializers.DefaultSerializers;
+import org.apache.dubbo.common.serialize.kryo.serializer.CommonJavaSerializer;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+import static org.junit.Assert.*;
+
+public class CompatibleKryoTest {
+
+    CompatibleKryo compatibleKryo = new CompatibleKryo();
+
+    @Test
+    public void getDefaultSerializer(){
+        Serializer longSerializer = compatibleKryo.getDefaultSerializer(Long.class);
+        assertEquals(CommonJavaSerializer.class, longSerializer.getClass());
+
+        Serializer localDateTimeSerializer = compatibleKryo.getDefaultSerializer(LocalDateTime.class);
+        assertEquals(CommonJavaSerializer.class, localDateTimeSerializer.getClass());
+
+        Serializer dateSerializer = compatibleKryo.getDefaultSerializer(Date.class);
+        assertEquals(DefaultSerializers.DateSerializer.class, dateSerializer.getClass());
+
+        Serializer byteSerializer = compatibleKryo.getDefaultSerializer(Byte.class);
+        assertEquals(CommonJavaSerializer.class, byteSerializer.getClass());
+
+    }
+
+    @Test
+    public void newInstance() {
+        Long longInstance = compatibleKryo.newInstance(Long.class);
+        LocalDateTime localTimeInstance = compatibleKryo.newInstance(LocalDateTime.class);
+        Date dateInstance = compatibleKryo.newInstance(Date.class);
+        assertNotNull(localTimeInstance);
+        assertNotNull(dateInstance);
+        assertNotNull(longInstance);
+    }
+}

--- a/dubbo-serialization/dubbo-serialization-kryo/src/test/java/org/apache/dubbo/common/serialize/kryo/ExtensionKryoTest.java
+++ b/dubbo-serialization/dubbo-serialization-kryo/src/test/java/org/apache/dubbo/common/serialize/kryo/ExtensionKryoTest.java
@@ -1,5 +1,6 @@
 package org.apache.dubbo.common.serialize.kryo;
 
+import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers;
 import org.apache.dubbo.common.serialize.kryo.serializer.CommonJavaSerializer;
@@ -8,33 +9,34 @@ import org.junit.Test;
 import java.time.LocalDateTime;
 import java.util.Date;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-public class CompatibleKryoTest {
+public class ExtensionKryoTest {
 
-    CompatibleKryo compatibleKryo = new CompatibleKryo();
+    private Kryo extensionKryo = new ExtensionKryo();
 
     @Test
     public void getDefaultSerializer(){
-        Serializer longSerializer = compatibleKryo.getDefaultSerializer(Long.class);
+        Serializer longSerializer = extensionKryo.getDefaultSerializer(Long.class);
         assertEquals(CommonJavaSerializer.class, longSerializer.getClass());
 
-        Serializer localDateTimeSerializer = compatibleKryo.getDefaultSerializer(LocalDateTime.class);
+        Serializer localDateTimeSerializer = extensionKryo.getDefaultSerializer(LocalDateTime.class);
         assertEquals(CommonJavaSerializer.class, localDateTimeSerializer.getClass());
 
-        Serializer dateSerializer = compatibleKryo.getDefaultSerializer(Date.class);
+        Serializer dateSerializer = extensionKryo.getDefaultSerializer(Date.class);
         assertEquals(DefaultSerializers.DateSerializer.class, dateSerializer.getClass());
 
-        Serializer byteSerializer = compatibleKryo.getDefaultSerializer(Byte.class);
+        Serializer byteSerializer = extensionKryo.getDefaultSerializer(Byte.class);
         assertEquals(CommonJavaSerializer.class, byteSerializer.getClass());
 
     }
 
     @Test
     public void newInstance() {
-        Long longInstance = compatibleKryo.newInstance(Long.class);
-        LocalDateTime localTimeInstance = compatibleKryo.newInstance(LocalDateTime.class);
-        Date dateInstance = compatibleKryo.newInstance(Date.class);
+        Long longInstance = extensionKryo.newInstance(Long.class);
+        LocalDateTime localTimeInstance = extensionKryo.newInstance(LocalDateTime.class);
+        Date dateInstance = extensionKryo.newInstance(Date.class);
         assertNotNull(localTimeInstance);
         assertNotNull(dateInstance);
         assertNotNull(longInstance);


### PR DESCRIPTION
## What is the purpose of the change
修复 #2178 对于空构造函数的 kryo 序列化问题

## Brief changelog
写了一个 kryo 的拓展类，增强 kryo 序列化能力

## Verifying this change
包含单元测试，测试全部通过

## Way
由于 kryo 工具在作对象序列化的时候会调用到对象的默认构造方法，但是对于 LocalDateTime 这一类的类没有默认构造方法导致序列化失败。
对 kryo 的序列化类进行拓展，对于这一些特殊类，在它无法找到对应的序列化器，可以使用反射工厂生成对应的默认构造函数。

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
