### PR TITLE
code promote: move constant field to Constants class

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
@@ -362,6 +362,8 @@ public class Constants {
 
     public final static String PATH_SEPARATOR = "/";
 
+    public final static String PROTOCOL_SEPARATOR = "://";
+
     public static final String REGISTRY_SEPARATOR = "|";
 
     public static final Pattern REGISTRY_SPLIT_PATTERN = Pattern

--- a/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/ZookeeperRegistry.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/ZookeeperRegistry.java
@@ -278,7 +278,7 @@ public class ZookeeperRegistry extends FailbackRegistry {
         if (providers != null && !providers.isEmpty()) {
             for (String provider : providers) {
                 provider = URL.decode(provider);
-                if (provider.contains("://")) {
+                if (provider.contains(Constants.PROTOCOL_SEPARATOR)) {
                     URL url = URL.valueOf(provider);
                     if (UrlUtils.isMatch(consumer, url)) {
                         urls.add(url);
@@ -292,7 +292,7 @@ public class ZookeeperRegistry extends FailbackRegistry {
     private List<URL> toUrlsWithEmpty(URL consumer, String path, List<String> providers) {
         List<URL> urls = toUrlsWithoutEmpty(consumer, providers);
         if (urls == null || urls.isEmpty()) {
-            int i = path.lastIndexOf('/');
+            int i = path.lastIndexOf(Constants.PATH_SEPARATOR);
             String category = i < 0 ? path : path.substring(i + 1);
             URL empty = consumer.setProtocol(Constants.EMPTY_PROTOCOL).addParameter(Constants.CATEGORY_KEY, category);
             urls.add(empty);


### PR DESCRIPTION
## What is the purpose of the change
to make to code more standard and clear

Just move constant field to Constants class and "/" will use Constants.PROTOCOL_SEPARATOR.

Thanks

