### PR TITLE
[Dubbo-2683] Fix typo error in FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -22,4 +22,4 @@ For committers, make sure select the right label and target branch for every PR,
 
 [Example question](https://github.com/alibaba/dubbo/issues/742)  
 
-Dubbo support to specify ip/port via system environment variables, examples can be found [here](https://github.com/dubbo/dubbo-samples/tree/master/dubbo-samples-docker).
+Dubbo supports specifying ip/port via system environment variables, examples can be found [here](https://github.com/dubbo/dubbo-samples/tree/master/dubbo-samples-docker).


### PR DESCRIPTION
fix typo error in FAQ

## What is the purpose of the change

change "Dubbo support to specify" to "Dubbo supports specifying" in FAQ

## Brief changelog

change "Dubbo support to specify" to "Dubbo supports specifying" in FAQ

## Verifying this change

NA

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
