### PR TITLE
[Dubbo-issue1054][Baiji-02]Support to send the Consumer application name to the Provider.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
@@ -341,6 +341,8 @@ public class Constants {
 
     public static final String VERSION_KEY = "version";
 
+    public static final String APP_NAME = "application";
+
     public static final String REVISION_KEY = "revision";
 
     public static final String DUBBO_VERSION_KEY = "dubbo";

--- a/dubbo-demo/dubbo-demo-consumer/src/main/resources/META-INF/spring/dubbo-demo-consumer.xml
+++ b/dubbo-demo/dubbo-demo-consumer/src/main/resources/META-INF/spring/dubbo-demo-consumer.xml
@@ -23,7 +23,7 @@
 
     <!-- consumer's application name, used for tracing dependency relationship (not a matching criterion),
     don't set it same as provider -->
-    <dubbo:application name="demo-consumer"/>
+    <dubbo:application name="group2-demo-consumer"/>
 
     <!-- use multicast registry center to discover service -->
     <dubbo:registry address="multicast://224.5.6.7:1234"/>

--- a/dubbo-demo/dubbo-demo-provider/src/main/java/org/apache/dubbo/demo/provider/DemoServiceImpl.java
+++ b/dubbo-demo/dubbo-demo-provider/src/main/java/org/apache/dubbo/demo/provider/DemoServiceImpl.java
@@ -26,7 +26,7 @@ public class DemoServiceImpl implements DemoService {
 
     @Override
     public String sayHello(String name) {
-        System.out.println("[" + new SimpleDateFormat("HH:mm:ss").format(new Date()) + "] Hello " + name + ", request from consumer: " + RpcContext.getContext().getRemoteAddress());
+        System.out.println("[" + new SimpleDateFormat("HH:mm:ss").format(new Date()) + "] Hello " + name + ", request from consumer: " + RpcContext.getContext().getRemoteAddress()+", consumer name is "+RpcContext.getContext().getConsumerAppName());
         return "Hello " + name + ", response from provider: " + RpcContext.getContext().getLocalAddress();
     }
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
@@ -730,4 +730,7 @@ public class RpcContext {
         return asyncContext;
     }
 
+    public String getConsumerAppName(){
+        return this.getAttachment("application");
+    }
 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvoker.java
@@ -54,6 +54,8 @@ public class DubboInvoker<T> extends AbstractInvoker<T> {
 
     private final Set<Invoker<?>> invokers;
 
+    private final String appName;
+
     public DubboInvoker(Class<T> serviceType, URL url, ExchangeClient[] clients) {
         this(serviceType, url, clients, null);
     }
@@ -64,6 +66,7 @@ public class DubboInvoker<T> extends AbstractInvoker<T> {
         // get version.
         this.version = url.getParameter(Constants.VERSION_KEY, "0.0.0");
         this.invokers = invokers;
+        this.appName = url.getParameter("application");
     }
 
     @Override
@@ -72,7 +75,7 @@ public class DubboInvoker<T> extends AbstractInvoker<T> {
         final String methodName = RpcUtils.getMethodName(invocation);
         inv.setAttachment(Constants.PATH_KEY, getUrl().getPath());
         inv.setAttachment(Constants.VERSION_KEY, version);
-
+        inv.setAttachment(Constants.APP_NAME,this.appName);
         ExchangeClient currentClient;
         if (clients.length == 1) {
             currentClient = clients[0];


### PR DESCRIPTION
## Support to send the Consumer application name to the Provider.
### Get the application name of the Consumer by calling the getConsumerAppName method of RpcContext.