### PR TITLE
[DUBBO-2748]: Provider should disable mock configuration

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ServiceConfig.java
@@ -819,6 +819,16 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
         }
     }
 
+    @Override
+    public void setMock(Boolean mock) {
+        throw new IllegalArgumentException("mock doesn't support on provider side");
+    }
+
+    @Override
+    public void setMock(String mock) {
+        throw new IllegalArgumentException("mock doesn't support on provider side");
+    }
+
     public List<URL> getExportedUrls() {
         return urls;
     }

--- a/dubbo-config/dubbo-config-api/src/test/java/com/alibaba/dubbo/config/ServiceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/com/alibaba/dubbo/config/ServiceConfigTest.java
@@ -194,6 +194,18 @@ public class ServiceConfigTest {
         service.setGeneric("illegal");
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testMock() throws Exception {
+        ServiceConfig service = new ServiceConfig();
+        service.setMock("true");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMock2() throws Exception {
+        ServiceConfig service = new ServiceConfig();
+        service.setMock(true);
+    }
+
     @Test
     public void testUniqueServiceName() throws Exception {
         ServiceConfig<Greeting> service = new ServiceConfig<Greeting>();


### PR DESCRIPTION
## What is the purpose of the change

fix #2748 

## Brief changelog

dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/ServiceConfig.java
dubbo-config/dubbo-config-api/src/test/java/com/alibaba/dubbo/config/ServiceConfigTest.java

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
