### PR TITLE
[Dubbo-issue-2136] Replace hard coded version number of hessian-lite with unified property variable. #2136

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -71,6 +71,10 @@
         <url>https://github.com/apache/incubator-dubbo/issues</url>
     </issueManagement>
 
+    <properties>
+        <hessian_lite_version>3.2.3</hessian_lite_version>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -291,7 +295,7 @@
             <dependency>
                 <groupId>com.alibaba</groupId>
                 <artifactId>hessian-lite</artifactId>
-                <version>3.2.3</version>
+                <version>${hessian_lite_version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/dubbo-serialization/dubbo-serialization-kryo/src/main/java/org/apache/dubbo/common/serialize/kryo/CompatibleKryo.java
+++ b/dubbo-serialization/dubbo-serialization-kryo/src/main/java/org/apache/dubbo/common/serialize/kryo/CompatibleKryo.java
@@ -24,6 +24,10 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.serializers.JavaSerializer;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
 public class CompatibleKryo extends Kryo {
 
     private static final Logger logger = LoggerFactory.getLogger(CompatibleKryo.class);
@@ -34,7 +38,7 @@ public class CompatibleKryo extends Kryo {
             throw new IllegalArgumentException("type cannot be null.");
         }
 
-        if (!type.isArray() && !type.isEnum() && !ReflectionUtils.checkZeroArgConstructor(type)) {
+        if (!type.isArray() && !type.isEnum() && !type.equals(LocalDate.class) && !type.equals(LocalDateTime.class) && !type.equals(LocalTime.class) && !ReflectionUtils.checkZeroArgConstructor(type)) {
             if (logger.isWarnEnabled()) {
                 logger.warn(type + " has no zero-arg constructor and this will affect the serialization performance");
             }


### PR DESCRIPTION
## What is the purpose of the change

Replace hard coded version number of hessian-lite with unified property variable. #2136

## Brief changelog

Replace hard coded version number of hessian-lite with unified property variable. 

## Verifying this change

dubbo-bom/pom.xml

From Baiji, Term 268, Team 3, Issue #2136, Q3-2
