### PR TITLE
[Dubbo-issue2][ Baiji-10] 

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
@@ -28,6 +28,8 @@ public class Constants {
 
     public static final String CONSUMER = "consumer";
 
+    public static final String CONSUMER_APPLICATION_NAME = "consumerAppName";
+
     public static final String REGISTER = "register";
 
     public static final String UNREGISTER = "unregister";

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
@@ -28,6 +28,9 @@ public class Constants {
 
     public static final String CONSUMER = "consumer";
 
+    /**
+     * 用于保存调用方的应用名
+     */
     public static final String CONSUMER_APPLICATION_NAME = "consumerAppName";
 
     public static final String REGISTER = "register";

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeHandler.java
@@ -181,6 +181,13 @@ public class HeaderExchangeHandler implements ChannelHandlerDelegate {
         }
     }
 
+    /**
+     * 接受请求数据，通过handleRequest方法处理后得到处理结果
+     *
+     * @param channel channel.
+     * @param message message.
+     * @throws RemotingException
+     */
     @Override
     public void received(Channel channel, Object message) throws RemotingException {
         channel.setAttribute(KEY_READ_TIMESTAMP, System.currentTimeMillis());

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/dispatcher/WrappedChannelHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/dispatcher/WrappedChannelHandler.java
@@ -57,6 +57,11 @@ public class WrappedChannelHandler implements ChannelHandlerDelegate {
         dataStore.put(componentKey, Integer.toString(url.getPort()), executor);
     }
 
+    /**
+     * 通过URL中的parameters映射，保存了调用方的AppName
+     *
+     * @return 返回的是方法调用方的AppName
+     */
     public String getConsumerAppName(){
         String consumerAppName = this.url.getParameter(Constants.CONSUMER_APPLICATION_NAME);
         return consumerAppName;

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/dispatcher/WrappedChannelHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/dispatcher/WrappedChannelHandler.java
@@ -57,6 +57,11 @@ public class WrappedChannelHandler implements ChannelHandlerDelegate {
         dataStore.put(componentKey, Integer.toString(url.getPort()), executor);
     }
 
+    public String getConsumerAppName(){
+        String consumerAppName = this.url.getParameter(Constants.CONSUMER_APPLICATION_NAME);
+        return consumerAppName;
+    }
+
     public void close() {
         try {
             if (executor != null) {

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvoker.java
@@ -72,6 +72,8 @@ public class DubboInvoker<T> extends AbstractInvoker<T> {
         final String methodName = RpcUtils.getMethodName(invocation);
         inv.setAttachment(Constants.PATH_KEY, getUrl().getPath());
         inv.setAttachment(Constants.VERSION_KEY, version);
+
+        // 通过ConfigUtils工具类获取到配置文件中的应用名，然后添加到RpcInvocation对象的attachments映射中去
         String consumerAppName = ConfigUtils.getProperty("dubbo.application.name");
         inv.setAttachment(Constants.CONSUMER_APPLICATION_NAME, consumerAppName);
 

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvoker.java
@@ -72,6 +72,8 @@ public class DubboInvoker<T> extends AbstractInvoker<T> {
         final String methodName = RpcUtils.getMethodName(invocation);
         inv.setAttachment(Constants.PATH_KEY, getUrl().getPath());
         inv.setAttachment(Constants.VERSION_KEY, version);
+        String consumerAppName = ConfigUtils.getProperty("dubbo.application.name");
+        inv.setAttachment(Constants.CONSUMER_APPLICATION_NAME, consumerAppName);
 
         ExchangeClient currentClient;
         if (clients.length == 1) {


### PR DESCRIPTION
## What is the purpose of the change
To support the feature: provider will know the appName of consumer.

## Brief changelog
- To append the consumer's appName in the request for rpc invocation, we get the name through ConfigUtil and store it in the map relation (parameters) of URL && attachment of RpcInvocation.
- For provider, wo offer a method (getConsumerAppName) in WrappedChannelHandler to get the consumer's appName.

## Verifying this change
tristanhuang

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
