### PR TITLE
[Dubbo-2471] Fix invalid name issue in web-fragment.xml

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/web-fragment.xml
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/web-fragment.xml
@@ -2,7 +2,7 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-fragment_3_0.xsd">
 
-    <name>dubbo-fragment</name>
+    <name>dubbo_fragment</name>
 
     <ordering>
         <before>


### PR DESCRIPTION
## What is the purpose of the change

Per xsd, web fragment's name should be a valid java identifier (can have a underscore but not a hyphen).

## Brief changelog

change `-` to `_` in name element in web-fragment.xml.

## Verifying this change

n.a.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
