### PR TITLE
add jdk11 to travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 sudo: false # faster builds
 
 jdk:
+  - oraclejdk111
   - oraclejdk10
   - oraclejdk9
   - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <maven_javadoc_version>3.0.1</maven_javadoc_version>
         <maven_jetty_version>9.4.11.v20180605</maven_jetty_version>
         <maven_checkstyle_version>3.0.0</maven_checkstyle_version>
-        <maven_jacoco_version>0.8.1</maven_jacoco_version>
+        <maven_jacoco_version>0.8.2</maven_jacoco_version>
         <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
         <arguments />
         <checkstyle.skip>true</checkstyle.skip>


### PR DESCRIPTION
## What is the purpose of the change

add jdk11 to travis ci
java11 is coming: http://openjdk.java.net/projects/jdk/11/

## Brief changelog

.travis.yml

## Verifying this change

ci success

