### PR TITLE
[Dubbo-#2218] fix judgment of telnet "invoke" null #2218  team 1

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/support/TelnetHandlerAdapter.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/support/TelnetHandlerAdapter.java
@@ -56,7 +56,11 @@ public class TelnetHandlerAdapter extends ChannelHandlerAdapter implements Telne
                     }
                     buf.append(result);
                 } catch (Throwable t) {
-                    buf.append(t.getMessage());
+                    if (t instanceof NullPointerException) {
+                        buf.append("Param can't be null");
+                    }else {
+                        buf.append(t.getMessage());
+                    }
                 }
             } else {
                 buf.append("Unsupported command: ");


### PR DESCRIPTION
From baiji, term 269, team 1, issue #2218, Q3.1
## What is the purpose of the change
fix #2218 When using telnet "invoke" method, if there is a [null] param, the response always be [null] 

## Brief changelog
Add a check before use it 

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
