### PR TITLE
[Dubbo-2328]Fix the concurrency limit of 'ActiveLimitFilter' to calculate atomicity

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
@@ -53,6 +53,12 @@ public class RpcStatus {
     private volatile Semaphore executesLimit;
     private volatile int executesPermits;
 
+    /**
+     * Semaphore used to control concurrency limit set by `actives`
+     */
+    private volatile Semaphore activesLimit;
+    private volatile int activesPermits;
+
     private RpcStatus() {
     }
 
@@ -333,5 +339,29 @@ public class RpcStatus {
         }
 
         return executesLimit;
+    }
+
+
+    /**
+     * Get the semaphore for thread number. Semaphore's permits is decided by {@link Constants#ACTIVES_KEY}
+     *
+     * @param maxThreadNum value of {@link Constants#ACTIVES_KEY}
+     * @return thread number semaphore
+     */
+    public Semaphore getActivesSemaphore(int maxThreadNum) {
+        if(maxThreadNum <= 0) {
+            return null;
+        }
+
+        if (activesLimit == null || activesPermits != maxThreadNum) {
+            synchronized (this) {
+                if (activesLimit == null || activesPermits != maxThreadNum) {
+                    activesLimit = new Semaphore(maxThreadNum);
+                    activesPermits = maxThreadNum;
+                }
+            }
+        }
+
+        return activesLimit;
     }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
