### PR TITLE
修复加载Service Interface时出现ClassNotFoundException的问题

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ReflectUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ReflectUtils.java
@@ -591,6 +591,14 @@ public final class ReflectUtils {
         }
     }
 
+    public static Class<?> forName(ClassLoader cl, String name) {
+        try {
+            return name2class(cl, name);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Not found class " + name + ", cause: " + e.getMessage(), e);
+        }
+    }
+
     /**
      * name to class.
      * "boolean" => boolean.class

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/RpcUtils.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/RpcUtils.java
@@ -49,8 +49,9 @@ public class RpcUtils {
                     && !invocation.getMethodName().startsWith("$")) {
                 String service = invocation.getInvoker().getUrl().getServiceInterface();
                 if (service != null && service.length() > 0) {
-                    ClassLoader classLoader = invocation.getInvoker().getInterface().getClassLoader();
-                    Class<?> cls = ReflectUtils.forName(classLoader, service);
+                    Class<?> invokerInterface = invocation.getInvoker().getInterface();
+                    Class<?> cls = invokerInterface != null ? ReflectUtils.forName(invokerInterface.getClassLoader(), service)
+                            : ReflectUtils.forName(service);
                     Method method = cls.getMethod(invocation.getMethodName(), invocation.getParameterTypes());
                     if (method.getReturnType() == void.class) {
                         return null;
@@ -72,8 +73,9 @@ public class RpcUtils {
                     && !invocation.getMethodName().startsWith("$")) {
                 String service = invocation.getInvoker().getUrl().getServiceInterface();
                 if (service != null && service.length() > 0) {
-                    ClassLoader classLoader = invocation.getInvoker().getInterface().getClassLoader();
-                    Class<?> cls = ReflectUtils.forName(classLoader, service);
+                    Class<?> invokerInterface = invocation.getInvoker().getInterface();
+                    Class<?> cls = invokerInterface != null ? ReflectUtils.forName(invokerInterface.getClassLoader(), service)
+                            : ReflectUtils.forName(service);
                     Method method = cls.getMethod(invocation.getMethodName(), invocation.getParameterTypes());
                     if (method.getReturnType() == void.class) {
                         return null;

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/RpcUtils.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/RpcUtils.java
@@ -49,7 +49,8 @@ public class RpcUtils {
                     && !invocation.getMethodName().startsWith("$")) {
                 String service = invocation.getInvoker().getUrl().getServiceInterface();
                 if (service != null && service.length() > 0) {
-                    Class<?> cls = ReflectUtils.forName(service);
+                    ClassLoader classLoader = invocation.getInvoker().getInterface().getClassLoader();
+                    Class<?> cls = ReflectUtils.forName(classLoader, service);
                     Method method = cls.getMethod(invocation.getMethodName(), invocation.getParameterTypes());
                     if (method.getReturnType() == void.class) {
                         return null;
@@ -71,7 +72,8 @@ public class RpcUtils {
                     && !invocation.getMethodName().startsWith("$")) {
                 String service = invocation.getInvoker().getUrl().getServiceInterface();
                 if (service != null && service.length() > 0) {
-                    Class<?> cls = ReflectUtils.forName(service);
+                    ClassLoader classLoader = invocation.getInvoker().getInterface().getClassLoader();
+                    Class<?> cls = ReflectUtils.forName(classLoader, service);
                     Method method = cls.getMethod(invocation.getMethodName(), invocation.getParameterTypes());
                     if (method.getReturnType() == void.class) {
                         return null;


### PR DESCRIPTION
用jarslink做的module隔离,dubbo调用时会抛ClassNotFoundException.经查是ClassLoader不一致。为了严谨，做此修改，以确保Service Interface和Invocation Interface采用同一个ClassLoader。

## What is the purpose of the change

避免ClassNotFoundException，为了严谨，确保Service Interface和Invocation Interface采用同一个ClassLoader

## Brief changelog

Service Interface 采用 Invocation Interface 的 ClassLoader 进行加载