### PR TITLE
Fix the bug that ReferenceBean refers service more than once when debugging.

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/com/alibaba/dubbo/config/AbstractConfig.java
@@ -457,7 +457,8 @@ public abstract class AbstractConfig implements Serializable {
                 try {
                     String name = method.getName();
                     if ((name.startsWith("get") || name.startsWith("is"))
-                            && !"getClass".equals(name) && !"get".equals(name) && !"is".equals(name)
+                            && !"get".equals(name) && !"is".equals(name)
+                            && !"getClass".equals(name) && !"getObject".equals(name)
                             && Modifier.isPublic(method.getModifiers())
                             && method.getParameterTypes().length == 0
                             && isPrimitive(method.getReturnType())) {


### PR DESCRIPTION
## What is the purpose of the change

Fix issue [#2757](https://github.com/apache/incubator-dubbo/issues/2757) that ReferenceBean refers service more than once when debugging.
Please visit [http://t.cn/EAhta27](http://t.cn/EAhta27) for more detail

## Brief changelog

dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractConfig.java