### PR TITLE
[Dubbo-2838] Fix UT failed on windows with FileNetworkerTest

### DIFF
--- a/dubbo-remoting/dubbo-remoting-p2p/src/test/java/org/apache/dubbo/remoting/p2p/support/FileNetworkerTest.java
+++ b/dubbo-remoting/dubbo-remoting-p2p/src/test/java/org/apache/dubbo/remoting/p2p/support/FileNetworkerTest.java
@@ -51,7 +51,11 @@ public class FileNetworkerTest {
 
     @Test
     public void testJoin() throws RemotingException, InterruptedException, IOException {
-        final String groupURL = "file://" + folder.newFile();
+        String filePath = folder.newFile().getAbsolutePath();
+        if (!filePath.startsWith("/")) {
+            filePath = "/" + filePath;
+        }
+        final String groupURL = "file://" + filePath;
 
         FileNetworker networker = new FileNetworker();
         Group group = networker.lookup(URL.valueOf(groupURL));


### PR DESCRIPTION
## What is the purpose of the change

Fix Dubbo-2838

## Brief changelog

Fix FileNetworkerTest failure

## Verifying this change

Run UT on windows platform

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
