### PR TITLE
fix the problem #1713_team10

### DIFF
--- a/dubbo-common/pom.xml
+++ b/dubbo-common/pom.xml
@@ -44,6 +44,14 @@
             <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
         </dependency>

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/logger/LoggerFactory.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/logger/LoggerFactory.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.logger.jcl.JclLoggerAdapter;
 import org.apache.dubbo.common.logger.jdk.JdkLoggerAdapter;
 import org.apache.dubbo.common.logger.log4j.Log4jLoggerAdapter;
+import org.apache.dubbo.common.logger.log4j2.Log4j2LoggerAdapter;
 import org.apache.dubbo.common.logger.slf4j.Slf4jLoggerAdapter;
 import org.apache.dubbo.common.logger.support.FailsafeLogger;
 
@@ -30,6 +31,7 @@ import java.util.concurrent.ConcurrentMap;
 
 /**
  * Logger factory
+ * add log4j2, to be compatible with old version, we keep log4j
  */
 public class LoggerFactory {
 
@@ -37,6 +39,7 @@ public class LoggerFactory {
     private static volatile LoggerAdapter LOGGER_ADAPTER;
 
     // search common-used logging frameworks
+
     static {
         String logger = System.getProperty("dubbo.application.logger");
         if ("slf4j".equals(logger)) {
@@ -47,6 +50,8 @@ public class LoggerFactory {
             setLoggerAdapter(new Log4jLoggerAdapter());
         } else if ("jdk".equals(logger)) {
             setLoggerAdapter(new JdkLoggerAdapter());
+        } else if("log4j2".equals(logger)){
+            setLoggerAdapter(new Log4j2LoggerAdapter());
         } else {
             try {
                 setLoggerAdapter(new Log4jLoggerAdapter());

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/logger/log4j2/Log4j2Logger.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/logger/log4j2/Log4j2Logger.java
@@ -1,0 +1,117 @@
+package org.apache.dubbo.common.logger.log4j2;
+
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.support.FailsafeLogger;
+import org.apache.log4j.Level;
+
+public class Log4j2Logger implements Logger {
+
+    private static final String FQCN = FailsafeLogger.class.getName();
+
+    private org.apache.logging.log4j.Logger logger;
+
+    public Log4j2Logger(org.apache.logging.log4j.Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void trace(String msg) {
+        logger.trace(FQCN, Level.TRACE, msg, null);
+    }
+
+    @Override
+    public void trace(Throwable e) {
+        logger.trace(FQCN, e == null ? null : e.getMessage(), e);
+    }
+
+    @Override
+    public void trace(String msg, Throwable e) {
+        logger.trace(FQCN, msg, e);
+    }
+
+    @Override
+    public void debug(String msg) {
+        logger.debug(FQCN, msg, null);
+    }
+
+    @Override
+    public void debug(Throwable e) {
+        logger.debug(FQCN, e == null ? null : e.getMessage(), e);
+    }
+
+    @Override
+    public void debug(String msg, Throwable e) {
+        logger.debug(FQCN, msg, e);
+    }
+
+    @Override
+    public void info(String msg) {
+        logger.info(FQCN, msg, null);
+    }
+
+    @Override
+    public void info(Throwable e) {
+        logger.info(FQCN, e == null ? null : e.getMessage(), e);
+    }
+
+    @Override
+    public void info(String msg, Throwable e) {
+        logger.info(FQCN, msg, e);
+    }
+
+    @Override
+    public void warn(String msg) {
+        logger.warn(FQCN, msg, null);
+    }
+
+    @Override
+    public void warn(Throwable e) {
+        logger.warn(FQCN, e == null ? null : e.getMessage(), e);
+    }
+
+    @Override
+    public void warn(String msg, Throwable e) {
+        logger.warn(FQCN, msg, e);
+    }
+
+    @Override
+    public void error(String msg) {
+        logger.error(FQCN, msg, null);
+    }
+
+    @Override
+    public void error(Throwable e) {
+        logger.error(FQCN, e == null ? null : e.getMessage(), e);
+    }
+
+    @Override
+    public void error(String msg, Throwable e) {
+        logger.error(FQCN, msg, e);
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return logger.isTraceEnabled();
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return logger.isInfoEnabled();
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return logger.isWarnEnabled();
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return logger.isErrorEnabled();
+    }
+
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/logger/log4j2/Log4j2LoggerAdapter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/logger/log4j2/Log4j2LoggerAdapter.java
@@ -1,0 +1,86 @@
+package org.apache.dubbo.common.logger.log4j2;
+
+import org.apache.dubbo.common.logger.Level;
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerAdapter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
+
+import java.io.File;
+
+/**
+ * log4j version 2.10.0
+ */
+public class Log4j2LoggerAdapter implements LoggerAdapter {
+
+
+    //log4j2 do not need to assign file, put log4j2.xml into resources
+    @Deprecated
+    private File file;
+
+    private static org.apache.logging.log4j.Level toLog4jLevel(Level level) {
+        if (level == Level.ALL)
+            return org.apache.logging.log4j.Level.ALL;
+        if (level == Level.TRACE)
+            return org.apache.logging.log4j.Level.TRACE;
+        if (level == Level.DEBUG)
+            return org.apache.logging.log4j.Level.DEBUG;
+        if (level == Level.INFO)
+            return org.apache.logging.log4j.Level.INFO;
+        if (level == Level.WARN)
+            return org.apache.logging.log4j.Level.WARN;
+        if (level == Level.ERROR)
+            return org.apache.logging.log4j.Level.ERROR;
+        // if (level == Level.OFF)
+        return org.apache.logging.log4j.Level.OFF;
+    }
+
+    private static Level fromLog4jLevel(org.apache.logging.log4j.Level level) {
+        if (level == org.apache.logging.log4j.Level.ALL)
+            return Level.ALL;
+        if (level == org.apache.logging.log4j.Level.TRACE)
+            return Level.TRACE;
+        if (level == org.apache.logging.log4j.Level.DEBUG)
+            return Level.DEBUG;
+        if (level == org.apache.logging.log4j.Level.INFO)
+            return Level.INFO;
+        if (level == org.apache.logging.log4j.Level.WARN)
+            return Level.WARN;
+        if (level == org.apache.logging.log4j.Level.ERROR)
+            return Level.ERROR;
+        // if (level == org.apache.log4j.Level.OFF)
+        return Level.OFF;
+    }
+
+    @Override
+    public Logger getLogger(Class<?> key) {
+        return new Log4j2Logger(LogManager.getLogger(key));
+    }
+
+    @Override
+    public Logger getLogger(String key) {
+        return new Log4j2Logger(LogManager.getLogger(key));
+    }
+
+    @Override
+    public Level getLevel() {
+        return fromLog4jLevel(LogManager.getRootLogger().getLevel());
+    }
+
+    @Override
+    public void setLevel(Level level) {
+        Configurator.setRootLevel(toLog4jLevel(level));
+    }
+
+    @Override
+    @Deprecated
+    public File getFile() {
+        return file;
+    }
+
+    @Override
+    @Deprecated
+    public void setFile(File file) {
+
+    }
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ClassHelper.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ClassHelper.java
@@ -112,7 +112,7 @@ public class ClassHelper {
      * reference as well).
      *
      * @return the default ClassLoader (never <code>null</code>)
-     * @see java.lang.Thread#getContextClassLoader()
+     * @see Thread#getContextClassLoader()
      */
     public static ClassLoader getClassLoader() {
         return getClassLoader(ClassHelper.class);

--- a/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.logger.LoggerAdapter
+++ b/dubbo-common/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.logger.LoggerAdapter
@@ -2,3 +2,4 @@ slf4j=org.apache.dubbo.common.logger.slf4j.Slf4jLoggerAdapter
 jcl=org.apache.dubbo.common.logger.jcl.JclLoggerAdapter
 log4j=org.apache.dubbo.common.logger.log4j.Log4jLoggerAdapter
 jdk=org.apache.dubbo.common.logger.jdk.JdkLoggerAdapter
+log4j2=org.apache.dubbo.common.logger.log4j2.Log4j2LoggerAdapter

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/bytecode/ClassGeneratorTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/bytecode/ClassGeneratorTest.java
@@ -75,7 +75,7 @@ public class ClassGeneratorTest extends TestCase {
         cg.setClassName(Bean.class.getName() + "$Builder2");
         cg.addInterface(Builder.class);
 
-        cg.addField("FNAME", Modifier.PUBLIC | Modifier.STATIC, java.lang.reflect.Field.class);
+        cg.addField("FNAME", Modifier.PUBLIC | Modifier.STATIC, Field.class);
 
         cg.addMethod("public Object getName(" + Bean.class.getName() + " o){ boolean[][][] bs = new boolean[0][][]; return (String)FNAME.get($1); }");
         cg.addMethod("public void setName(" + Bean.class.getName() + " o, Object name){ FNAME.set($1, $2); }");

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/logger/LoggerAdapterTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/logger/LoggerAdapterTest.java
@@ -22,6 +22,8 @@ import org.apache.dubbo.common.logger.jdk.JdkLogger;
 import org.apache.dubbo.common.logger.jdk.JdkLoggerAdapter;
 import org.apache.dubbo.common.logger.log4j.Log4jLogger;
 import org.apache.dubbo.common.logger.log4j.Log4jLoggerAdapter;
+import org.apache.dubbo.common.logger.log4j2.Log4j2Logger;
+import org.apache.dubbo.common.logger.log4j2.Log4j2LoggerAdapter;
 import org.apache.dubbo.common.logger.slf4j.Slf4jLogger;
 import org.apache.dubbo.common.logger.slf4j.Slf4jLoggerAdapter;
 import org.junit.Test;
@@ -42,7 +44,8 @@ public class LoggerAdapterTest {
                 {JclLoggerAdapter.class, JclLogger.class},
                 {JdkLoggerAdapter.class, JdkLogger.class},
                 {Log4jLoggerAdapter.class, Log4jLogger.class},
-                {Slf4jLoggerAdapter.class, Slf4jLogger.class}
+                {Slf4jLoggerAdapter.class, Slf4jLogger.class},
+                {Log4j2LoggerAdapter.class, Log4j2Logger.class}
         });
     }
 

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/logger/LoggerFactoryTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/logger/LoggerFactoryTest.java
@@ -35,7 +35,7 @@ public class LoggerFactoryTest {
 
     @Test
     public void testGetLogFile() {
-        LoggerFactory.setLoggerAdapter("slf4j");
+        LoggerFactory.setLoggerAdapter("log4j2");
         File file = LoggerFactory.getFile();
 
         assertThat(file, is(nullValue()));

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/logger/LoggerTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/logger/LoggerTest.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.common.logger;
 import org.apache.dubbo.common.logger.jcl.JclLoggerAdapter;
 import org.apache.dubbo.common.logger.jdk.JdkLoggerAdapter;
 import org.apache.dubbo.common.logger.log4j.Log4jLoggerAdapter;
+import org.apache.dubbo.common.logger.log4j2.Log4j2LoggerAdapter;
 import org.apache.dubbo.common.logger.slf4j.Slf4jLoggerAdapter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,7 +41,8 @@ public class LoggerTest {
                 {JclLoggerAdapter.class},
                 {JdkLoggerAdapter.class},
                 {Log4jLoggerAdapter.class},
-                {Slf4jLoggerAdapter.class}
+                {Slf4jLoggerAdapter.class},
+                {Log4j2LoggerAdapter.class}
         });
     }
 

--- a/dubbo-common/src/test/resources/log4j2.xml
+++ b/dubbo-common/src/test/resources/log4j2.xml
@@ -1,0 +1,15 @@
+<configuration status="error">
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <ThresholdFilter level="trace" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %class{36} %L %M - %msg%xEx%n"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Root level="trace">
+            <appender-ref ref="Console"/>
+        </Root>
+    </Loggers>
+</configuration>

--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -105,6 +105,9 @@
         <slf4j_version>1.7.25</slf4j_version>
         <jcl_version>1.2</jcl_version>
         <log4j_version>1.2.16</log4j_version>
+        <!-- log4j2 libs -->
+        <log4j_core_version>2.5</log4j_core_version>
+        <log4j_api_version>2.5</log4j_api_version>
         <logback_version>1.2.2</logback_version>
         <embedded_redis_version>0.6</embedded_redis_version>
 
@@ -325,6 +328,16 @@
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
                 <version>${log4j_version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j_core_version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j_api_version}</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Team10 work issue 4:

What is the purpose of the change
To solve issue: support log4j2 #1713 

Brief changelog
1. Add log4j-core, log4j-api dependencies, version:2.5
2. Add class Log4j2Logger and class Log4j2LoggerAdapter
3. Modified org.apache.dubbo.common.logger.LoggerAdapter add 
log4j2=org.apache.dubbo.common.logger.log4j2.Log4j2LoggerAdapter
4. Modified LoggerFactory add log4j2

Verifying this change
I have added some test cases for my change in LoggerAdapterTest.java, LoggerFactoryTest.java and LoggerTest.java, and the test cases have all passed.