### PR TITLE
[DUBBO-2489] MockClusterInvoker provides local forced mock，I tested it locally, but it doesn't work

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractInterfaceConfig.java
@@ -288,7 +288,36 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
         }
     }
 
-    protected void checkStubAndMock(Class<?> interfaceClass) {
+    void checkMock(Class<?> interfaceClass) {
+        if (ConfigUtils.isEmpty(mock)) {
+            return;
+        }
+
+        String normalizedMock = MockInvoker.normalizeMock(mock);
+        if (normalizedMock.startsWith(Constants.RETURN_PREFIX)) {
+            normalizedMock = normalizedMock.substring(Constants.RETURN_PREFIX.length()).trim();
+            try {
+                MockInvoker.parseMockValue(normalizedMock);
+            } catch (Exception e) {
+                throw new IllegalStateException("Illegal mock return in <dubbo:service/reference ... " +
+                        "mock=\"" + mock + "\" />");
+            }
+        } else if (normalizedMock.startsWith(Constants.THROW_PREFIX)) {
+            normalizedMock = normalizedMock.substring(Constants.THROW_PREFIX.length()).trim();
+            if (ConfigUtils.isNotEmpty(normalizedMock)) {
+                try {
+                    MockInvoker.getThrowable(normalizedMock);
+                } catch (Exception e) {
+                    throw new IllegalStateException("Illegal mock throw in <dubbo:service/reference ... " +
+                            "mock=\"" + mock + "\" />");
+                }
+            }
+        } else {
+            MockInvoker.getMockObject(normalizedMock, interfaceClass);
+        }
+    }
+
+    void checkStub(Class<?> interfaceClass) {
         if (ConfigUtils.isNotEmpty(local)) {
             Class<?> localClass = ConfigUtils.isDefault(local) ? ReflectUtils.forName(interfaceClass.getName() + "Local") : ReflectUtils.forName(local);
             if (!interfaceClass.isAssignableFrom(localClass)) {
@@ -309,26 +338,6 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
                 ReflectUtils.findConstructor(localClass, interfaceClass);
             } catch (NoSuchMethodException e) {
                 throw new IllegalStateException("No such constructor \"public " + localClass.getSimpleName() + "(" + interfaceClass.getName() + ")\" in local implementation class " + localClass.getName());
-            }
-        }
-        if (ConfigUtils.isNotEmpty(mock)) {
-            if (mock.startsWith(Constants.RETURN_PREFIX)) {
-                String value = mock.substring(Constants.RETURN_PREFIX.length());
-                try {
-                    MockInvoker.parseMockValue(value);
-                } catch (Exception e) {
-                    throw new IllegalStateException("Illegal mock json value in <dubbo:service ... mock=\"" + mock + "\" />");
-                }
-            } else {
-                Class<?> mockClass = ConfigUtils.isDefault(mock) ? ReflectUtils.forName(interfaceClass.getName() + "Mock") : ReflectUtils.forName(mock);
-                if (!interfaceClass.isAssignableFrom(mockClass)) {
-                    throw new IllegalStateException("The mock implementation class " + mockClass.getName() + " not implement interface " + interfaceClass.getName());
-                }
-                try {
-                    mockClass.getConstructor(new Class<?>[0]);
-                } catch (NoSuchMethodException e) {
-                    throw new IllegalStateException("No such empty constructor \"public " + mockClass.getSimpleName() + "()\" in mock implementation class " + mockClass.getName());
-                }
             }
         }
     }

--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ReferenceConfig.java
@@ -276,7 +276,8 @@ public class ReferenceConfig<T> extends AbstractReferenceConfig {
             }
         }
         checkApplication();
-        checkStubAndMock(interfaceClass);
+        checkStub(interfaceClass);
+        checkMock(interfaceClass);
         Map<String, String> map = new HashMap<String, String>();
         Map<Object, Object> attributes = new HashMap<Object, Object>();
         map.put(Constants.SIDE_KEY, Constants.CONSUMER_SIDE);

--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ServiceConfig.java
@@ -310,7 +310,8 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
         checkRegistry();
         checkProtocol();
         appendProperties(this);
-        checkStubAndMock(interfaceClass);
+        checkStub(interfaceClass);
+        checkMock(interfaceClass);
         if (path == null || path.length() == 0) {
             path = interfaceName;
         }

