### PR TITLE
[Dubbo-issue1293][Baiji-02]Provide independent api that can be judged by the user whether the cache already exists

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ReferenceConfigCache.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ReferenceConfigCache.java
@@ -115,6 +115,10 @@ public class ReferenceConfigCache {
         return (T) config.get();
     }
 
+    public <T> boolean isExist(ReferenceConfig<T> referenceConfig){
+        return cache.get(generator.generateKey(referenceConfig)) != null;
+    }
+
     void destroyKey(String key) {
         ReferenceConfig<?> config = cache.remove(key);
         if (config == null) return;


### PR DESCRIPTION
## This can be achieved by the isExist method of the ReferenceConfigCache class.