### PR TITLE
Fix FailbackClusterInvoker one risk of memory leak #2425

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvoker.java
@@ -50,7 +50,7 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
 
     private final int retries;
 
-    private final int failCapacitySize;
+    private final int failbacktasks;
 
     private volatile Timer failTimer;
 
@@ -61,12 +61,12 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
         if (retriesConfig <= 0) {
             retriesConfig = Constants.DEFAULT_FAILBACK_TIMES;
         }
-        int failCapacitySizeConfig = getUrl().getParameter(Constants.FAIL_BACK_TASKS_KEY, Constants.DEFAULT_FAILBACK_TASKS);
-        if (failCapacitySizeConfig <= 0) {
-            failCapacitySizeConfig = Constants.DEFAULT_FAILBACK_TASKS;
+        int failbacktasksConfig = getUrl().getParameter(Constants.FAIL_BACK_TASKS_KEY, Constants.DEFAULT_FAILBACK_TASKS);
+        if (failbacktasksConfig <= 0) {
+            failbacktasksConfig = Constants.DEFAULT_FAILBACK_TASKS;
         }
         retries = retriesConfig;
-        failCapacitySize = failCapacitySizeConfig;
+        failbacktasks = failbacktasksConfig;
     }
 
     private void addFailed(Invocation invocation, AbstractClusterInvoker<?> router) {
@@ -76,7 +76,7 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
                     failTimer = new HashedWheelTimer(
                             new NamedThreadFactory("failback-cluster-timer", true),
                             1,
-                            TimeUnit.SECONDS, 32, failCapacitySize);
+                            TimeUnit.SECONDS, 32, failbacktasks);
                 }
             }
         }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvoker.java
@@ -118,7 +118,7 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
         private final Invocation invocation;
         private final LoadBalance loadbalance;
         private final List<Invoker<T>> invokers;
-        private final List<Invoker<T>> selectedInvokers = new ArrayList<>();
+        private final List<Invoker<T>> lastInvokers = new ArrayList<>();
         private final int retries;
         private final long tick;
         private int retryTimes = 0;
@@ -129,15 +129,15 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
             this.invokers = invokers;
             this.retries = retries;
             this.tick = tick;
