### PR TITLE
[Dubbo-config]fix the bug of the delay configuration in dubbo.properties is invalid team2

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -204,7 +204,7 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
         if (export != null && !export) {
             return;
         }
-
+        appendProperties(this);
         if (delay != null && delay > 0) {
             delayExportExecutor.schedule(new Runnable() {
                 @Override

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -309,7 +309,7 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
         checkApplication();
         checkRegistry();
         checkProtocol();
-        appendProperties(this);
+        //appendProperties(this);
         checkStubAndMock(interfaceClass);
         if (path == null || path.length() == 0) {
             path = interfaceName;

--- a/dubbo-demo/dubbo-demo-provider/src/main/resources/dubbo.properties
+++ b/dubbo-demo/dubbo-demo-provider/src/main/resources/dubbo.properties
@@ -1,3 +1,1 @@
 dubbo.application.qos.port=22222
-
-dubbo.service.delay=5000

--- a/dubbo-demo/dubbo-demo-provider/src/main/resources/dubbo.properties
+++ b/dubbo-demo/dubbo-demo-provider/src/main/resources/dubbo.properties
@@ -1,1 +1,3 @@
 dubbo.application.qos.port=22222
+
+dubbo.service.delay=5000


### PR DESCRIPTION
## What is the purpose of the change

fix the bug of the delay configuration in dubbo.properties is invalid, close #1728 

## Brief changelog

change ServiceConfig.java, get properties before judge delay

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).

# issue3

- bug复现

  搜索export服务发布接口，设置断点进行问题复现 ------dubbo.properties中的delay配置不生效 

![1](https://user-images.githubusercontent.com/36910887/44069247-7418e9f4-9fb0-11e8-80bc-3a358993bc9f.PNG)


- Debug

  doExport()中参数校验、反射默认初始化

  appendProperties(this)中

  
![2](https://user-images.githubusercontent.com/36910887/44069268-882b503a-9fb0-11e8-8c86-ebd74f0c9aba.png)
![3](https://user-images.githubusercontent.com/36910887/44069277-8e49ad0e-9fb0-11e8-809d-98a81a65e927.png)
![4](https://user-images.githubusercontent.com/36910887/44069279-90892d7e-9fb0-11e8-91c7-573a6fa36ddc.png)


  可以看到这里对延时进行了读取，所以问题找到了。就是在 if (delay != null && delay > 0)判断时 还没有读取properties中的参数设置。 解决就是在判断前进行读取appendProperties(this);

  

  