### PR TITLE
Update ConfigUtils.java

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
@@ -217,7 +217,8 @@ public class ConfigUtils {
      */
     public static Properties loadProperties(String fileName, boolean allowMultiFile, boolean optional) {
         Properties properties = new Properties();
-        if (fileName.startsWith("/")) {
+        //add scene judgement in windows environment Fix 2557
+        if (fileName.startsWith("/")||fileName.matches("^[A-z]:\\\\\\S+$")) {
             try {
                 FileInputStream input = new FileInputStream(fileName);
                 try {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
@@ -217,8 +217,8 @@ public class ConfigUtils {
      */
     public static Properties loadProperties(String fileName, boolean allowMultiFile, boolean optional) {
         Properties properties = new Properties();
-        //add scene judgement in windows environment Fix 2557
-        if (fileName.startsWith("/")||fileName.matches("^[A-z]:\\\\\\S+$")) {
+        // add scene judgement in windows environment Fix 2557
+        if (fileName.startsWith("/") || fileName.matches("^[A-z]:\\\\\\S+$")) {
             try {
                 FileInputStream input = new FileInputStream(fileName);
                 try {


### PR DESCRIPTION
add scene judgement in windows environment Fix 2557

## What is the purpose of the change

fix #2557

## Brief changelog

 add scene judgement in windows environment

## Verifying this change

When run the testcase(com.alibaba.dubbo.config.AbstractInterfaceConfigTest#checkApplication1) in windows environment,It will be wrong.

So It should add scene judgement in windows environment(org.apache.dubbo.common.utils.ConfigUtils#loadProperties(java.lang.String, boolean, boolean),Line 220).

if (fileName.startsWith("/")) {
change to

if (fileName.startsWith("/")||fileName.matches("^[A-z]:\\\\\\S+$")) {
the testcase (com.alibaba.dubbo.config.AbstractInterfaceConfigTest#checkApplication1) will go well.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
