### PR TITLE
Remove method.async of provider url.

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/ClusterUtils.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/ClusterUtils.java
@@ -20,11 +20,12 @@ import org.apache.dubbo.common.Constants;
 import org.apache.dubbo.common.URL;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * ClusterUtils
- *
  */
 public class ClusterUtils {
 
@@ -63,6 +64,17 @@ public class ClusterUtils {
 
             map.remove(Constants.ASYNC_KEY);
             map.remove(Constants.DEFAULT_KEY_PREFIX + Constants.ASYNC_KEY);
+
+            // remove method async entry.
+            Set<String> methodAsyncKey = new HashSet<>();
+            for (String key : map.keySet()) {
+                if (key != null && key.endsWith("." + Constants.ASYNC_KEY)) {
+                    methodAsyncKey.add(key);
+                }
+            }
+            for (String needRemove : methodAsyncKey) {
+                map.remove(needRemove);
+            }
         }
 
         if (localMap != null && localMap.size() > 0) {


### PR DESCRIPTION
Remove method.async of provider url to avoid that consumer use async value from provider.

Fix issue:
https://github.com/apache/incubator-dubbo/issues/2321

Related pr:
https://github.com/apache/incubator-dubbo/pull/2322