--- a/dubbo-config/dubbo-config-api/src/test/java/com/alibaba/dubbo/config/AbstractInterfaceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/com/alibaba/dubbo/config/AbstractInterfaceConfigTest.java
@@ -178,63 +178,72 @@ public class AbstractInterfaceConfigTest {
     public void checkStubAndMock1() throws Exception {
         InterfaceConfig interfaceConfig = new InterfaceConfig();
         interfaceConfig.setLocal(GreetingLocal1.class.getName());
-        interfaceConfig.checkStubAndMock(Greeting.class);
+        interfaceConfig.checkStub(Greeting.class);
+        interfaceConfig.checkMock(Greeting.class);
     }
 
     @Test(expected = IllegalStateException.class)
     public void checkStubAndMock2() throws Exception {
         InterfaceConfig interfaceConfig = new InterfaceConfig();
         interfaceConfig.setLocal(GreetingLocal2.class.getName());
-        interfaceConfig.checkStubAndMock(Greeting.class);
+        interfaceConfig.checkStub(Greeting.class);
+        interfaceConfig.checkMock(Greeting.class);
     }
 
     @Test
     public void checkStubAndMock3() throws Exception {
         InterfaceConfig interfaceConfig = new InterfaceConfig();
         interfaceConfig.setLocal(GreetingLocal3.class.getName());
-        interfaceConfig.checkStubAndMock(Greeting.class);
+        interfaceConfig.checkStub(Greeting.class);
+        interfaceConfig.checkMock(Greeting.class);
     }
 
     @Test(expected = IllegalStateException.class)
     public void checkStubAndMock4() throws Exception {
         InterfaceConfig interfaceConfig = new InterfaceConfig();
         interfaceConfig.setStub(GreetingLocal1.class.getName());
-        interfaceConfig.checkStubAndMock(Greeting.class);
+        interfaceConfig.checkStub(Greeting.class);
+        interfaceConfig.checkMock(Greeting.class);
     }
 
     @Test(expected = IllegalStateException.class)
     public void checkStubAndMock5() throws Exception {
         InterfaceConfig interfaceConfig = new InterfaceConfig();
         interfaceConfig.setStub(GreetingLocal2.class.getName());
-        interfaceConfig.checkStubAndMock(Greeting.class);
+        interfaceConfig.checkStub(Greeting.class);
+        interfaceConfig.checkMock(Greeting.class);
     }
 
     @Test
     public void checkStubAndMock6() throws Exception {
         InterfaceConfig interfaceConfig = new InterfaceConfig();
         interfaceConfig.setStub(GreetingLocal3.class.getName());
-        interfaceConfig.checkStubAndMock(Greeting.class);
+        interfaceConfig.checkStub(Greeting.class);
+        interfaceConfig.checkMock(Greeting.class);
     }
 
     @Test(expected = IllegalStateException.class)
     public void checkStubAndMock7() throws Exception {
         InterfaceConfig interfaceConfig = new InterfaceConfig();
         interfaceConfig.setMock("return {a, b}");
-        interfaceConfig.checkStubAndMock(Greeting.class);
+        interfaceConfig.checkStub(Greeting.class);
+        interfaceConfig.checkMock(Greeting.class);
     }
 
     @Test(expected = IllegalStateException.class)
     public void checkStubAndMock8() throws Exception {
         InterfaceConfig interfaceConfig = new InterfaceConfig();
         interfaceConfig.setMock(GreetingMock1.class.getName());
-        interfaceConfig.checkStubAndMock(Greeting.class);
+        interfaceConfig.checkStub(Greeting.class);
+        interfaceConfig.checkMock(Greeting.class);
     }
 
     @Test(expected = IllegalStateException.class)
     public void checkStubAndMock9() throws Exception {
         InterfaceConfig interfaceConfig = new InterfaceConfig();
         interfaceConfig.setMock(GreetingMock2.class.getName());
-        interfaceConfig.checkStubAndMock(Greeting.class);
+        interfaceConfig.checkStub(Greeting.class);
+        interfaceConfig.checkMock(Greeting.class);
     }
 
     @Test

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/support/MockInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/support/MockInvoker.java
@@ -96,26 +96,21 @@ final public class MockInvoker<T> implements Invoker<T> {
         if (StringUtils.isBlank(mock)) {
             throw new RpcException(new IllegalAccessException("mock can not be null. url :" + url));
         }
-        mock = normallizeMock(URL.decode(mock));
-        if (Constants.RETURN_PREFIX.trim().equalsIgnoreCase(mock.trim())) {
-            RpcResult result = new RpcResult();
-            result.setValue(null);
-            return result;
-        } else if (mock.startsWith(Constants.RETURN_PREFIX)) {
+        mock = normalizeMock(URL.decode(mock));
+        if (mock.startsWith(Constants.RETURN_PREFIX)) {
             mock = mock.substring(Constants.RETURN_PREFIX.length()).trim();
-            mock = mock.replace('`', '"');
             try {
                 Type[] returnTypes = RpcUtils.getReturnTypes(invocation);
                 Object value = parseMockValue(mock, returnTypes);
                 return new RpcResult(value);
             } catch (Exception ew) {
-                throw new RpcException("mock return invoke error. method :" + invocation.getMethodName() + ", mock:" + mock + ", url: " + url, ew);
+                throw new RpcException("mock return invoke error. method :" + invocation.getMethodName()
+                        + ", mock:" + mock + ", url: " + url, ew);
             }
         } else if (mock.startsWith(Constants.THROW_PREFIX)) {
             mock = mock.substring(Constants.THROW_PREFIX.length()).trim();
-            mock = mock.replace('`', '"');
             if (StringUtils.isBlank(mock)) {
-                throw new RpcException(" mocked exception for Service degradation. ");
+                throw new RpcException("mocked exception for service degradation.");
             } else { // user customized class
                 Throwable t = getThrowable(mock);
                 throw new RpcException(RpcException.BIZ_EXCEPTION, t);
@@ -125,29 +120,29 @@ final public class MockInvoker<T> implements Invoker<T> {
                 Invoker<T> invoker = getInvoker(mock);
                 return invoker.invoke(invocation);
             } catch (Throwable t) {
-                throw new RpcException("Failed to create mock implemention class " + mock, t);
+                throw new RpcException("Failed to create mock implementation class " + mock, t);
             }
         }
     }
 
-    private Throwable getThrowable(String throwstr) {
-        Throwable throwable = (Throwable) throwables.get(throwstr);
+    public static Throwable getThrowable(String throwstr) {
+        Throwable throwable = throwables.get(throwstr);
         if (throwable != null) {
             return throwable;
-        } else {
-            Throwable t = null;
-            try {
-                Class<?> bizException = ReflectUtils.forName(throwstr);
-                Constructor<?> constructor;
-                constructor = ReflectUtils.findConstructor(bizException, String.class);
-                t = (Throwable) constructor.newInstance(new Object[]{" mocked exception for Service degradation. "});
-                if (throwables.size() < 1000) {
-                    throwables.put(throwstr, t);
-                }
-            } catch (Exception e) {
-                throw new RpcException("mock throw error :" + throwstr + " argument error.", e);
+        }
+
+        try {
+            Throwable t;
+            Class<?> bizException = ReflectUtils.forName(throwstr);
+            Constructor<?> constructor;
+            constructor = ReflectUtils.findConstructor(bizException, String.class);
+            t = (Throwable) constructor.newInstance(new Object[]{"mocked exception for service degradation."});
+            if (throwables.size() < 1000) {
+                throwables.put(throwstr, t);
             }
             return t;
+        } catch (Exception e) {
+            throw new RpcException("mock throw error :" + throwstr + " argument error.", e);
         }
     }
 
@@ -156,49 +151,83 @@ final public class MockInvoker<T> implements Invoker<T> {
         Invoker<T> invoker = (Invoker<T>) mocks.get(mockService);
         if (invoker != null) {
             return invoker;
-        } else {
-            Class<T> serviceType = (Class<T>) ReflectUtils.forName(url.getServiceInterface());
-            if (ConfigUtils.isDefault(mockService)) {
-                mockService = serviceType.getName() + "Mock";
-            }
+        }
 
-            Class<?> mockClass = ReflectUtils.forName(mockService);
-            if (!serviceType.isAssignableFrom(mockClass)) {
-                throw new IllegalArgumentException("The mock implemention class " + mockClass.getName() + " not implement interface " + serviceType.getName());
-            }
+        Class<T> serviceType = (Class<T>) ReflectUtils.forName(url.getServiceInterface());
+        T mockObject = (T) getMockObject(mockService, serviceType);
+        invoker = proxyFactory.getInvoker(mockObject, serviceType, url);
+        if (mocks.size() < 10000) {
+            mocks.put(mockService, invoker);
+        }
+        return invoker;
+    }
 
-            if (!serviceType.isAssignableFrom(mockClass)) {
-                throw new IllegalArgumentException("The mock implemention class " + mockClass.getName() + " not implement interface " + serviceType.getName());
-            }
-            try {
-                T mockObject = (T) mockClass.newInstance();
-                invoker = proxyFactory.getInvoker(mockObject, (Class<T>) serviceType, url);
-                if (mocks.size() < 10000) {
-                    mocks.put(mockService, invoker);
-                }
-                return invoker;
-            } catch (InstantiationException e) {
-                throw new IllegalStateException("No such empty constructor \"public " + mockClass.getSimpleName() + "()\" in mock implemention class " + mockClass.getName(), e);
-            } catch (IllegalAccessException e) {
-                throw new IllegalStateException(e);
-            }
+    @SuppressWarnings("unchecked")
+    public static Object getMockObject(String mockService, Class serviceType) {
+        if (ConfigUtils.isDefault(mockService)) {
+            mockService = serviceType.getName() + "Mock";
+        }
+
+        Class<?> mockClass = ReflectUtils.forName(mockService);
+        if (!serviceType.isAssignableFrom(mockClass)) {
+            throw new IllegalArgumentException("The mock class " + mockClass.getName() +
+                    " not implement interface " + serviceType.getName());
+        }
+
+        try {
+            return mockClass.newInstance();
+        } catch (InstantiationException e) {
+            throw new IllegalStateException("No default constructor from mock class " + mockClass.getName(), e);
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException(e);
         }
     }
 
-    //mock=fail:throw
-    //mock=fail:return
-    //mock=xx.Service
-    private String normallizeMock(String mock) {
-        if (mock == null || mock.trim().length() == 0) {
+
+    /**
+     * Normalize mock string:
+     *
+     * <ol>
+     *     <li>return => return null</li>
+     *     <li>fail => default</li>
+     *     <li>force => default</li>
+     *     <li>fail:throw/return foo => throw/return foo</li>
+     *     <li>force:throw/return foo => throw/return foo</li>
+     * </ol>
+     * @param mock mock string
+     * @return normalized mock string
+     */
+    public static String normalizeMock(String mock) {
+        if (mock == null) {
             return mock;
-        } else if (ConfigUtils.isDefault(mock) || "fail".equalsIgnoreCase(mock.trim()) || "force".equalsIgnoreCase(mock.trim())) {
-            mock = url.getServiceInterface() + "Mock";
         }
+
+        mock = mock.trim();
+
+        if (mock.length() == 0) {
+            return mock;
+        }
+
+        if (Constants.RETURN_KEY.equalsIgnoreCase(mock)) {
+            return Constants.RETURN_PREFIX + "null";
+        }
+
+        if (ConfigUtils.isDefault(mock) || "fail".equalsIgnoreCase(mock) || "force".equalsIgnoreCase(mock)) {
+            return "default";
+        }
+
         if (mock.startsWith(Constants.FAIL_PREFIX)) {
             mock = mock.substring(Constants.FAIL_PREFIX.length()).trim();
-        } else if (mock.startsWith(Constants.FORCE_PREFIX)) {
+        }
+
+        if (mock.startsWith(Constants.FORCE_PREFIX)) {
             mock = mock.substring(Constants.FORCE_PREFIX.length()).trim();
         }
+
+        if (mock.startsWith(Constants.RETURN_PREFIX) || mock.startsWith(Constants.THROW_PREFIX)) {
+            mock = mock.replace('`', '"');
+        }
+
         return mock;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

fix https://github.com/apache/incubator-dubbo/issues/2489

## Brief changelog

dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractInterfaceConfig.java
dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ReferenceConfig.java
dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ServiceConfig.java
dubbo-config/dubbo-config-api/src/test/java/com/alibaba/dubbo/config/AbstractInterfaceConfigTest.java
dubbo-rpc/dubbo-rpc-api/src/main/java/com/alibaba/dubbo/rpc/support/MockInvoker.java

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
