### PR TITLE
[Dubbo-1814][Baiji-Team1]Add: xml attributes for graceful-shutdown timeout #1814

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
@@ -83,6 +83,10 @@ public class ApplicationConfig extends AbstractConfig {
     // customized parameters
     private Map<String, String> parameters;
 
+    // graceful-shutdown timeout
+    private String shutdownWaitKey;
+    private String shutdownWaitSecondsKey;
+
     public ApplicationConfig() {
     }
 
@@ -253,5 +257,22 @@ public class ApplicationConfig extends AbstractConfig {
     public void setParameters(Map<String, String> parameters) {
         checkParameterName(parameters);
         this.parameters = parameters;
+    }
+
+    @Parameter(key = Constants.SHUTDOWN_WAIT_KEY)
+    public String getShutdownWaitKey() {
+        return shutdownWaitKey;
+    }
+
+    public void setShutdownWaitKey(String shutdownWaitKey) {
+        this.shutdownWaitKey = shutdownWaitKey;
+    }
+    @Parameter(key = Constants.SHUTDOWN_WAIT_SECONDS_KEY)
+    public String getShutdownWaitSecondsKey() {
+        return shutdownWaitSecondsKey;
+    }
+
+    public void setShutdownWaitSecondsKey(String shutdownWaitSecondsKey) {
+        this.shutdownWaitSecondsKey = shutdownWaitSecondsKey;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix issue #1814 By BaiJi the 274th team 1

## Brief changelog

* dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
* * Added the part to get the xml attribute in the getServerShutdownTimeout function, first get the xml attribute, if not, get dubbo.properties

* dubbo-config-api/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
* * Add Member variables shutdownWaitKey , shutdownWaitSecondsKey and their getter setter method. For get 'graceful-shutdown timeout'  attribute from  xml file.

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
