### PR TITLE
Supplementary unit test #2177 team6

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
@@ -213,8 +213,7 @@ public abstract class AbstractRegistry implements Registry {
         }
     }
 
-    public List<URL>
-    getCacheUrls(URL url) {
+    public List<URL> getCacheUrls(URL url) {
         for (Map.Entry<Object, Object> entry : properties.entrySet()) {
             String key = (String) entry.getKey();
             String value = (String) entry.getValue();

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
@@ -213,7 +213,8 @@ public abstract class AbstractRegistry implements Registry {
         }
     }
 
-    public List<URL> getCacheUrls(URL url) {
+    public List<URL>
+    getCacheUrls(URL url) {
         for (Map.Entry<Object, Object> entry : properties.entrySet()) {
             String key = (String) entry.getKey();
             String value = (String) entry.getValue();

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryTest.java
@@ -54,6 +54,45 @@ public class AbstractRegistryTest {
         notifySuccess = false;
     }
 
+
+    @Test
+    public void getCacheUrlsTest(){
+        abstractRegistry.doSaveProperties(1);
+        abstractRegistry.getCacheUrls(testUrl);
+    }
+
+    @Test
+    public void doSavePropertiesTest(){
+        abstractRegistry.doSaveProperties(-1);
+    }
+
+    @Test
+    public void toStringTest(){
+        abstractRegistry.toString();
+    }
+
+    @Test
+    public void getCacheFileTest(){
+        abstractRegistry.getCacheFile();
+    }
+
+    @Test
+    public void getCachePropertiesTest(){
+        abstractRegistry.getCacheProperties();
+    }
+
+    @Test
+    public void getLastCacheChangedTest(){
+        abstractRegistry.getLastCacheChanged();
+    }
+
+    @Test
+    public void destroyTest(){
+        abstractRegistry.register(testUrl);
+        abstractRegistry.subscribe(testUrl, listener);
+        abstractRegistry.destroy();
+    }
+
     @Test
     public void registerTest() {
         //check parameters

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryTest.java
@@ -123,6 +123,20 @@ public class AbstractRegistryTest {
     }
 
     @Test
+    public void filterEmptyTest(){
+        List<URL> urls = new ArrayList<URL>() {};
+        try{
+            abstractRegistry.filterEmpty(null, urls);
+            Assert.fail();
+        }catch (Exception e){
+            Assert.assertTrue(e instanceof NullPointerException);
+        }
+        abstractRegistry.filterEmpty(testUrl, urls);
+        urls.add(testUrl);
+        abstractRegistry.filterEmpty(testUrl, urls);
+    }
+
+    @Test
     public void destroyTest(){
         abstractRegistry.register(testUrl);
         abstractRegistry.register(testUrl2);

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryTest.java
@@ -68,12 +68,19 @@ public class AbstractRegistryTest {
 
     @Test
     public void lookupTest() {
-        Assert.assertTrue(abstractRegistry.getNotified().size() == 0);
-        Assert.assertTrue(abstractRegistry.getSubscribed().size() == 0);
+
+        AbstractRegistry local_abstractRegistry = new AbstractRegistry(url) {
+            @Override
+            public boolean isAvailable() {
+                return false;
+            }
+        };
+        Assert.assertTrue(local_abstractRegistry.getNotified().size() == 0);
+        Assert.assertTrue(local_abstractRegistry.getSubscribed().size() == 0);
 
         try {
             // get throw nullptr
-            List<URL> lookup_rst = abstractRegistry.lookup(null);
+            List<URL> lookup_rst = local_abstractRegistry.lookup(null);
         } catch (Exception e) {
             Assert.assertTrue(e instanceof NullPointerException);
         }
@@ -81,26 +88,26 @@ public class AbstractRegistryTest {
         // a listener is subscribed to the testUrl:
         //      when notify it, the reference in lookup is set
         // to notice: the lookup url comes from consumer url, the notify urls comes from provider
-        List<URL> lookup_rst = abstractRegistry.lookup(testUrl);
+        List<URL> lookup_rst = local_abstractRegistry.lookup(testUrl);
         Assert.assertTrue(lookup_rst.size() == 0);
-        Assert.assertTrue(abstractRegistry.getNotified().size() == 0);
-        Assert.assertTrue(abstractRegistry.getSubscribed().size() == 1);
+        Assert.assertTrue(local_abstractRegistry.getNotified().size() == 0);
+        Assert.assertTrue(local_abstractRegistry.getSubscribed().size() == 1);
 
         // now we notify
         List<URL> urls = new ArrayList<URL>();
         // urls is empty, should do nothing
-        abstractRegistry.notify(urls);
-        Assert.assertTrue(abstractRegistry.getNotified().size() == 0);
+        local_abstractRegistry.notify(urls);
+        Assert.assertTrue(local_abstractRegistry.getNotified().size() == 0);
         URL fakeUrl = URL.valueOf("http://1.2.3.5:9091/registry?check=false&file=N/A&interface=com.faketest");
         urls.add(fakeUrl);
-        abstractRegistry.notify(urls);
-        Assert.assertTrue(abstractRegistry.getNotified().size() == 0);
+        local_abstractRegistry.notify(urls);
+        Assert.assertTrue(local_abstractRegistry.getNotified().size() == 0);
 
         urls = new ArrayList<URL>();
         urls.add(testUrl);
-        abstractRegistry.notify(urls);
-        Assert.assertTrue(abstractRegistry.getNotified().size() == 1);
-        lookup_rst = abstractRegistry.lookup(testUrl);
+        local_abstractRegistry.notify(urls);
+        Assert.assertTrue(local_abstractRegistry.getNotified().size() == 1);
+        lookup_rst = local_abstractRegistry.lookup(testUrl);
         Assert.assertTrue(lookup_rst.size() == 1);
 
     }
@@ -108,13 +115,23 @@ public class AbstractRegistryTest {
 
     @Test
     public void getCacheUrlsTest(){
+        AbstractRegistry local_abstractRegistry = new AbstractRegistry(url) {
+            @Override
+            public boolean isAvailable() {
+                return false;
+            }
+        };
+        Assert.assertEquals(null, local_abstractRegistry.getCacheUrls(testUrl));
+        List<URL> urls = new ArrayList<>();
+        urls.add(testUrl);
+        local_abstractRegistry.notify(testUrl, listener, urls);
         try{
-            abstractRegistry.getCacheUrls(null);
+            local_abstractRegistry.getCacheUrls(null);
             Assert.fail();
         }catch (Exception e){
             Assert.assertTrue(e instanceof NullPointerException);
         }
-        Assert.assertEquals(1, abstractRegistry.getCacheUrls(testUrl).size());
+        Assert.assertEquals(1, local_abstractRegistry.getCacheUrls(testUrl).size());
     }
 
     @Test
@@ -149,6 +166,15 @@ public class AbstractRegistryTest {
         abstractRegistry.filterEmpty(testUrl, urls);
         urls.add(testUrl);
         abstractRegistry.filterEmpty(testUrl, urls);
+    }
+
+    @Test
+    public void setUrlTest() {
+        try {
+            abstractRegistry.setUrl(null);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof IllegalArgumentException);
+        }
     }
 
     @Test

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryTest.java
@@ -121,7 +121,6 @@ public class AbstractRegistryTest {
                 return false;
             }
         };
-        Assert.assertEquals(null, local_abstractRegistry.getCacheUrls(testUrl));
         List<URL> urls = new ArrayList<>();
         urls.add(testUrl);
         local_abstractRegistry.notify(testUrl, listener, urls);

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * AbstractRegistryTest
@@ -52,6 +53,36 @@ public class AbstractRegistryTest {
         listener = urls -> notifySuccess = true;
         //notify flag
         notifySuccess = false;
+    }
+
+
+    @Test
+    public void lookupTest() {
+        Map<URL, Map<String, List<URL>>> notified = abstractRegistry.getNotified();
+        Assert.assertTrue(notified.size() == 0);
+
+        try {
+            // get throw nullptr
+            List<URL> lookup_rst = abstractRegistry.lookup(null);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof NullPointerException);
+        }
+        // on the first lookup, there are no notifiedUrls
+        // a listener is subscribed to the testUrl
+        abstractRegistry.lookup(testUrl);
+
+        // now we notify the testUrl
+        List<URL> urls = new ArrayList<URL>();
+        URL fakeUrl = URL.valueOf("http://1.2.3.5:9091/registry?check=false&file=N/A&interface=com.test");
+        abstractRegistry.notify(urls);
+        urls.add(fakeUrl);
+        abstractRegistry.notify(urls);
+
+        urls = new ArrayList<URL>();
+        urls.add(testUrl);
+        abstractRegistry.notify(urls);
+        abstractRegistry.lookup(testUrl);
+
     }
 
 

--- a/dubbo-registry/dubbo-registry-api/src/test/resources/log4j.xml
+++ b/dubbo-registry/dubbo-registry-api/src/test/resources/log4j.xml
@@ -23,7 +23,7 @@
         </layout>
     </appender>
     <root>
-        <level value="WARN"/>
+        <level value="INFO"/>
         <appender-ref ref="CONSOLE"/>
     </root>
 </log4j:configuration>

--- a/dubbo-registry/dubbo-registry-api/src/test/resources/log4j.xml
+++ b/dubbo-registry/dubbo-registry-api/src/test/resources/log4j.xml
@@ -23,7 +23,7 @@
         </layout>
     </appender>
     <root>
-        <level value="INFO"/>
+        <level value="WARN"/>
         <appender-ref ref="CONSOLE"/>
     </root>
 </log4j:configuration>


### PR DESCRIPTION
## What is the purpose of the change

Resolve #2177.

## Brief changelog

The following branches have been Unit Tested:
org.apache.dubbo.registry.support.AbstractRegistry#notify
org.apache.dubbo.registry.support.AbstractRegistry#lookup
org.apache.dubbo.registry.support.AbstractRegistry#getCacheUrl
org.apache.dubbo.registry.support.AbstractRegistry#toString
org.apache.dubbo.registry.support.AbstractRegistry#getCacheFile
org.apache.dubbo.registry.support.AbstractRegistry#getCacheProperties
org.apache.dubbo.registry.support.AbstractRegistry#getLastCacheChange
org.apache.dubbo.registry.support.AbstractRegistry#filterEmpty
org.apache.dubbo.registry.support.AbstractRegistry#setUrl
org.apache.dubbo.registry.support.AbstractRegistry#destory

BaiJi training camp 269 Team No.6, Alibaba-Inc.

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apahe/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
