### PR TITLE
[Dubbo-2499-2.6.x]fix PojoUtil realize type convert not support subclasses of 'java.util.date' #2499

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/CompatibleTypeUtils.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/utils/CompatibleTypeUtils.java
@@ -79,9 +79,18 @@ public class CompatibleTypeUtils {
                 return new Byte(string);
             } else if (type == Boolean.class || type == boolean.class) {
                 return new Boolean(string);
-            } else if (type == Date.class) {
+            } else if (type == Date.class || type == java.sql.Date.class || type == java.sql.Timestamp.class || type == java.sql.Time.class) {
                 try {
-                    return new SimpleDateFormat(DATE_FORMAT).parse((String) value);
+                    Date date = new SimpleDateFormat(DATE_FORMAT).parse((String) value);
+                    if (type == java.sql.Date.class) {
+                        return new java.sql.Date(date.getTime());
+                    } else if (type == java.sql.Timestamp.class) {
+                        return new java.sql.Timestamp(date.getTime());
+                    } else if (type == java.sql.Time.class) {
+                        return new java.sql.Time(date.getTime());
+                    } else {
+                        return date;
+                    }
                 } catch (ParseException e) {
                     throw new IllegalStateException("Failed to parse date " + value + " by format " + DATE_FORMAT + ", cause: " + e.getMessage(), e);
                 }

--- a/dubbo-common/src/test/java/com/alibaba/dubbo/common/utils/CompatibleTypeUtilsTest.java
+++ b/dubbo-common/src/test/java/com/alibaba/dubbo/common/utils/CompatibleTypeUtilsTest.java
@@ -68,6 +68,15 @@ public class CompatibleTypeUtilsTest {
             result = CompatibleTypeUtils.compatibleTypeConvert("2011-12-11 12:24:12", Date.class);
             assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2011-12-11 12:24:12"), (Date) result);
 
+            result = CompatibleTypeUtils.compatibleTypeConvert("2011-12-11 12:24:12", java.sql.Date.class);
+            assertEquals(new SimpleDateFormat("yyyy-MM-dd").format((java.sql.Date) result), "2011-12-11");
+
+            result = CompatibleTypeUtils.compatibleTypeConvert("2011-12-11 12:24:12", java.sql.Time.class);
+            assertEquals(new SimpleDateFormat("HH:mm:ss").format((java.sql.Time) result), "12:24:12");
+
+            result = CompatibleTypeUtils.compatibleTypeConvert("2011-12-11 12:24:12", java.sql.Timestamp.class);
+            assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format((java.sql.Timestamp) result), "2011-12-11 12:24:12");
+
             result = CompatibleTypeUtils.compatibleTypeConvert("ab", char[].class);
             assertEquals(2, ((char[]) result).length);
             assertEquals('a', ((char[]) result)[0]);

--- a/dubbo-common/src/test/java/com/alibaba/dubbo/common/utils/PojoUtilsTest.java
+++ b/dubbo-common/src/test/java/com/alibaba/dubbo/common/utils/PojoUtilsTest.java
@@ -29,8 +29,10 @@ import org.junit.Test;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -557,6 +559,34 @@ public class PojoUtilsTest {
         Parent realizeParent = (Parent) realizeParentList.getList().get(0);
         Assert.assertEquals(parent.getName(), realizeParent.getName());
         Assert.assertEquals(parent.getAge(), realizeParent.getAge());
+    }
+
+    @Test
+    public void testDateTimeTimestamp() throws Exception {
+        String dateStr = "2018-09-12";
+        String timeStr = "10:12:33";
+        String dateTimeStr = "2018-09-12 10:12:33";
+        String[] dateFormat = new String[]{"yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd", "HH:mm:ss"};
+
+        //java.util.Date
+        Object date = PojoUtils.realize(dateTimeStr, Date.class, (Type) Date.class);
+        assertEquals(Date.class, date.getClass());
+        assertEquals(dateTimeStr, new SimpleDateFormat(dateFormat[0]).format(date));
+
+        //java.sql.Time
+        Object time = PojoUtils.realize(dateTimeStr, java.sql.Time.class, (Type) java.sql.Time.class);
+        assertEquals(java.sql.Time.class, time.getClass());
+        assertEquals(timeStr, new SimpleDateFormat(dateFormat[2]).format(time));
+
+        //java.sql.Date
+        Object sqlDate = PojoUtils.realize(dateTimeStr, java.sql.Date.class, (Type) java.sql.Date.class);
+        assertEquals(java.sql.Date.class, sqlDate.getClass());
+        assertEquals(dateStr, new SimpleDateFormat(dateFormat[1]).format(sqlDate));
+
+        //java.sql.Timestamp
+        Object timestamp = PojoUtils.realize(dateTimeStr, java.sql.Timestamp.class, (Type) java.sql.Timestamp.class);
+        assertEquals(java.sql.Timestamp.class, timestamp.getClass());
+        assertEquals(dateTimeStr, new SimpleDateFormat(dateFormat[0]).format(timestamp));
     }
 
     public static class Parent {


### PR DESCRIPTION
## What is the purpose of the change

fix PojoUtil realize type convert not support subclasses of 'java.util.date' #2499 
merge to 2.6.x

## Brief changelog

The type convert was modified to support the 'java.util.date' subclass

## Verifying this change

org.apache.dubbo.common.utils.CompatibleTypeUtils.java
org.apache.dubbo.common.utils.PojoUtilsTest.java
org.apache.dubbo.common.utils.CompatibleTypeUtilsTest.java

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).