### PR TITLE
[Dubbo-2850] Fix consumer stub bug in multi registries

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -363,9 +363,10 @@ public class ReferenceConfig<T> extends AbstractReferenceConfig {
                 List<Invoker<?>> invokers = new ArrayList<Invoker<?>>();
                 URL registryURL = null;
                 for (URL url : urls) {
-                    invokers.add(refprotocol.refer(interfaceClass, url));
+                    Invoker tmpInvoker = refprotocol.refer(interfaceClass, url);
+                    invokers.add(tmpInvoker);
                     if (Constants.REGISTRY_PROTOCOL.equals(url.getProtocol())) {
-                        registryURL = url; // use last registry url
+                        registryURL = tmpInvoker.getUrl(); // use last registry url
                     }
                 }
                 if (registryURL != null) { // registry url is available


### PR DESCRIPTION
## What is the purpose of the change

api启动consumer时，如果配置了多个registry，stub参数无法获取到，进而导致stub逻辑无法执行，根本原因在于构造StaticDirectory时传递的url参数的refer参数并没有解析为map并添加到parameters中导致。

注：因为refer字符串参数中还包含mock配置，所以此处修改同时解决了多注册中心mock逻辑处理异常问题。

## Brief changelog

由于RegistryProtocol在refer方法中已经将refer参数解析为了map，所以改为直接调用返回的invoker的getUrl方法即可，而不是采用原始的urls变量。

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
