### PR TITLE
issue3源码分析

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -562,7 +562,7 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
             throw new IllegalArgumentException("Specified invalid bind ip from property:" + Constants.DUBBO_IP_TO_BIND + ", value:" + hostToBind);
         }
 
-        // if bind ip is not found in environment, keep looking up
+        // if bind ip is not fou nd in environment, keep looking up
         if (hostToBind == null || hostToBind.length() == 0) {
             hostToBind = protocolConfig.getHost();
             if (provider != null && (hostToBind == null || hostToBind.length() == 0)) {


### PR DESCRIPTION
### 通过对源码的分析，我们发现，在provider注册过程中，获取ip是在ServiceConfig类的findConfigedHosts方法中实现的，分为三个步骤，先通过环境变量获取，找不到的话，再通过xml配置，再找不到，则通过InetAddress.getLocalHost().getHostAddress()获取本地ip.所以这部分通过环境变量获取ip已经实现了，而且是最高优先级。