### PR TITLE
[Dubbo-1054][Baiji-9] add "send consumer application name to provider " feature   #1054

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
@@ -235,6 +235,8 @@ public class Constants {
 
     public static final String EXPORTER_LISTENER_KEY = "exporter.listener";
 
+    public static final String SEND_CONSUMER_APPLICATION_NAME_KEY = "sendConsumerApplicationName";
+
     public static final String ACCESS_LOG_KEY = "accesslog";
 
     public static final String ACTIVES_KEY = "actives";

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/SendConsumerApplicationNameFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/SendConsumerApplicationNameFilter.java
@@ -1,0 +1,22 @@
+package org.apache.dubbo.rpc.filter;
+
+import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.extension.Activate;
+import org.apache.dubbo.rpc.*;
+
+/**
+ * @author pfjia
+ * @since 2018/8/27 22:29
+ */
+@Activate(group = Constants.CONSUMER)
+public class SendConsumerApplicationNameFilter implements Filter {
+
+    @Override
+    public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
+        if (invocation instanceof RpcInvocation) {
+            String consumerApplicationName = invoker.getUrl().getParameter(Constants.APPLICATION_KEY);
+            ((RpcInvocation) invocation).setAttachment(Constants.SEND_CONSUMER_APPLICATION_NAME_KEY, consumerApplicationName);
+        }
+        return invoker.invoke(invocation);
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.Filter
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.Filter
@@ -12,3 +12,4 @@ executelimit=org.apache.dubbo.rpc.filter.ExecuteLimitFilter
 deprecated=org.apache.dubbo.rpc.filter.DeprecatedFilter
 compatible=org.apache.dubbo.rpc.filter.CompatibleFilter
 timeout=org.apache.dubbo.rpc.filter.TimeoutFilter
+sendConsumerApplicationName=org.apache.dubbo.rpc.filter.SendConsumerApplicationNameFilter


### PR DESCRIPTION
## What is the purpose of the change

resolve the issue -- Provider cannot get the application parameter of consumer's url [#1054](https://github.com/apache/incubator-dubbo/issues/1054)

## Brief changelog

Add an internal filter to add consumer application name to Invocation attachements.In the provider endpoint,use RpcContext to get consumer application name.

## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).