### PR TITLE
Fixing test-order dependency for FstObjectInputTest

### DIFF
--- a/dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/fst/FstObjectOutputTest.java
+++ b/dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/fst/FstObjectOutputTest.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.common.serialize.fst;
 
 import org.apache.dubbo.common.serialize.model.AnimalEnum;
 import org.apache.dubbo.common.serialize.model.person.FullAddress;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -39,6 +40,11 @@ public class FstObjectOutputTest {
     public void setUp() {
         this.byteArrayOutputStream = new ByteArrayOutputStream();
         this.fstObjectOutput = new FstObjectOutput(byteArrayOutputStream);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        new FstObjectInput(new ByteArrayInputStream(new byte[]{0}));
     }
 
 


### PR DESCRIPTION
## What is the purpose of the change

When tests in FstObjectOutputTest, e.g., testWriteInt, runs right before FstObjectInputTest, FstObjectInputTest fails. There is some state from FstObjectInput that is preserved between the test runs that leads to FstObjectInputTest to fail when run afterwards.

The proposed fix is a patch that I found can help reset the state so FstObjectInputTest does not fail when run afterwards. The patch is based off of FstObjectOutputTest.testWriteBool, which indirectly resets the state itself. As such, another potential patch is to use the entire testWriteBool logic in the tearDown method:
```
@After
public void tearDown() throws IOException {
    this.byteArrayOutputStream = new ByteArrayOutputStream();
    this.fstObjectOutput = new FstObjectOutput(byteArrayOutputStream);
    this.fstObjectOutput.writeBool(false);
    this.flushToInput();
}
```

I would be happy to discuss other ways of fixing the issue.

## Brief changelog

dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/fst/FstObjectOutputTest.java

## Verifying this change

```
mvn test -pl dubbo-serialization/dubbo-serialization-test/ -Dtest=FstObjectOutputTest#testWriteInt,FstObjectInputTest -DfailIfNoTests=false
```
fails before the change. The same command will pass after the change.