-            selectedInvokers.add(lastInvoker);
+            lastInvokers.add(lastInvoker);
         }
 
         @Override
         public void run(Timeout timeout) {
             try {
-                Invoker<T> retryInvoker = select(loadbalance, invocation, invokers, selectedInvokers);
-                selectedInvokers.clear();
-                selectedInvokers.add(retryInvoker);
+                Invoker<T> retryInvoker = select(loadbalance, invocation, invokers, lastInvokers);
+                lastInvokers.clear();
+                lastInvokers.add(retryInvoker);
                 retryInvoker.invoke(invocation);
             } catch (Throwable e) {
                 logger.error("Failed retry to invoke method " + invocation.getMethodName() + ", waiting again.", e);

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvoker.java
@@ -57,13 +57,13 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
     public FailbackClusterInvoker(Directory<T> directory) {
         super(directory);
 
-        int retriesConfig = getUrl().getParameter(Constants.RETRIES_KEY, Constants.DEFAULT_FAIL_RETRY_SIZE) + 1;
+        int retriesConfig = getUrl().getParameter(Constants.RETRIES_KEY, Constants.DEFAULT_FAILBACK_TIMES);
         if (retriesConfig <= 0) {
-            retriesConfig = Constants.DEFAULT_FAIL_RETRY_SIZE;
+            retriesConfig = Constants.DEFAULT_FAILBACK_TIMES;
         }
-        int failCapacitySizeConfig = getUrl().getParameter(Constants.FAIL_CAPACITY_KEY, Constants.DEFAULT_FAIL_CAPACITY_SIZE);
+        int failCapacitySizeConfig = getUrl().getParameter(Constants.FAIL_BACK_TASKS_KEY, Constants.DEFAULT_FAILBACK_TASKS);
         if (failCapacitySizeConfig <= 0) {
-            failCapacitySizeConfig = Constants.DEFAULT_FAIL_RETRY_SIZE;
+            failCapacitySizeConfig = Constants.DEFAULT_FAILBACK_TASKS;
         }
         retries = retriesConfig;
         failCapacitySize = failCapacitySizeConfig;

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvoker.java
@@ -16,90 +16,75 @@
  */
 package org.apache.dubbo.rpc.cluster.support;
 
+import org.apache.dubbo.common.Constants;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
-import org.apache.dubbo.common.threadlocal.NamedInternalThreadFactory;
+import org.apache.dubbo.common.timer.HashedWheelTimer;
+import org.apache.dubbo.common.timer.Timeout;
+import org.apache.dubbo.common.timer.Timer;
+import org.apache.dubbo.common.timer.TimerTask;
+import org.apache.dubbo.common.utils.NamedThreadFactory;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.RpcException;
 import org.apache.dubbo.rpc.RpcResult;
-import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.rpc.cluster.Directory;
 import org.apache.dubbo.rpc.cluster.LoadBalance;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * When fails, record failure requests and schedule for retry on a regular interval.
  * Especially useful for services of notification.
  *
  * <a href="http://en.wikipedia.org/wiki/Failback">Failback</a>
- *
  */
 public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
 
     private static final Logger logger = LoggerFactory.getLogger(FailbackClusterInvoker.class);
 
-    private static final long RETRY_FAILED_PERIOD = 5 * 1000;
+    private static final long RETRY_FAILED_PERIOD = 5;
 
-    /**
-     * Use {@link NamedInternalThreadFactory} to produce {@link org.apache.dubbo.common.threadlocal.InternalThread}
-     * which with the use of {@link org.apache.dubbo.common.threadlocal.InternalThreadLocal} in {@link RpcContext}.
-     */
-    private final ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(2,
-            new NamedInternalThreadFactory("failback-cluster-timer", true));
+    private final int retries;
 
-    private final ConcurrentMap<Invocation, AbstractClusterInvoker<?>> failed = new ConcurrentHashMap<>();
-    private volatile ScheduledFuture<?> retryFuture;
+    private final int failCapacitySize;
+
+    private volatile Timer failTimer;
 
     public FailbackClusterInvoker(Directory<T> directory) {
         super(directory);
+
+        int retriesConfig = getUrl().getParameter(Constants.RETRIES_KEY, Constants.DEFAULT_FAIL_RETRY_SIZE) + 1;
+        if (retriesConfig <= 0) {
+            retriesConfig = Constants.DEFAULT_FAIL_RETRY_SIZE;
+        }
+        int failCapacitySizeConfig = getUrl().getParameter(Constants.FAIL_CAPACITY_KEY, Constants.DEFAULT_FAIL_CAPACITY_SIZE);
+        if (failCapacitySizeConfig <= 0) {
+            failCapacitySizeConfig = Constants.DEFAULT_FAIL_RETRY_SIZE;
+        }
+        retries = retriesConfig;
+        failCapacitySize = failCapacitySizeConfig;
     }
 
-    private void addFailed(Invocation invocation, AbstractClusterInvoker<?> invoker) {
-        if (retryFuture == null) {
+    private void addFailed(Invocation invocation, AbstractClusterInvoker<?> router) {
+        if (failTimer == null) {
             synchronized (this) {
-                if (retryFuture == null) {
-                    retryFuture = scheduledExecutorService.scheduleWithFixedDelay(new Runnable() {
-
-                        @Override
-                        public void run() {
-                            // collect retry statistics
-                            try {
-                                retryFailed();
-                            } catch (Throwable t) { // Defensive fault tolerance
-                                logger.error("Unexpected error occur at collect statistic", t);
-                            }
-                        }
-                    }, RETRY_FAILED_PERIOD, RETRY_FAILED_PERIOD, TimeUnit.MILLISECONDS);
+                if (failTimer == null) {
+                    failTimer = new HashedWheelTimer(
+                            new NamedThreadFactory("failback-cluster-timer", true),
+                            1,
+                            TimeUnit.SECONDS, 32, failCapacitySize);
                 }
             }
         }
-        failed.put(invocation, invoker);
-    }
-
-    void retryFailed() {
-        if (failed.isEmpty()) {
-            return;
-        }
-        for (Map.Entry<Invocation, AbstractClusterInvoker<?>> entry : new HashMap<>(failed).entrySet()) {
-            Invocation invocation = entry.getKey();
-            Invoker<?> invoker = entry.getValue();
-            try {
-                invoker.invoke(invocation);
-                failed.remove(invocation);
-            } catch (Throwable e) {
-                logger.error("Failed retry to invoke method " + invocation.getMethodName() + ", waiting again.", e);
-            }
+        RetryTimerTask retryTimerTask = new RetryTimerTask(invocation, router, retries, RETRY_FAILED_PERIOD);
+        try {
+            failTimer.newTimeout(retryTimerTask, RETRY_FAILED_PERIOD, TimeUnit.SECONDS);
+        } catch (Throwable e) {
+            logger.error("Failback background works error,invocation->" + invocation + ", exception: " + e.getMessage());
         }
     }
 
@@ -117,4 +102,56 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
         }
     }
 
+    @Override
+    public void destroy() {
+        super.destroy();
+        if (failTimer != null) {
+            failTimer.stop();
+        }
+    }
+
+    /**
+     * RetryTimerTask
+     */
+    private static class RetryTimerTask implements TimerTask {
+        private final Invocation invocation;
+        private final AbstractClusterInvoker<?> router;
+        private final int retries;
+        private final long tick;
+        private final AtomicInteger retryTimes = new AtomicInteger(0);
+
+        RetryTimerTask(Invocation invocation, AbstractClusterInvoker<?> router, int retries, long tick) {
+            this.invocation = invocation;
+            this.router = router;
+            this.retries = retries;
+            this.tick = tick;
+        }
+
+        @Override
+        public void run(Timeout timeout) throws Exception {
+            try {
+                router.invoke(invocation);
+            } catch (Throwable e) {
+                logger.error("Failed retry to invoke method " + invocation.getMethodName() + ", waiting again.", e);
+                if (retryTimes.incrementAndGet() >= retries) {
+                    logger.error("Failed retry times exceed threshold (" + retries + "), We have to abandon, invocation->" + invocation);
+                } else {
+                    rePut(timeout);
+                }
+            }
+        }
+
+        private void rePut(Timeout timeout) {
+            if (timeout == null) {
+                return;
+            }
+
+            Timer timer = timeout.timer();
+            if (timer.isStop() || timeout.isCancelled()) {
+                return;
+            }
+
+            timer.newTimeout(timeout.task(), tick, TimeUnit.SECONDS);
+        }
+    }
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvoker.java
@@ -34,7 +34,6 @@ import org.apache.dubbo.rpc.cluster.LoadBalance;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * When fails, record failure requests and schedule for retry on a regular interval.
@@ -118,7 +117,7 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
         private final AbstractClusterInvoker<?> router;
         private final int retries;
         private final long tick;
-        private final AtomicInteger retryTimes = new AtomicInteger(0);
+        private int retryTimes = 0;
 
         RetryTimerTask(Invocation invocation, AbstractClusterInvoker<?> router, int retries, long tick) {
             this.invocation = invocation;
@@ -133,7 +132,7 @@ public class FailbackClusterInvoker<T> extends AbstractClusterInvoker<T> {
                 router.invoke(invocation);
             } catch (Throwable e) {
                 logger.error("Failed retry to invoke method " + invocation.getMethodName() + ", waiting again.", e);
-                if (retryTimes.incrementAndGet() >= retries) {
+                if ((++retryTimes) >= retries) {
                     logger.error("Failed retry times exceed threshold (" + retries + "), We have to abandon, invocation->" + invocation);
                 } else {
                     rePut(timeout);

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;
@@ -131,7 +132,8 @@ public class FailbackClusterInvokerTest {
         Assert.assertNull(RpcContext.getContext().getInvoker());
 //        invoker.retryFailed();// when retry the invoker which get from failed map already is not the mocked invoker,so
         //Ensure that the main thread is online
-        Thread.sleep(60000L);
+        CountDownLatch countDown = new CountDownLatch(1);
+        countDown.await();
         // it can be invoke successfully
     }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
@@ -29,6 +29,7 @@ import org.apache.dubbo.rpc.cluster.Directory;
 import org.apache.log4j.Level;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -41,6 +42,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 @SuppressWarnings("unchecked")
+@FixMethodOrder(org.junit.runners.MethodSorters.NAME_ASCENDING)
 public class FailbackClusterInvokerTest {
 
     List<Invoker<FailbackClusterInvokerTest>> invokers = new ArrayList<Invoker<FailbackClusterInvokerTest>>();
@@ -116,20 +118,21 @@ public class FailbackClusterInvokerTest {
         FailbackClusterInvoker<FailbackClusterInvokerTest> invoker = new FailbackClusterInvoker<FailbackClusterInvokerTest>(
                 dic);
         LogUtil.start();
+        DubboAppender.clear();
         invoker.invoke(invocation);
         assertEquals(1, LogUtil.findMessage("Failback to invoke"));
         LogUtil.stop();
     }
 
     @Test()
-    public void testRetryFailed() throws Exception {
+    public void testARetryFailed() throws Exception {
         //Test retries and
 
         resetInvokerToException();
 
         FailbackClusterInvoker<FailbackClusterInvokerTest> invoker = new FailbackClusterInvoker<FailbackClusterInvokerTest>(
                 dic);
-        DubboAppender.doStart();
+        LogUtil.start();
         DubboAppender.clear();
         invoker.invoke(invocation);
         invoker.invoke(invocation);
@@ -138,12 +141,11 @@ public class FailbackClusterInvokerTest {
 //        invoker.retryFailed();// when retry the invoker which get from failed map already is not the mocked invoker,so
         //Ensure that the main thread is online
         CountDownLatch countDown = new CountDownLatch(1);
-        countDown.await(30000L, TimeUnit.MILLISECONDS);
+        countDown.await(15000L, TimeUnit.MILLISECONDS);
+        LogUtil.stop();
         Assert.assertEquals("must have four error message ", 4, LogUtil.findMessage(Level.ERROR, "Failed retry to invoke method"));
         Assert.assertEquals("must have two error message ", 2, LogUtil.findMessage(Level.ERROR, "Failed retry times exceed threshold"));
         Assert.assertEquals("must have one error message ", 1, LogUtil.findMessage(Level.ERROR, "Failback background works error"));
-        LogUtil.checkNoError();
-        DubboAppender.doStop();
         // it can be invoke successfully
     }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
@@ -139,8 +139,8 @@ public class FailbackClusterInvokerTest {
         //Ensure that the main thread is online
         CountDownLatch countDown = new CountDownLatch(1);
         countDown.await(30000L, TimeUnit.MILLISECONDS);
-        Assert.assertEquals("must have one error message ", 4, LogUtil.findMessage(Level.ERROR, "Failed retry to invoke method"));
-        Assert.assertEquals("must have one error message ", 2, LogUtil.findMessage(Level.ERROR, "Failed retry times exceed threshold"));
+        Assert.assertEquals("must have four error message ", 4, LogUtil.findMessage(Level.ERROR, "Failed retry to invoke method"));
+        Assert.assertEquals("must have two error message ", 2, LogUtil.findMessage(Level.ERROR, "Failed retry times exceed threshold"));
         Assert.assertEquals("must have one error message ", 1, LogUtil.findMessage(Level.ERROR, "Failback background works error"));
         LogUtil.checkNoError();
         DubboAppender.doStop();

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
@@ -31,8 +31,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;
@@ -42,7 +40,7 @@ import static org.mockito.Mockito.mock;
 public class FailbackClusterInvokerTest {
 
     List<Invoker<FailbackClusterInvokerTest>> invokers = new ArrayList<Invoker<FailbackClusterInvokerTest>>();
-    URL url = URL.valueOf("test://test:11/test?retries=2&failbacktasks=2");
+    URL url = URL.valueOf("test://test:11/test");
     Invoker<FailbackClusterInvokerTest> invoker = mock(Invoker.class);
     RpcInvocation invocation = new RpcInvocation();
     Directory<FailbackClusterInvokerTest> dic;
@@ -78,7 +76,7 @@ public class FailbackClusterInvokerTest {
     }
 
     @Test
-    public void testInvokeException() {
+    public void testInvokeExceptoin() {
         resetInvokerToException();
         FailbackClusterInvoker<FailbackClusterInvokerTest> invoker = new FailbackClusterInvoker<FailbackClusterInvokerTest>(
                 dic);
@@ -87,7 +85,7 @@ public class FailbackClusterInvokerTest {
     }
 
     @Test()
-    public void testInvokeNoException() {
+    public void testInvokeNoExceptoin() {
 
         resetInvokerToNoException();
 
@@ -120,21 +118,15 @@ public class FailbackClusterInvokerTest {
     }
 
     @Test()
-    public void testRetryFailed() throws Exception{
-        //Test retries and
+    public void testRetryFailed() {
 
         resetInvokerToException();
 
         FailbackClusterInvoker<FailbackClusterInvokerTest> invoker = new FailbackClusterInvoker<FailbackClusterInvokerTest>(
                 dic);
         invoker.invoke(invocation);
-        invoker.invoke(invocation);
-        invoker.invoke(invocation);
         Assert.assertNull(RpcContext.getContext().getInvoker());
 //        invoker.retryFailed();// when retry the invoker which get from failed map already is not the mocked invoker,so
-        //Ensure that the main thread is online
-        CountDownLatch countDown = new CountDownLatch(1);
-        countDown.await(30000L, TimeUnit.MILLISECONDS);
         // it can be invoke successfully
     }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
@@ -41,6 +41,11 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+ /**
+  * FailbackClusterInvokerTest
+  *
+  * add annotation @FixMethodOrder, the testARetryFailed Method must to first execution
+ */
 @SuppressWarnings("unchecked")
 @FixMethodOrder(org.junit.runners.MethodSorters.NAME_ASCENDING)
 public class FailbackClusterInvokerTest {

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
@@ -126,7 +126,7 @@ public class FailbackClusterInvokerTest {
                 dic);
         invoker.invoke(invocation);
         Assert.assertNull(RpcContext.getContext().getInvoker());
-        invoker.retryFailed();// when retry the invoker which get from failed map already is not the mocked invoker,so
+//        invoker.retryFailed();// when retry the invoker which get from failed map already is not the mocked invoker,so
         // it can be invoke successfully
     }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.mock;
 public class FailbackClusterInvokerTest {
 
     List<Invoker<FailbackClusterInvokerTest>> invokers = new ArrayList<Invoker<FailbackClusterInvokerTest>>();
-    URL url = URL.valueOf("test://test:11/test");
+    URL url = URL.valueOf("test://test:11/test?retries=2&failbacktasks=2");
     Invoker<FailbackClusterInvokerTest> invoker = mock(Invoker.class);
     RpcInvocation invocation = new RpcInvocation();
     Directory<FailbackClusterInvokerTest> dic;
@@ -76,7 +76,7 @@ public class FailbackClusterInvokerTest {
     }
 
     @Test
-    public void testInvokeExceptoin() {
+    public void testInvokeException() {
         resetInvokerToException();
         FailbackClusterInvoker<FailbackClusterInvokerTest> invoker = new FailbackClusterInvoker<FailbackClusterInvokerTest>(
                 dic);
@@ -85,7 +85,7 @@ public class FailbackClusterInvokerTest {
     }
 
     @Test()
-    public void testInvokeNoExceptoin() {
+    public void testInvokeNoException() {
 
         resetInvokerToNoException();
 
@@ -118,15 +118,20 @@ public class FailbackClusterInvokerTest {
     }
 
     @Test()
-    public void testRetryFailed() {
+    public void testRetryFailed() throws Exception{
+        //Test retries and
 
         resetInvokerToException();
 
         FailbackClusterInvoker<FailbackClusterInvokerTest> invoker = new FailbackClusterInvoker<FailbackClusterInvokerTest>(
                 dic);
         invoker.invoke(invocation);
+        invoker.invoke(invocation);
+        invoker.invoke(invocation);
         Assert.assertNull(RpcContext.getContext().getInvoker());
 //        invoker.retryFailed();// when retry the invoker which get from failed map already is not the mocked invoker,so
+        //Ensure that the main thread is online
+        Thread.sleep(60000L);
         // it can be invoke successfully
     }
 }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
@@ -88,6 +88,7 @@ public class FailbackClusterInvokerTest {
                 dic);
         invoker.invoke(invocation);
         Assert.assertNull(RpcContext.getContext().getInvoker());
+        DubboAppender.clear();
     }
 
     @Test()

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;
@@ -133,7 +134,7 @@ public class FailbackClusterInvokerTest {
 //        invoker.retryFailed();// when retry the invoker which get from failed map already is not the mocked invoker,so
         //Ensure that the main thread is online
         CountDownLatch countDown = new CountDownLatch(1);
-        countDown.await();
+        countDown.await(30000L, TimeUnit.MILLISECONDS);
         // it can be invoke successfully
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
@@ -304,6 +304,8 @@ public class Constants {
 
     public static final String RETRIES_KEY = "retries";
 
+    public static final String FAIL_BACK_TASKS_KEY = "failbacktasks";
+
     public static final String PROMPT_KEY = "prompt";
 
     public static final String DEFAULT_PROMPT = "dubbo>";

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
@@ -304,8 +304,6 @@ public class Constants {
 
     public static final String RETRIES_KEY = "retries";
 
-    public static final String FAIL_BACK_TASKS_KEY = "failbacktasks";
-
     public static final String PROMPT_KEY = "prompt";
 
     public static final String DEFAULT_PROMPT = "dubbo>";

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
@@ -159,6 +159,10 @@ public class Constants {
 
     public static final int DEFAULT_RETRIES = 2;
 
+    public static final int DEFAULT_FAIL_CAPACITY_SIZE = 1000;
+
+    public static final int DEFAULT_FAIL_RETRY_SIZE = 100;
+
     // default buffer size is 8k.
     public static final int DEFAULT_BUFFER_SIZE = 8 * 1024;
 
@@ -299,6 +303,8 @@ public class Constants {
     public static final String TIMEOUT_KEY = "timeout";
 
     public static final String RETRIES_KEY = "retries";
+
+    public static final String FAIL_CAPACITY_KEY = "failcapacity";
 
     public static final String PROMPT_KEY = "prompt";
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
@@ -159,9 +159,9 @@ public class Constants {
 
     public static final int DEFAULT_RETRIES = 2;
 
-    public static final int DEFAULT_FAIL_CAPACITY_SIZE = 1000;
+    public static final int DEFAULT_FAILBACK_TASKS = 100;
 
-    public static final int DEFAULT_FAIL_RETRY_SIZE = 100;
+    public static final int DEFAULT_FAILBACK_TIMES = 3;
 
     // default buffer size is 8k.
     public static final int DEFAULT_BUFFER_SIZE = 8 * 1024;
@@ -304,7 +304,7 @@ public class Constants {
 
     public static final String RETRIES_KEY = "retries";
 
-    public static final String FAIL_CAPACITY_KEY = "failcapacity";
+    public static final String FAIL_BACK_TASKS_KEY = "failbacktasks";
 
     public static final String PROMPT_KEY = "prompt";
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
@@ -159,9 +159,9 @@ public class Constants {
 
     public static final int DEFAULT_RETRIES = 2;
 
-    public static final int DEFAULT_FAILBACK_TASKS = 100;
+    public static final int DEFAULT_FAIL_CAPACITY_SIZE = 1000;
 
-    public static final int DEFAULT_FAILBACK_TIMES = 3;
+    public static final int DEFAULT_FAIL_RETRY_SIZE = 100;
 
     // default buffer size is 8k.
     public static final int DEFAULT_BUFFER_SIZE = 8 * 1024;
@@ -304,7 +304,7 @@ public class Constants {
 
     public static final String RETRIES_KEY = "retries";
 
-    public static final String FAIL_BACK_TASKS_KEY = "failbacktasks";
+    public static final String FAIL_CAPACITY_KEY = "failcapacity";
 
     public static final String PROMPT_KEY = "prompt";
 

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/compat/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/compat/dubbo.xsd
@@ -25,6 +25,11 @@
                 <xsd:documentation><![CDATA[ The method retry times. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
+        <xsd:attribute name="failbacktasks" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[ The max failback tasks capacity size. ]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
         <xsd:attribute name="actives" type="xsd:string">
             <xsd:annotation>
                 <xsd:documentation><![CDATA[ The max active requests. ]]></xsd:documentation>

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
@@ -25,6 +25,11 @@
                 <xsd:documentation><![CDATA[ The method retry times. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
+        <xsd:attribute name="failcapacity" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[ The max failback capacity size. ]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
         <xsd:attribute name="actives" type="xsd:string">
             <xsd:annotation>
                 <xsd:documentation><![CDATA[ The max active requests. ]]></xsd:documentation>

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
@@ -25,9 +25,9 @@
                 <xsd:documentation><![CDATA[ The method retry times. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
-        <xsd:attribute name="failbacktasks" type="xsd:string">
+        <xsd:attribute name="failcapacity" type="xsd:string">
             <xsd:annotation>
-                <xsd:documentation><![CDATA[ The max failback tasks capacity size. ]]></xsd:documentation>
+                <xsd:documentation><![CDATA[ The max failback capacity size. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
         <xsd:attribute name="actives" type="xsd:string">

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
@@ -25,9 +25,9 @@
                 <xsd:documentation><![CDATA[ The method retry times. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
-        <xsd:attribute name="failcapacity" type="xsd:string">
+        <xsd:attribute name="failbacktasks" type="xsd:string">
             <xsd:annotation>
-                <xsd:documentation><![CDATA[ The max failback capacity size. ]]></xsd:documentation>
+                <xsd:documentation><![CDATA[ The max failback tasks capacity size. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
         <xsd:attribute name="actives" type="xsd:string">


### PR DESCRIPTION
1.limit the size of the map,default is 1000. can config by key failcapacity
2.retry period,default is 100.can config by key retries.
3.shutdown the timer when destroyed

The issues:
https://github.com/apache/incubator-dubbo/issues/2425
