### PR TITLE
Fixing flaky tests in PortTelnetHandlerTest

### DIFF
--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvokerAvilableTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvokerAvilableTest.java
@@ -26,6 +26,7 @@ import org.apache.dubbo.remoting.exchange.ExchangeClient;
 import org.apache.dubbo.rpc.Exporter;
 import org.apache.dubbo.rpc.ProxyFactory;
 import org.apache.dubbo.rpc.protocol.dubbo.support.ProtocolUtils;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -49,6 +50,11 @@ public class DubboInvokerAvilableTest {
 
     @Before
     public void setUp() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        ProtocolUtils.closeAll();
     }
 
     @Test

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboLazyConnectTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboLazyConnectTest.java
@@ -22,6 +22,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.rpc.RpcException;
 import org.apache.dubbo.rpc.protocol.dubbo.support.ProtocolUtils;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -38,6 +39,11 @@ public class DubboLazyConnectTest {
 
     @Before
     public void setUp() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        ProtocolUtils.closeAll();
     }
 
     @Test(expected = RpcException.class)

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ExplicitCallbackTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ExplicitCallbackTest.java
@@ -49,6 +49,7 @@ public class ExplicitCallbackTest {
     @After
     public void tearDown() {
         destroyService();
+        ProtocolUtils.closeAll();
     }
 
     public void exportService() {

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/MultiThreadTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/MultiThreadTest.java
@@ -23,6 +23,8 @@ import org.apache.dubbo.rpc.Protocol;
 import org.apache.dubbo.rpc.ProxyFactory;
 import org.apache.dubbo.rpc.protocol.dubbo.support.DemoService;
 import org.apache.dubbo.rpc.protocol.dubbo.support.DemoServiceImpl;
+import org.apache.dubbo.rpc.protocol.dubbo.support.ProtocolUtils;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -35,6 +37,11 @@ public class MultiThreadTest {
 
     private Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
     private ProxyFactory proxy = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
+
+    @After
+    public void after() {
+        ProtocolUtils.closeAll();
+    }
 
     @Test
     public void testDubboMultiThreadInvoke() throws Exception {

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/RpcFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/RpcFilterTest.java
@@ -22,14 +22,21 @@ import org.apache.dubbo.rpc.Protocol;
 import org.apache.dubbo.rpc.ProxyFactory;
 import org.apache.dubbo.rpc.protocol.dubbo.support.DemoService;
 import org.apache.dubbo.rpc.protocol.dubbo.support.DemoServiceImpl;
+import org.apache.dubbo.rpc.protocol.dubbo.support.ProtocolUtils;
 import org.apache.dubbo.rpc.service.EchoService;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class RpcFilterTest {
     private Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
     private ProxyFactory proxy = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
+
+    @After
+    public void after() {
+        ProtocolUtils.closeAll();
+    }
 
     @Test
     public void testRpcFilter() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

Related to #2741, PortTelnetHandlerTest tests fail when run after other tests besides DubboProtocolTest. The reason for failing is the same, these other tests open new ports and servers while PortTestnetHandlerTest implicitly assumes no such new ports and servers. The change makes a similar patch as in #2741 to these other tests to close opened ports and servers.

## Brief changelog

dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvokerAvilableTest.java
dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboLazyConnectTest.java
dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ExplicitCallbackTest.java
dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/MultiThreadTest.java
dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/RpcFilterTest.java