### PR TITLE
        add new feature -> globalConfigCenter  

### DIFF
--- a/dubbo-cluster/pom.xml
+++ b/dubbo-cluster/pom.xml
@@ -34,5 +34,10 @@
             <artifactId>dubbo-rpc-api</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-remoting-zookeeper</artifactId>
+            <version>2.7.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/configurator/GlobalConfiguratorCenter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/configurator/GlobalConfiguratorCenter.java
@@ -1,0 +1,49 @@
+package org.apache.dubbo.rpc.cluster.configurator;
+
+import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.remoting.zookeeper.ChildListener;
+import org.apache.dubbo.remoting.zookeeper.ZookeeperClient;
+import org.apache.dubbo.rpc.Invoker;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+
+public class GlobalConfiguratorCenter {
+    private  static final ConcurrentHashMap<String,URL> configuratorMap= new ConcurrentHashMap();
+    private  static   ZookeeperClient zkClient = null;
+
+    public static void initZkClient( ZookeeperClient zookeeperClient){
+        zkClient=zookeeperClient;
+        zkClient.addChildListener( Constants.GLOBALCONFIG_ZK_PATH, new ChildListener()  {
+            @Override
+            public void childChanged(String path, List<String> children) {
+                for (String configUrl: children) {
+                        URL url = URL.valueOf( URL.decode(configUrl));
+                        String mapKey=url.getAddress();
+                        if(mapKey!=null&&!"".equals(mapKey)) configuratorMap.put(mapKey,url);
+                }
+            }
+        });
+    }
+
+
+
+    public  static  int getInvokerWeight(Invoker<?> invoker, int deafultWeight) {
+        try {
+
+            if(invoker!=null&& invoker.getUrl()!=null){
+                URL url =  configuratorMap.get(invoker.getUrl().getAddress());
+                if(url!=null)deafultWeight =url.getParameter( Constants.WEIGHT_KEY, deafultWeight);
+                return  deafultWeight;
+            }
+        }catch (Exception e){
+            return  deafultWeight;
+        }
+        return  deafultWeight;
+    }
+
+
+
+}

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/AbstractLoadBalance.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.cluster.LoadBalance;
+import org.apache.dubbo.rpc.cluster.configurator.GlobalConfiguratorCenter;
 
 import java.util.List;
 
@@ -50,6 +51,7 @@ public abstract class AbstractLoadBalance implements LoadBalance {
 
     protected int getWeight(Invoker<?> invoker, Invocation invocation) {
         int weight = invoker.getUrl().getMethodParameter(invocation.getMethodName(), Constants.WEIGHT_KEY, Constants.DEFAULT_WEIGHT);
+            weight=  GlobalConfiguratorCenter.getInvokerWeight(invoker,weight);
         if (weight > 0) {
             long timestamp = invoker.getUrl().getParameter(Constants.REMOTE_TIMESTAMP_KEY, 0L);
             if (timestamp > 0L) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
@@ -647,6 +647,9 @@ public class Constants {
 
     public static final String REQUEST_TAG_KEY = "request.tag";
 
+
+    public static final String GLOBALCONFIG_ZK_PATH =   "/dubbo/global";
+
     /*
      * private Constants(){ }
      */


### PR DESCRIPTION
does not care about individual urls  , currently  only  add  global routing       eg.  this have two privoder  A= 192.168.1.1:1000  b=192.168.1.2:1000      i want a provder into idle status, dont receive any request  , change zk-zode gloalConfigcenter path:/dubbo/global

           node: override://192.168.2.8:20101/globalService?anyhost=true&application=*&category=global&disabled=false&&weight=0

## What is the purpose of the change
add new feature  globalConfigCenter

## Brief changelog

add class  GlobalConfiguratorCenterand its unit test.

## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
