### PR TITLE
Fix incorrect descriptions for dubbo-serialization module for 2.6.x.

### DIFF
--- a/dubbo-serialization/dubbo-serialization-api/pom.xml
+++ b/dubbo-serialization/dubbo-serialization-api/pom.xml
@@ -25,7 +25,7 @@ limitations under the License.
     <artifactId>dubbo-serialization-api</artifactId>
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
-    <description>The common module of dubbo project</description>
+    <description>The serialization interface module of dubbo project</description>
     <properties>
         <skip_maven_deploy>false</skip_maven_deploy>
     </properties>

--- a/dubbo-serialization/dubbo-serialization-fastjson/pom.xml
+++ b/dubbo-serialization/dubbo-serialization-fastjson/pom.xml
@@ -25,7 +25,7 @@ limitations under the License.
     <artifactId>dubbo-serialization-fastjson</artifactId>
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
-    <description>The common module of dubbo project</description>
+    <description>The fastjson serialization module of dubbo project</description>
     <properties>
         <skip_maven_deploy>false</skip_maven_deploy>
     </properties>

--- a/dubbo-serialization/dubbo-serialization-fst/pom.xml
+++ b/dubbo-serialization/dubbo-serialization-fst/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>dubbo-serialization-fst</artifactId>
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
-    <description>The common module of dubbo project</description>
+    <description>The fst serialization module of dubbo project</description>
     <properties>
         <skip_maven_deploy>false</skip_maven_deploy>
     </properties>

--- a/dubbo-serialization/dubbo-serialization-hessian2/pom.xml
+++ b/dubbo-serialization/dubbo-serialization-hessian2/pom.xml
@@ -25,7 +25,7 @@ limitations under the License.
     <artifactId>dubbo-serialization-hessian2</artifactId>
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
-    <description>The common module of dubbo project</description>
+    <description>The hessian2 serialization module of dubbo project</description>
     <properties>
         <skip_maven_deploy>false</skip_maven_deploy>
     </properties>

--- a/dubbo-serialization/dubbo-serialization-jdk/pom.xml
+++ b/dubbo-serialization/dubbo-serialization-jdk/pom.xml
@@ -25,7 +25,7 @@ limitations under the License.
     <artifactId>dubbo-serialization-jdk</artifactId>
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
-    <description>The common module of dubbo project</description>
+    <description>The jdk serialization module of dubbo project</description>
     <properties>
         <skip_maven_deploy>false</skip_maven_deploy>
     </properties>

--- a/dubbo-serialization/dubbo-serialization-kryo/pom.xml
+++ b/dubbo-serialization/dubbo-serialization-kryo/pom.xml
@@ -25,7 +25,7 @@ limitations under the License.
     <artifactId>dubbo-serialization-kryo</artifactId>
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
-    <description>The common module of dubbo project</description>
+    <description>The kryo serialization module of dubbo project</description>
     <properties>
         <skip_maven_deploy>false</skip_maven_deploy>
     </properties>


### PR DESCRIPTION
Fix incorrect descriptions for dubbo-serialization module for 2.6.x.
pr for master is here:
https://github.com/apache/incubator-dubbo/pull/2620