### PR TITLE
重构 ServiceBean 的 isDelay 方法，使其更符合语义

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ServiceBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ServiceBean.java
@@ -107,7 +107,7 @@ public class ServiceBean<T> extends ServiceConfig<T> implements InitializingBean
 
     @Override
     public void onApplicationEvent(ContextRefreshedEvent event) {
-        if (isDelay() && !isExported() && !isUnexported()) {
+        if (!isDelay() && !isExported() && !isUnexported()) {
             if (logger.isInfoEnabled()) {
                 logger.info("The service ready on spring started. service: " + getInterface());
             }
@@ -121,7 +121,7 @@ public class ServiceBean<T> extends ServiceConfig<T> implements InitializingBean
         if (delay == null && provider != null) {
             delay = provider.getDelay();
         }
-        return supportedApplicationListener && (delay == null || delay == -1);
+        return delay != null && delay > 0;
     }
 
     @Override
@@ -251,7 +251,7 @@ public class ServiceBean<T> extends ServiceConfig<T> implements InitializingBean
                 setPath(beanName);
             }
         }
-        if (!isDelay()) {
+        if (!supportedApplicationListener || isDelay()) {
             export();
         }
     }

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ServiceBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ServiceBean.java
@@ -107,21 +107,12 @@ public class ServiceBean<T> extends ServiceConfig<T> implements InitializingBean
 
     @Override
     public void onApplicationEvent(ContextRefreshedEvent event) {
-        if (!isDelay() && !isExported() && !isUnexported()) {
+        if (!isExported() && !isUnexported()) {
             if (logger.isInfoEnabled()) {
                 logger.info("The service ready on spring started. service: " + getInterface());
             }
             export();
         }
-    }
-
-    private boolean isDelay() {
-        Integer delay = getDelay();
-        ProviderConfig provider = getProvider();
-        if (delay == null && provider != null) {
-            delay = provider.getDelay();
-        }
-        return delay != null && delay > 0;
     }
 
     @Override
@@ -251,7 +242,7 @@ public class ServiceBean<T> extends ServiceConfig<T> implements InitializingBean
                 setPath(beanName);
             }
         }
-        if (!supportedApplicationListener || isDelay()) {
+        if (!supportedApplicationListener) {
             export();
         }
     }


### PR DESCRIPTION
 isDelay 方法目前返回值如下：
- true: delay == null || delay == -1，表示不延迟导出服务
- false: delay > 0，表示延迟导出服务

我觉得 isDelay  方法返回值如下时，更合理一些：
- true: 延迟导出服务
- false: 无需延迟导出服务

## What is the purpose of the change

Fix the wrong meaning of the method isDelay
