### PR TITLE
，不存在多线程安全的…

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistryFactory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistryFactory.java
@@ -26,6 +26,7 @@ import org.apache.dubbo.registry.RegistryService;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
@@ -44,7 +45,7 @@ public abstract class AbstractRegistryFactory implements RegistryFactory {
     private static final ReentrantLock LOCK = new ReentrantLock();
 
     // Registry Collection Map<RegistryAddress, Registry>
-    private static final Map<String, Registry> REGISTRIES = new ConcurrentHashMap<String, Registry>();
+    private static final Map<String, Registry> REGISTRIES = new HashMap<>();
 
     /**
      * Get all registries


### PR DESCRIPTION
这里REGISTRIES在使用的时候都会先加锁，不存在多线程安全的问题，所以建议把ConcurrentHashMap改成HashMap，提高运行效率。

issue ：#2685