### PR TITLE
Jacoco aggregate report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -474,10 +474,10 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>jacoco-site</id>
-                        <phase>package</phase>
+                        <id>report-aggregate</id>
+                        <phase>verify</phase>
                         <goals>
-                            <goal>report</goal>
+                            <goal>report-aggregate</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
## What is the purpose of the change

JaCoCo Maven goals used to work on single modules only: Tests are executed within the module and contributed coverage only to code within the same module.
Dubbo is a multi module project which combine by api and their implements, current configuration is not suitable for Dubbo. Coverage reports were created for each module separately. 

In order to get right test coverage, we can use new goal `maven goal jacoco:report-aggregate`. This report aggregates coverage data across Maven modules.

## Brief changelog

Change maven configuration. 

## Verifying this change

CI pass and coverage increase.
