### PR TITLE
Fix #1343 A port conflict problem of dubbo provider when multiple services start concurrently. team6

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -21,12 +21,7 @@ import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 
 import java.io.IOException;
-import java.net.Inet6Address;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.NetworkInterface;
-import java.net.ServerSocket;
-import java.net.UnknownHostException;
+import java.net.*;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.Random;
@@ -75,21 +70,26 @@ public class NetUtils {
         }
     }
 
-    public static int getAvailablePort(int port) {
+    public static int getAvailablePort(String host, int port) {
         if (port <= 0) {
             return getAvailablePort();
         }
+        InetAddress inetAddress = null;
+        Socket socket = null;
+        try {
+            inetAddress = InetAddress.getByName(host);
+        } catch (UnknownHostException e) {
+            return port;
+        }
         for (int i = port; i < MAX_PORT; i++) {
-            ServerSocket ss = null;
             try {
-                ss = new ServerSocket(i);
-                return i;
+                socket = new Socket(inetAddress, i);
             } catch (IOException e) {
-                // continue
+                return i;
             } finally {
-                if (ss != null) {
+                if (socket != null) {
                     try {
-                        ss.close();
+                        socket.close();
                     } catch (IOException e) {
                     }
                 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -21,7 +21,13 @@ import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 
 import java.io.IOException;
-import java.net.*;
+import java.net.InetAddress;
+import java.net.Inet6Address;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.NetworkInterface;
+import java.net.UnknownHostException;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.Random;

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/NetUtilsTest.java
@@ -47,8 +47,8 @@ public class NetUtilsTest {
     @Test
     public void testGetAvailablePort() throws Exception {
         assertThat(NetUtils.getAvailablePort(), greaterThan(0));
-        assertThat(NetUtils.getAvailablePort(12345), greaterThanOrEqualTo(12345));
-        assertThat(NetUtils.getAvailablePort(-1), greaterThanOrEqualTo(30000));
+        assertThat(NetUtils.getAvailablePort("localhost",12345), greaterThanOrEqualTo(12345));
+        assertThat(NetUtils.getAvailablePort("localhost",-1), greaterThanOrEqualTo(30000));
     }
 
     @Test

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -355,7 +355,21 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
     private void doExportUrls() {
         List<URL> registryURLs = loadRegistries(true);
         for (ProtocolConfig protocolConfig : protocols) {
-            doExportUrlsFor1Protocol(protocolConfig, registryURLs);
+            while (true) {
+                try {
+                    doExportUrlsFor1Protocol(protocolConfig, registryURLs);
+                    break;
+                } catch (Exception e) {
+                    if (e.getMessage().contains("Address already in use")) {
+                        RANDOM_PORT_MAP.remove(protocolConfig.getName() != null ? protocolConfig.getName().toLowerCase() : "dubbo");
+                        try {
+                            Thread.sleep(500);
+                        } catch (Exception e1) {}
+                    } else {
+                        throw e;
+                    }
+                }
+            }
         }
     }
 

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -482,7 +482,7 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
         }
 
         String host = this.findConfigedHosts(protocolConfig, registryURLs, map);
-        Integer port = this.findConfigedPorts(protocolConfig, name, map);
+        Integer port = this.findConfigedPorts(protocolConfig, name, host, map);
         URL url = new URL(name, host, port, (contextPath == null || contextPath.length() == 0 ? "" : contextPath + "/") + path, map);
 
         if (ExtensionLoader.getExtensionLoader(ConfiguratorFactory.class)
@@ -646,7 +646,7 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
      * @param name
      * @return
      */
-    private Integer findConfigedPorts(ProtocolConfig protocolConfig, String name, Map<String, String> map) {
+    private Integer findConfigedPorts(ProtocolConfig protocolConfig, String name, String host, Map<String, String> map) {
         Integer portToBind = null;
 
         // parse bind port from environment
@@ -666,7 +666,7 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
             if (portToBind == null || portToBind <= 0) {
                 portToBind = getRandomPort(name);
                 if (portToBind == null || portToBind < 0) {
-                    portToBind = getAvailablePort(defaultPort);
+                    portToBind = getAvailablePort(host, defaultPort);
                     putRandomPort(name, portToBind);
                 }
                 logger.warn("Use random available port(" + portToBind + ") for protocol " + name);


### PR DESCRIPTION
## What is the purpose of the change

Resolve #1343 
Fix Issue #1343 A port conflict problem of dubbo provider when multiple services start concurrently.

## Brief changelog

Fix the problem of finding port.

BaiJi training camp 269 Team No.6, Alibaba-Inc.

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
