### PR TITLE
remove the duplicate superclass of TagRouter and ConditionRouter

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/ConditionRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/ConditionRouter.java
@@ -42,7 +42,7 @@ import java.util.regex.Pattern;
  * ConditionRouter
  *
  */
-public class ConditionRouter implements Router, Comparable<Router> {
+public class ConditionRouter implements Router {
 
     private static final Logger logger = LoggerFactory.getLogger(ConditionRouter.class);
     private static Pattern ROUTE_PATTERN = Pattern.compile("([&!=,]*)\\s*([^&!=,\\s]+)");

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/TagRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/TagRouter.java
@@ -33,7 +33,7 @@ import java.util.List;
 /**
  * TagRouter
  */
-public class TagRouter implements Router, Comparable<Router> {
+public class TagRouter implements Router {
 
     private static final Logger logger = LoggerFactory.getLogger(TagRouter.class);
 

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/script/ScriptRouterTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/script/ScriptRouterTest.java
@@ -113,7 +113,7 @@ public class ScriptRouterTest {
     }
     
     @Test
-    public void testRoute_throwExcetion() {
+    public void testRoute_throwException() {
     	List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
     	MockInvoker<String> invoker1 = new MockInvoker<String>(URL.valueOf("dubbo://10.134.108.1:20880/com.dubbo.HelloService"));
     	MockInvoker<String> invoker2 = new MockInvoker<String>(URL.valueOf("dubbo://10.134.108.2:20880/com.dubbo.HelloService"));

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/script/ScriptRouterTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/script/ScriptRouterTest.java
@@ -17,21 +17,19 @@
 package org.apache.dubbo.rpc.cluster.router.script;
 
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.dubbo.common.Constants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcInvocation;
 import org.apache.dubbo.rpc.cluster.Router;
 import org.apache.dubbo.rpc.cluster.router.MockInvoker;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import javax.script.ScriptException;
-import java.util.ArrayList;
-import java.util.List;
 
 public class ScriptRouterTest {
 
@@ -85,5 +83,48 @@ public class ScriptRouterTest {
         Assert.assertEquals(invoker3, filteredInvokers.get(1));
     }
 
-    //TODO Add tests for abnormal scene
+    @Test
+    public void testRouteHostFilter() {
+    	List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
+    	MockInvoker<String> invoker1 = new MockInvoker<String>(URL.valueOf("dubbo://10.134.108.1:20880/com.dubbo.HelloService"));
+    	MockInvoker<String> invoker2 = new MockInvoker<String>(URL.valueOf("dubbo://10.134.108.2:20880/com.dubbo.HelloService"));
+    	MockInvoker<String> invoker3 = new MockInvoker<String>(URL.valueOf("dubbo://10.134.108.3:20880/com.dubbo.HelloService"));
+        invokers.add(invoker1);
+        invokers.add(invoker2);
+        invokers.add(invoker3);
+        
+        String script = "function route(invokers, invocation, context){ " + 
+        		"	var result = new java.util.ArrayList(invokers.size()); " + 
+        		"	var targetHost = new java.util.ArrayList(); " + 
+        		"	targetHost.add(\"10.134.108.2\"); " + 
+        		"	for (var i = 0; i < invokers.length; i++) { " + 
+        		"		if(targetHost.contains(invokers[i].getUrl().getHost())){ " + 
+        		"			result.add(invokers[i]); " + 
+        		"		} " + 
+        		"	} " + 
+        		"	return result; " + 
+        		"} " + 
+        		"route(invokers, invocation, context) ";
+        
+        Router router = new ScriptRouterFactory().getRouter(getRouteUrl(script));
+        List<Invoker<String>> routeResult = router.route(invokers, invokers.get(0).getUrl(), new RpcInvocation());
+        Assert.assertEquals(1, routeResult.size());
+        Assert.assertEquals(invoker2,routeResult.get(0));
+    }
+    
+    @Test
+    public void testRoute_throwExcetion() {
+    	List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
+    	MockInvoker<String> invoker1 = new MockInvoker<String>(URL.valueOf("dubbo://10.134.108.1:20880/com.dubbo.HelloService"));
+    	MockInvoker<String> invoker2 = new MockInvoker<String>(URL.valueOf("dubbo://10.134.108.2:20880/com.dubbo.HelloService"));
+    	MockInvoker<String> invoker3 = new MockInvoker<String>(URL.valueOf("dubbo://10.134.108.3:20880/com.dubbo.HelloService"));
+        invokers.add(invoker1);
+        invokers.add(invoker2);
+        invokers.add(invoker3);
+        
+        String script = "/";
+        Router router = new ScriptRouterFactory().getRouter(getRouteUrl(script));
+        List<Invoker<String>> routeResult = router.route(invokers, invokers.get(0).getUrl(), new RpcInvocation());
+        Assert.assertEquals(3, routeResult.size());
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

the class ConditionRouter and TagRouter implement duplicate superclass Comparable

## Brief changelog
/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/router/condition/ConditionRouter.java
/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/tag/TagRouter.java
## Verifying this change

run all the test case about the two functions，and their functions are all right

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
