### PR TITLE
Fix UT failed on windows with FileNetworkerTest

### DIFF
--- a/dubbo-remoting/dubbo-remoting-p2p/src/test/java/org/apache/dubbo/remoting/p2p/support/FileNetworkerTest.java
+++ b/dubbo-remoting/dubbo-remoting-p2p/src/test/java/org/apache/dubbo/remoting/p2p/support/FileNetworkerTest.java
@@ -51,7 +51,7 @@ public class FileNetworkerTest {
 
     @Test
     public void testJoin() throws RemotingException, InterruptedException, IOException {
-        final String groupURL = "file://" + folder.newFile();
+        final String groupURL = "file:///" + folder.newFile();
 
         FileNetworker networker = new FileNetworker();
         Group group = networker.lookup(URL.valueOf(groupURL));


### PR DESCRIPTION
What is the purpose of the change
Fix issue-2838

Brief changelog
Fix FileNetworkerTest failure

Verifying this change
Run UT on windows platform

issue 
https://github.com/apache/incubator-dubbo/issues/2838