@@ -349,10 +349,6 @@ public class RpcStatus {
      * @return thread number semaphore
      */
     public Semaphore getActivesSemaphore(int maxThreadNum) {
-        if(maxThreadNum <= 0) {
-            return null;
-        }
-
         if (activesLimit == null || activesPermits != maxThreadNum) {
             synchronized (this) {
                 if (activesLimit == null || activesPermits != maxThreadNum) {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ActiveLimitFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ActiveLimitFilter.java
@@ -25,6 +25,8 @@ import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.RpcException;
 import org.apache.dubbo.rpc.RpcStatus;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 
 /**
  * LimitInvokerFilter
@@ -37,30 +39,28 @@ public class ActiveLimitFilter implements Filter {
         URL url = invoker.getUrl();
         String methodName = invocation.getMethodName();
         int max = invoker.getUrl().getMethodParameter(methodName, Constants.ACTIVES_KEY, 0);
+        Semaphore activesLimit = null;
+        boolean acquireResult = false;
         RpcStatus count = RpcStatus.getStatus(invoker.getUrl(), invocation.getMethodName());
         if (max > 0) {
             long timeout = invoker.getUrl().getMethodParameter(invocation.getMethodName(), Constants.TIMEOUT_KEY, 0);
             long start = System.currentTimeMillis();
-            long remain = timeout;
-            int active = count.getActive();
-            if (active >= max) {
-                synchronized (count) {
-                    while ((active = count.getActive()) >= max) {
-                        try {
-                            count.wait(remain);
-                        } catch (InterruptedException e) {
-                        }
-                        long elapsed = System.currentTimeMillis() - start;
-                        remain = timeout - elapsed;
-                        if (remain <= 0) {
-                            throw new RpcException("Waiting concurrent invoke timeout in client-side for service:  "
-                                    + invoker.getInterface().getName() + ", method: "
-                                    + invocation.getMethodName() + ", elapsed: " + elapsed
-                                    + ", timeout: " + timeout + ". concurrent invokes: " + active
-                                    + ". max concurrent invoke limit: " + max);
-                        }
-                    }
+            activesLimit = count.getActivesSemaphore(max);
+            try {
+                if(activesLimit != null && !(acquireResult = activesLimit.tryAcquire(timeout,TimeUnit.MILLISECONDS))) {
+                    long elapsed = System.currentTimeMillis() - start;
+                    int active=count.getActive();
+                    throw new RpcException("Waiting concurrent invoke timeout in client-side for service:  "
+                            + invoker.getInterface().getName() + ", method: "
+                            + invocation.getMethodName() + ", elapsed: " + elapsed
+                            + ", timeout: " + timeout + ". concurrent invokes: " + active
+                            + ". max concurrent invoke limit: " + max);
+
                 }
+            } catch (InterruptedException e) {
+                throw new RpcException("Waiting concurrent invoke fail in client-side for service:  "
+                        + invoker.getInterface().getName() + ", method: "
+                        + invocation.getMethodName());
             }
         }
         try {
@@ -76,8 +76,8 @@ public class ActiveLimitFilter implements Filter {
             }
         } finally {
             if (max > 0) {
-                synchronized (count) {
-                    count.notify();
+                if(acquireResult){
+                    activesLimit.release();
                 }
             }
         }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ActiveLimitFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ActiveLimitFilter.java
@@ -47,7 +47,7 @@ public class ActiveLimitFilter implements Filter {
             long start = System.currentTimeMillis();
             activesLimit = count.getActivesSemaphore(max);
             try {
-                if(activesLimit != null && !(acquireResult = activesLimit.tryAcquire(timeout,TimeUnit.MILLISECONDS))) {
+                if(!(acquireResult = activesLimit.tryAcquire(timeout,TimeUnit.MILLISECONDS))) {
                     long elapsed = System.currentTimeMillis() - start;
                     int active=count.getActive();
                     throw new RpcException("Waiting concurrent invoke timeout in client-side for service:  "
@@ -75,10 +75,8 @@ public class ActiveLimitFilter implements Filter {
                 throw t;
             }
         } finally {
-            if (max > 0) {
-                if(acquireResult){
-                    activesLimit.release();
-                }
+            if(acquireResult){
+                activesLimit.release();
             }
         }
     }

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ActiveLimitFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ActiveLimitFilterTest.java
@@ -102,7 +102,7 @@ public class ActiveLimitFilterTest {
         AtomicInteger count = new AtomicInteger(0);
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch latchBlocking = new CountDownLatch(totalThread);
-        URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&actives="+maxActives+"&timeout="+timeout+"");
+        URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&actives="+maxActives+"&timeout="+timeout);
         final Invoker<ActiveLimitFilterTest> invoker = new BlockMyInvoker<ActiveLimitFilterTest>(url, blockTime);
         final Invocation invocation = new MockInvocation();
         for (int i = 0; i < totalThread; i++) {
@@ -145,7 +145,7 @@ public class ActiveLimitFilterTest {
         AtomicInteger count = new AtomicInteger(0);
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch latchBlocking = new CountDownLatch(totalThread);
-        URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&actives="+maxActives+"&timeout="+timeout+"");
+        URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&actives="+maxActives+"&timeout="+timeout);
         final Invoker<ActiveLimitFilterTest> invoker = new BlockMyInvoker<ActiveLimitFilterTest>(url, blockTime);
         final Invocation invocation = new MockInvocation();
         for (int i = 0; i < totalThread; i++) {

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ActiveLimitFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ActiveLimitFilterTest.java
@@ -38,7 +38,6 @@ import static org.junit.Assert.assertNotSame;
  */
 public class ActiveLimitFilterTest {
 
-    private static AtomicInteger count = new AtomicInteger(0);
     Filter activeLimitFilter = new ActiveLimitFilter();
 
     @Test
@@ -59,6 +58,7 @@ public class ActiveLimitFilterTest {
 
     @Test
     public void testInvokeGreaterActives() {
+        AtomicInteger count = new AtomicInteger(0);
         URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&actives=1&timeout=1");
         final Invoker<ActiveLimitFilterTest> invoker = new BlockMyInvoker<ActiveLimitFilterTest>(url, 100);
         final Invocation invocation = new MockInvocation();
@@ -98,11 +98,12 @@ public class ActiveLimitFilterTest {
         int totalThread = 100;
         int maxActives = 10;
         long timeout = 1;
-        long boockTime = 100;
+        long blockTime = 100;
+        AtomicInteger count = new AtomicInteger(0);
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch latchBlocking = new CountDownLatch(totalThread);
         URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&actives="+maxActives+"&timeout="+timeout+"");
-        final Invoker<ActiveLimitFilterTest> invoker = new BlockMyInvoker<ActiveLimitFilterTest>(url, boockTime);
+        final Invoker<ActiveLimitFilterTest> invoker = new BlockMyInvoker<ActiveLimitFilterTest>(url, blockTime);
         final Invocation invocation = new MockInvocation();
         for (int i = 0; i < totalThread; i++) {
             Thread thread = new Thread(new Runnable() {
@@ -140,11 +141,12 @@ public class ActiveLimitFilterTest {
         int totalThread = 100;
         int maxActives = 10;
         long timeout = 1000;
-        long boockTime = 0;
+        long blockTime = 0;
+        AtomicInteger count = new AtomicInteger(0);
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch latchBlocking = new CountDownLatch(totalThread);
         URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&actives="+maxActives+"&timeout="+timeout+"");
-        final Invoker<ActiveLimitFilterTest> invoker = new BlockMyInvoker<ActiveLimitFilterTest>(url, boockTime);
+        final Invoker<ActiveLimitFilterTest> invoker = new BlockMyInvoker<ActiveLimitFilterTest>(url, blockTime);
         final Invocation invocation = new MockInvocation();
         for (int i = 0; i < totalThread; i++) {
             Thread thread = new Thread(new Runnable() {


### PR DESCRIPTION

## What is the purpose of the change

Solves the problem of 'ActiveLimitFilter' consumer concurrency limit #2328

## Brief changelog

adjust the concurrency limit of 'ActiveLimitFilter' to calculate atomicity by Semaphore

## Verifying this change

org.apache.dubbo.rpc.filter.ActiveLimitFilter
org.apache.dubbo.rpc.RpcStatus

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
