### PR TITLE
[Dubbo-1054][Baiji-Team1] Pass application name from Consumer to Provider#1054

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
@@ -77,6 +77,8 @@ public class RpcContext {
 
     private Object[] arguments;
 
+    private String consumerApplication;
+
     private InetSocketAddress localAddress;
 
     private InetSocketAddress remoteAddress;
@@ -730,4 +732,11 @@ public class RpcContext {
         return asyncContext;
     }
 
+    public String getConsumerApplication() {
+        return consumerApplication;
+    }
+
+    public void setConsumerApplication(String consumerApplication) {
+        this.consumerApplication = consumerApplication;
+    }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ConsumerContextFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ConsumerContextFilter.java
@@ -41,6 +41,10 @@ public class ConsumerContextFilter extends AbstractPostProcessFilter {
                 .setLocalAddress(NetUtils.getLocalHost(), 0)
                 .setRemoteAddress(invoker.getUrl().getHost(),
                         invoker.getUrl().getPort());
+        //add application of consumer
+        String application = invoker.getUrl().getParameter("application");
+        RpcContext.getContext().setConsumerApplication(application);
+
         if (invocation instanceof RpcInvocation) {
             ((RpcInvocation) invocation).setInvoker(invoker);
         }


### PR DESCRIPTION
## What is the purpose of the change

resolve the issue -- Provider cannot get the application parameter of consumer's url #1054

## Brief changelog

add the application of consumer to RpcContext, so the provider can get application of consumer by RpcContext. 
TO be specific, we add the property of ConsumerApplication to RpcContext, before invoke, we add the
application of consumer in the ConsumerContextFilter 

## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
