### PR TITLE
[Dubbo-2328]Fix the concurrency limit of 'ActiveLimitFilter' to calculate atomicity

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ActiveLimitFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ActiveLimitFilter.java
@@ -42,9 +42,9 @@ public class ActiveLimitFilter implements Filter {
             long timeout = invoker.getUrl().getMethodParameter(invocation.getMethodName(), Constants.TIMEOUT_KEY, 0);
             long start = System.currentTimeMillis();
             long remain = timeout;
-            int active = count.getActive();
-            if (active >= max) {
-                synchronized (count) {
+            synchronized (count) {
+                int active = count.getActive();
+                if (active >= max) {
                     while ((active = count.getActive()) >= max) {
                         try {
                             count.wait(remain);
@@ -61,11 +61,13 @@ public class ActiveLimitFilter implements Filter {
                         }
                     }
                 }
+                RpcStatus.beginCount(url, methodName);
             }
+        } else {
+            RpcStatus.beginCount(url, methodName);
         }
         try {
             long begin = System.currentTimeMillis();
-            RpcStatus.beginCount(url, methodName);
             try {
                 Result result = invoker.invoke(invocation);
                 RpcStatus.endCount(url, methodName, System.currentTimeMillis() - begin, true);


### PR DESCRIPTION
## What is the purpose of the change

Solves the problem of 'ActiveLimitFilter' consumer concurrency limit #2328 

## Brief changelog

adjust the concurrency limit of 'ActiveLimitFilter' to calculate atomicity

## Verifying this change

org.apache.dubbo.rpc.filter.ActiveLimitFilter

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
