### PR TITLE
[Dubbo-2233] fix reference config cache issue #2233

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ReferenceConfigCache.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ReferenceConfigCache.java
@@ -110,9 +110,13 @@ public class ReferenceConfigCache {
             return (T) config.get();
         }
 
-        cache.putIfAbsent(key, referenceConfig);
-        config = cache.get(key);
-        return (T) config.get();
+        T t = referenceConfig.get();
+        if (null == t){
+            return null;
+        }else{
+            cache.putIfAbsent(key, referenceConfig);
+            return t;
+        }
     }
 
     void destroyKey(String key) {

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/MockReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/MockReferenceConfig.java
@@ -25,6 +25,7 @@ public class MockReferenceConfig extends ReferenceConfig<String> {
 
     String value;
     boolean destroyMethodRun = false;
+    boolean shouldReturnNull = false;
 
     public static void setCounter(long c) {
         counter.set(c);
@@ -40,10 +41,15 @@ public class MockReferenceConfig extends ReferenceConfig<String> {
 
     @Override
     public synchronized String get() {
+        if (shouldReturnNull) return null;
         if (value != null) return value;
 
         value = "" + counter.getAndIncrement();
         return value;
+    }
+
+    public void setShouldReturnNull(boolean shouldReturnNull){
+        this.shouldReturnNull = shouldReturnNull;
     }
 
     @Override

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/ReferenceConfigCacheTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/utils/ReferenceConfigCacheTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class ReferenceConfigCacheTest {
@@ -110,5 +111,38 @@ public class ReferenceConfigCacheTest {
         config.setGroup(group);
         config.setVersion(version);
         return config;
+    }
+
+    @Test
+    public void testGetCache_NullReference() throws Exception {
+        ReferenceConfigCache cache = ReferenceConfigCache.getCache();
+
+        {
+            MockReferenceConfig config = buildMockReferenceConfig("FooService", "group1", "1.0.0");
+            config.setShouldReturnNull(true);
+
+            // first time should get null
+            String value = cache.get(config);
+            assertFalse(config.isGetMethodRun());
+            assertNull(value);
+        }
+
+        {
+            MockReferenceConfig configCopy = buildMockReferenceConfig("FooService", "group1", "1.0.0");
+
+            // second time should get 0
+            String value = cache.get(configCopy);
+            assertTrue(configCopy.isGetMethodRun());
+            assertEquals("0", value);
+        }
+
+        {
+            MockReferenceConfig configCopy = buildMockReferenceConfig("FooService", "group1", "1.0.0");
+
+            // third time should get 0 and this is cache data
+            String value = cache.get(configCopy);
+            assertFalse(configCopy.isGetMethodRun());
+            assertEquals("0", value);
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

fix issue #2233 

## Brief changelog

fix the referenceconfig cache null forever if no provider and then provider startup

## Verifying this change
1. provider not startup
2. invoke with reference cache get null
3. provider startup
4. invoker with reference cache again get what you want

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
