### PR TITLE
bug fix to 2218_team8

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/support/TelnetHandlerAdapter.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/support/TelnetHandlerAdapter.java
@@ -56,7 +56,11 @@ public class TelnetHandlerAdapter extends ChannelHandlerAdapter implements Telne
                     }
                     buf.append(result);
                 } catch (Throwable t) {
-                    buf.append(t.getMessage());
+                    if (t instanceof NullPointerException) {
+                        buf.append("Parameters can't be null");
+                    }else {
+                        buf.append(t.getMessage());
+                    }
                 }
             } else {
                 buf.append("Unsupported command: ");


### PR DESCRIPTION
## What is the purpose of the change

#2218 
When user use telnet to invoke org.apache.dubbo.demo.DemoService#sayHello and the parameter
is null, he gets a response called "null".The change is to make response more understandably.

## Brief changelog

When catch NPE,return "parameters can't be null"

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
