### PR TITLE
fix issue system property dubbo.service.delay invalid #1728

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -197,24 +197,11 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
             if (export == null) {
                 export = provider.getExport();
             }
-            if (delay == null) {
-                delay = provider.getDelay();
-            }
         }
         if (export != null && !export) {
             return;
         }
-
-        if (delay != null && delay > 0) {
-            delayExportExecutor.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    doExport();
-                }
-            }, delay, TimeUnit.MILLISECONDS);
-        } else {
-            doExport();
-        }
+        doExport();
     }
 
     protected synchronized void doExport() {
@@ -314,6 +301,19 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
         if (path == null || path.length() == 0) {
             path = interfaceName;
         }
+        if (delay != null && delay > 0) {
+            delayExportExecutor.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    publish();
+                }
+            }, delay, TimeUnit.MILLISECONDS);
+        } else {
+            publish();
+        }
+    }
+
+    private synchronized void publish() {
         doExportUrls();
         ProviderModel providerModel = new ProviderModel(getUniqueServiceName(), this, ref);
         ApplicationModel.initProviderModel(getUniqueServiceName(), providerModel);


### PR DESCRIPTION
## Team_10: fix issue system property dubbo.service.delay invalid #1728 

Issue [https://github.com/apache/incubator-dubbo/issues/1728](url) has been fixed

## Brief changelog

Modify method export() and doExport(), add method publish() in ServiceConfig.java, 

## Verifying this change

The issue is due to bug in the class ServiceConfig.

When dubbo exports a service, there is a bean of ServiceConfig create by spring and the method export() is invoked. The bean of ServiceConfig is initialized by the configuration <dubbo:service /> in .xml. So in the method export(), the variable delay is initialized by <dubbo:service delay="5000"/> and the system property does not work. 

To fix this issue, I judge the variable delay in the method doExport() and the judgement is after the method appendProperties() which can check the overrides of the priorities and set the variables correct values.
