### PR TITLE
Fixing test-order dependency in org.apache.dubbo.rpc.cluster.StickyTest

### DIFF
--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/StickyTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/StickyTest.java
@@ -19,6 +19,7 @@ package org.apache.dubbo.rpc.cluster;
 
 import org.apache.dubbo.common.Constants;
 import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
@@ -68,6 +69,8 @@ public class StickyTest {
         invokers.add(invoker2);
 
         clusterinvoker = new StickyClusterInvoker<StickyTest>(dic);
+
+        ExtensionLoader.resetExtensionLoader(LoadBalance.class);
     }
 
     @Test

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -124,6 +124,20 @@ public class ExtensionLoader<T> {
         return loader;
     }
 
+    // For testing purposes only
+    public static void resetExtensionLoader(Class type) {
+        ExtensionLoader loader = EXTENSION_LOADERS.get(type);
+        if (loader != null) {
+            // Remove all instances associated with this loader as well
+            Map<String, Class<?>> classes = loader.getExtensionClasses();
+            for (Map.Entry<String, Class<?>> entry : classes.entrySet()) {
+                EXTENSION_INSTANCES.remove(entry.getValue());
+            }
+            classes.clear();
+            EXTENSION_LOADERS.remove(type);
+        }
+    }
+
     private static ClassLoader findClassLoader() {
         return ClassHelper.getClassLoader(ExtensionLoader.class);
     }


### PR DESCRIPTION
## What is the purpose of the change

There are test-order dependencies in org.apache.dubbo.rpc.cluster.StickyTest. testStickyNoCheck fails when run after testStickyForceCheck. The tests depend on the same LoadBalance instance, which enters a different state after testStickyForceCheck runs, which then results in testStickNoCheck to fail when it runs.

The proposed fix introduces a method in ExtensionLoader to reset cached ExtensionLoader instances, for testing purposes only. StickyTest can then use this method to reset the ExtensionLoader for LoadBalance between test runs.

## Brief changelog

dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/StickyTest.java
dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
