### PR TITLE
[Dubbo-2352][Baiji-1] Add unit test for HeaderExchangeChannel #2352

### DIFF
--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeChannelTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeChannelTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.remoting.exchange.support.header;
+
+import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.remoting.Channel;
+import org.apache.dubbo.remoting.RemotingException;
+import org.apache.dubbo.remoting.TimeoutException;
+import org.apache.dubbo.remoting.exchange.Request;
+import org.apache.dubbo.remoting.exchange.ResponseFuture;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class HeaderExchangeChannelTest {
+    private MockChannel channel;
+    private HeaderExchangeChannel headerExchangeChannel;
+    private HeaderExchangeChannel closedHeaderExchangeChannel;
+    private URL url = URL.valueOf("dubbo://localhost:20880");
+
+    private MockChannel makeChannel() {
+        return new MockChannel() {
+            @Override
+            public URL getUrl() {
+                return url;
+            }
+        };
+    }
+
+    @Before
+    public void setup() throws Exception {
+        channel = this.makeChannel();
+        headerExchangeChannel = new HeaderExchangeChannel(channel);
+
+        closedHeaderExchangeChannel = new HeaderExchangeChannel(this.makeChannel());
+        closedHeaderExchangeChannel.close();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructWithNullChannel() {
+        new HeaderExchangeChannel(null);
+    }
+
+    @Test
+    public void testGetOrAddChannel() {
+        Assert.assertNull(HeaderExchangeChannel.getOrAddChannel(null));
+
+        HeaderExchangeChannel result = HeaderExchangeChannel.getOrAddChannel(channel);
+        Assert.assertEquals(headerExchangeChannel, result);
+    }
+
+    @Test
+    public void testSendString() throws Exception {
+        final String requestData = "charles";
+
+        headerExchangeChannel.send(requestData);
+        List<Object> objects = channel.getSentObjects();
+        Assert.assertTrue(objects.size() > 0);
+
+        Object obj = objects.get(0);
+        Assert.assertTrue(obj instanceof String);
+
+        String data = (String) obj;
+        Assert.assertEquals(requestData, data);
+    }
+
+    @Test
+    public void testSendRequest() throws Exception {
+        final Request req = new Request();
+
+        headerExchangeChannel.send(req);
+        List<Object> objects = channel.getSentObjects();
+        Assert.assertTrue(objects.size() > 0);
+
+        Object obj = objects.get(0);
+        Assert.assertTrue(obj instanceof Request);
+
+        Request request = (Request) obj;
+        Assert.assertEquals(req, request);
+    }
+
+    @Test
+    public void testSendObject() throws Exception {
+        final Person requestData = new Person("charles");
+
+        headerExchangeChannel.send(requestData);
+        List<Object> objects = channel.getSentObjects();
+        Assert.assertTrue(objects.size() > 0);
+
+        Object obj = objects.get(0);
+        Assert.assertTrue(obj instanceof Request);
+
+        Request request = (Request) obj;
+        Assert.assertFalse(request.isTwoWay());
+
+        Object data = request.getData();
+        Assert.assertEquals(requestData, data);
+    }
+
+    @Test(expected = RemotingException.class)
+    public void testSendWithClosedChannel() throws Exception {
+        closedHeaderExchangeChannel.send("Charles");
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void testRequest() throws Exception {
+        final Person requestData = new Person("charles");
+        final int timeout = 200;
+
+        ResponseFuture future = headerExchangeChannel.request(requestData, timeout);
+
+        List<Object> objects = channel.getSentObjects();
+        Assert.assertTrue(objects.size() > 0);
+
+        Object obj = objects.get(0);
+        Assert.assertTrue(obj instanceof Request);
+
+        Request request = (Request) obj;
+        Assert.assertTrue(request.isTwoWay());
+
+        Object data = request.getData();
+        Assert.assertEquals(requestData, data);
+
+        future.get();
+    }
+
+    @Test(expected = RemotingException.class)
+    public void testRequestWithClosedChannel() throws Exception {
+        closedHeaderExchangeChannel.request("Charles");
+    }
+
+    @Test
+    public void testHashCode() throws Exception {
+        int hashCode = headerExchangeChannel.hashCode();
+        Assert.assertEquals(hashCode, headerExchangeChannel.hashCode());
+
+        Channel anotherChannel = new MockChannel();
+        HeaderExchangeChannel anotherHeaderExchangeChannel = new HeaderExchangeChannel(anotherChannel);
+        Assert.assertNotEquals(hashCode, anotherHeaderExchangeChannel.hashCode());
+    }
+
+    @Test
+    public void testEquals() throws Exception {
+        Assert.assertEquals(headerExchangeChannel, headerExchangeChannel);
+        Assert.assertNotEquals(headerExchangeChannel, null);
+        Assert.assertNotEquals(headerExchangeChannel, new Person("charles"));
+
+        Channel anotherChannel = new MockChannel();
+        Assert.assertNotEquals(headerExchangeChannel, new HeaderExchangeChannel(anotherChannel));
+
+        Assert.assertEquals(headerExchangeChannel, new HeaderExchangeChannel(channel));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        headerExchangeChannel.close();
+        Assert.assertTrue(channel.isClosed());
+    }
+
+    private class Person {
+        private String name;
+
+        public Person(String name) {
+            super();
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return "Person [name=" + name + "]";
+        }
+    }
+}

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/MockChannel.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/MockChannel.java
@@ -84,11 +84,14 @@ public class MockChannel implements Channel {
 
     @Override
     public void send(Object message) throws RemotingException {
-        sentObjects.add(message);
+        send(message, false);
     }
 
     @Override
     public void send(Object message, boolean sent) throws RemotingException {
+        if (closed) {
+            throw new RemotingException(this.getLocalAddress(), null, "Failed to send message " + message + ", cause: The channel " + this + " is closed!");
+        }
         sentObjects.add(message);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Add unit test for HeaderExchangeChannel
Group 1, Baiji 274.

## Brief changelog

Handle closed channel in MockChannel
Add unit test for HeaderExchangeChannelTest. (#2352)

## Verifying this change

The test is tested locally.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
