### PR TITLE
[Dubbo 2926] standardize semantics of all mergers,enhance mergeFactory and testcases

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/ArrayMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/ArrayMerger.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.rpc.cluster.merger;
 
+import org.apache.dubbo.common.utils.ArrayUtils;
 import org.apache.dubbo.rpc.cluster.Merger;
 
 import java.lang.reflect.Array;
@@ -25,34 +26,48 @@ public class ArrayMerger implements Merger<Object[]> {
     public static final ArrayMerger INSTANCE = new ArrayMerger();
 
     @Override
-    public Object[] merge(Object[]... others) {
-        if (others.length == 0) {
-            return null;
+    public Object[] merge(Object[]... items) {
+        if (ArrayUtils.isEmpty(items)) {
+            return new Object[0];
         }
+
+        int i = 0;
+        while (i < items.length && items[i] == null) {
+            i++;
+        }
+
+        if (i == items.length) {
+            return new Object[0];
+        }
+
+        Class<?> type = items[i].getClass().getComponentType();
+
         int totalLen = 0;
-        for (int i = 0; i < others.length; i++) {
-            Object item = others[i];
-            if (item != null && item.getClass().isArray()) {
-                totalLen += Array.getLength(item);
-            } else {
-                throw new IllegalArgumentException((i + 1) + "th argument is not an array");
+        for (; i < items.length; i++) {
+            if (items[i] == null) {
+                continue;
             }
+            Class<?> itemType = items[i].getClass().getComponentType();
+            if (itemType != type) {
+                throw new IllegalArgumentException("Arguments' types are different");
+            }
+            totalLen += items[i].length;
         }
 
         if (totalLen == 0) {
-            return null;
+            return new Object[0];
         }
 
-        Class<?> type = others[0].getClass().getComponentType();
-
         Object result = Array.newInstance(type, totalLen);
+
         int index = 0;
-        for (Object array : others) {
-            for (int i = 0; i < Array.getLength(array); i++) {
-                Array.set(result, index++, Array.get(array, i));
+        for (Object[] array : items) {
+            if (array != null) {
+                for (int j = 0; j < array.length; j++) {
+                    Array.set(result, index++, array[j]);
+                }
             }
         }
         return (Object[]) result;
     }
-
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/BooleanArrayMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/BooleanArrayMerger.java
@@ -17,21 +17,29 @@
 
 package org.apache.dubbo.rpc.cluster.merger;
 
+import org.apache.dubbo.common.utils.ArrayUtils;
 import org.apache.dubbo.rpc.cluster.Merger;
 
 public class BooleanArrayMerger implements Merger<boolean[]> {
 
     @Override
     public boolean[] merge(boolean[]... items) {
+        if (ArrayUtils.isEmpty(items)) {
+            return new boolean[0];
+        }
         int totalLen = 0;
         for (boolean[] array : items) {
-            totalLen += array.length;
+            if (array != null) {
+                totalLen += array.length;
+            }
         }
         boolean[] result = new boolean[totalLen];
         int index = 0;
         for (boolean[] array : items) {
-            for (boolean item : array) {
-                result[index++] = item;
+            if (array != null) {
+                for (boolean item : array) {
+                    result[index++] = item;
+                }
             }
         }
         return result;

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/ByteArrayMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/ByteArrayMerger.java
@@ -17,21 +17,29 @@
 
 package org.apache.dubbo.rpc.cluster.merger;
 
+import org.apache.dubbo.common.utils.ArrayUtils;
 import org.apache.dubbo.rpc.cluster.Merger;
 
 public class ByteArrayMerger implements Merger<byte[]> {
 
     @Override
     public byte[] merge(byte[]... items) {
+        if (ArrayUtils.isEmpty(items)) {
+            return new byte[0];
+        }
         int total = 0;
         for (byte[] array : items) {
-            total += array.length;
+            if (array != null) {
+                total += array.length;
+            }
         }
         byte[] result = new byte[total];
         int index = 0;
         for (byte[] array : items) {
-            for (byte item : array) {
-                result[index++] = item;
+            if (array != null) {
+                for (byte item : array) {
+                    result[index++] = item;
+                }
             }
         }
         return result;

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/CharArrayMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/CharArrayMerger.java
@@ -17,21 +17,29 @@
 
 package org.apache.dubbo.rpc.cluster.merger;
 
+import org.apache.dubbo.common.utils.ArrayUtils;
 import org.apache.dubbo.rpc.cluster.Merger;
 
 public class CharArrayMerger implements Merger<char[]> {
 
     @Override
     public char[] merge(char[]... items) {
+        if (ArrayUtils.isEmpty(items)) {
+            return new char[0];
+        }
         int total = 0;
         for (char[] array : items) {
-            total += array.length;
+            if (array != null) {
+                total += array.length;
+            }
         }
         char[] result = new char[total];
         int index = 0;
         for (char[] array : items) {
-            for (char item : array) {
-                result[index++] = item;
+            if (array != null) {
+                for (char item : array) {
+                    result[index++] = item;
+                }
             }
         }
         return result;

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/DoubleArrayMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/DoubleArrayMerger.java
@@ -17,21 +17,29 @@
 
 package org.apache.dubbo.rpc.cluster.merger;
 
+import org.apache.dubbo.common.utils.ArrayUtils;
 import org.apache.dubbo.rpc.cluster.Merger;
 
 public class DoubleArrayMerger implements Merger<double[]> {
 
     @Override
     public double[] merge(double[]... items) {
+        if (ArrayUtils.isEmpty(items)) {
+            return new double[0];
+        }
         int total = 0;
         for (double[] array : items) {
-            total += array.length;
+            if (array != null) {
+                total += array.length;
+            }
         }
         double[] result = new double[total];
         int index = 0;
         for (double[] array : items) {
-            for (double item : array) {
-                result[index++] = item;
+            if (array != null) {
+                for (double item : array) {
+                    result[index++] = item;
+                }
             }
         }
         return result;

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/FloatArrayMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/FloatArrayMerger.java
@@ -17,21 +17,29 @@
 
 package org.apache.dubbo.rpc.cluster.merger;
 
+import org.apache.dubbo.common.utils.ArrayUtils;
 import org.apache.dubbo.rpc.cluster.Merger;
 
 public class FloatArrayMerger implements Merger<float[]> {
 
     @Override
     public float[] merge(float[]... items) {
+        if (ArrayUtils.isEmpty(items)) {
+            return new float[0];
+        }
         int total = 0;
         for (float[] array : items) {
-            total += array.length;
+            if (array != null) {
+                total += array.length;
+            }
         }
         float[] result = new float[total];
         int index = 0;
         for (float[] array : items) {
-            for (float item : array) {
-                result[index++] = item;
+            if (array != null) {
+                for (float item : array) {
+                    result[index++] = item;
+                }
             }
         }
         return result;

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/IntArrayMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/IntArrayMerger.java
@@ -17,21 +17,29 @@
 
 package org.apache.dubbo.rpc.cluster.merger;
 
+import org.apache.dubbo.common.utils.ArrayUtils;
 import org.apache.dubbo.rpc.cluster.Merger;
 
 public class IntArrayMerger implements Merger<int[]> {
 
     @Override
     public int[] merge(int[]... items) {
+        if (ArrayUtils.isEmpty(items)) {
+            return new int[0];
+        }
         int totalLen = 0;
-        for (int[] item : items) {
-            totalLen += item.length;
+        for (int[] array : items) {
+            if (array != null) {
+                totalLen += array.length;
+            }
         }
         int[] result = new int[totalLen];
         int index = 0;
-        for (int[] item : items) {
-            for (int i : item) {
-                result[index++] = i;
+        for (int[] array : items) {
+            if (array != null) {
+                for (int item : array) {
+                    result[index++] = item;
+                }
             }
         }
         return result;

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/ListMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/ListMerger.java
@@ -17,15 +17,20 @@
 
 package org.apache.dubbo.rpc.cluster.merger;
 
+import org.apache.dubbo.common.utils.ArrayUtils;
 import org.apache.dubbo.rpc.cluster.Merger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class ListMerger implements Merger<List<?>> {
 
     @Override
     public List<Object> merge(List<?>... items) {
+        if (ArrayUtils.isEmpty(items)) {
+            return Collections.emptyList();
+        }
         List<Object> result = new ArrayList<Object>();
         for (List<?> item : items) {
             if (item != null) {

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/LongArrayMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/LongArrayMerger.java
@@ -17,21 +17,29 @@
 
 package org.apache.dubbo.rpc.cluster.merger;
 
+import org.apache.dubbo.common.utils.ArrayUtils;
 import org.apache.dubbo.rpc.cluster.Merger;
 
 public class LongArrayMerger implements Merger<long[]> {
 
     @Override
     public long[] merge(long[]... items) {
+        if (ArrayUtils.isEmpty(items)) {
+            return new long[0];
+        }
         int total = 0;
         for (long[] array : items) {
-            total += array.length;
+            if (array != null) {
+                total += array.length;
+            }
         }
         long[] result = new long[total];
         int index = 0;
         for (long[] array : items) {
-            for (long item : array) {
-                result[index++] = item;
+            if (array != null) {
+                for (long item : array) {
+                    result[index++] = item;
+                }
             }
         }
         return result;

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/MapMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/MapMerger.java
@@ -16,8 +16,10 @@
  */
 package org.apache.dubbo.rpc.cluster.merger;
 
+import org.apache.dubbo.common.utils.ArrayUtils;
 import org.apache.dubbo.rpc.cluster.Merger;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,8 +27,8 @@ public class MapMerger implements Merger<Map<?, ?>> {
 
     @Override
     public Map<?, ?> merge(Map<?, ?>... items) {
-        if (items.length == 0) {
-            return null;
+        if (ArrayUtils.isEmpty(items)) {
+            return Collections.emptyMap();
         }
         Map<Object, Object> result = new HashMap<Object, Object>();
         for (Map<?, ?> item : items) {

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/MergerFactory.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/MergerFactory.java
@@ -30,7 +30,19 @@ public class MergerFactory {
     private static final ConcurrentMap<Class<?>, Merger<?>> mergerCache =
             new ConcurrentHashMap<Class<?>, Merger<?>>();
 
+    /**
+     * Find the merger according to the returnType class, the merger will
+     * merge an array of returnType into one
+     *
+     * @param returnType the merger will return this type
+     * @return the merger which merges an array of returnType into one, return null if not exist
+     * @throws IllegalArgumentException if returnType is null
+     */
     public static <T> Merger<T> getMerger(Class<T> returnType) {
+        if (returnType == null) {
+            throw new IllegalArgumentException("returnType is null");
+        }
+
         Merger result;
         if (returnType.isArray()) {
             Class type = returnType.getComponentType();

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/SetMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/SetMerger.java
@@ -16,8 +16,10 @@
  */
 package org.apache.dubbo.rpc.cluster.merger;
 
+import org.apache.dubbo.common.utils.ArrayUtils;
 import org.apache.dubbo.rpc.cluster.Merger;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -25,7 +27,9 @@ public class SetMerger implements Merger<Set<?>> {
 
     @Override
     public Set<Object> merge(Set<?>... items) {
-
+        if (ArrayUtils.isEmpty(items)) {
+            return Collections.emptySet();
+        }
         Set<Object> result = new HashSet<Object>();
 
         for (Set<?> item : items) {

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/ShortArrayMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/ShortArrayMerger.java
@@ -17,21 +17,29 @@
 
 package org.apache.dubbo.rpc.cluster.merger;
 
+import org.apache.dubbo.common.utils.ArrayUtils;
 import org.apache.dubbo.rpc.cluster.Merger;
 
 public class ShortArrayMerger implements Merger<short[]> {
 
     @Override
     public short[] merge(short[]... items) {
+        if (ArrayUtils.isEmpty(items)) {
+            return new short[0];
+        }
         int total = 0;
         for (short[] array : items) {
-            total += array.length;
+            if (array != null) {
+                total += array.length;
+            }
         }
         short[] result = new short[total];
         int index = 0;
         for (short[] array : items) {
-            for (short item : array) {
-                result[index++] = item;
+            if (array != null) {
+                for (short item : array) {
+                    result[index++] = item;
+                }
             }
         }
         return result;

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/merger/ResultMergerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/merger/ResultMergerTest.java
@@ -28,18 +28,45 @@ import java.util.Map;
 import java.util.Set;
 
 public class ResultMergerTest {
+
     /**
-     * ArrayMerger test
-     *
-     * @throws Exception
+     * MergerFactory test
      */
     @Test
-    public void testArrayMerger() throws Exception {
+    public void testMergerFactoryIllegalArgumentException() {
+        try {
+            MergerFactory.getMerger(null);
+            Assert.fail("expected IllegalArgumentException for null argument");
+        } catch (IllegalArgumentException exception) {
+            Assert.assertEquals("returnType is null", exception.getMessage());
+        }
+    }
+
+    /**
+     * ArrayMerger test
+     */
+    @Test
+    public void testArrayMergerIllegalArgumentException() {
+        String[] stringArray = {"1", "2", "3"};
+        Integer[] integerArray = {3, 4, 5};
+        try {
+            Object result = ArrayMerger.INSTANCE.merge(stringArray, null, integerArray);
+            Assert.fail("expected IllegalArgumentException for different arguments' types");
+        } catch (IllegalArgumentException exception) {
+            Assert.assertEquals("Arguments' types are different", exception.getMessage());
+        }
+    }
+
+    /**
+     * ArrayMerger test
+     */
+    @Test
+    public void testArrayMerger() {
         String[] stringArray1 = {"1", "2", "3"};
         String[] stringArray2 = {"4", "5", "6"};
         String[] stringArray3 = {};
 
-        Object result = ArrayMerger.INSTANCE.merge(stringArray1, stringArray2, stringArray3);
+        Object result = ArrayMerger.INSTANCE.merge(stringArray1, stringArray2, stringArray3, null);
         Assert.assertTrue(result.getClass().isArray());
         Assert.assertEquals(6, Array.getLength(result));
         Assert.assertTrue(String.class.isInstance(Array.get(result, 0)));
@@ -47,139 +74,170 @@ public class ResultMergerTest {
             Assert.assertEquals(String.valueOf(i + 1), Array.get(result, i));
         }
 
-        int[] intArray1 = {1, 2, 3};
-        int[] intArray2 = {4, 5, 6};
-        int[] intArray3 = {7};
-        result = MergerFactory.getMerger(int[].class).merge(intArray1, intArray2, intArray3);
+        Integer[] intArray1 = {1, 2, 3};
+        Integer[] intArray2 = {4, 5, 6};
+        Integer[] intArray3 = {7};
+        // trigger ArrayMerger
+        result = MergerFactory.getMerger(Integer[].class).merge(intArray1, intArray2, intArray3, null);
         Assert.assertTrue(result.getClass().isArray());
         Assert.assertEquals(7, Array.getLength(result));
-        Assert.assertTrue(int.class == result.getClass().getComponentType());
+        Assert.assertTrue(Integer.class == result.getClass().getComponentType());
         for (int i = 0; i < 7; i++) {
             Assert.assertEquals(i + 1, Array.get(result, i));
         }
 
+        result = ArrayMerger.INSTANCE.merge(null);
+        Assert.assertEquals(0, Array.getLength(result));
+
+        result = ArrayMerger.INSTANCE.merge(null, null);
+        Assert.assertEquals(0, Array.getLength(result));
+
+        result = ArrayMerger.INSTANCE.merge(null, new Object[0]);
+        Assert.assertEquals(0, Array.getLength(result));
     }
 
     /**
      * BooleanArrayMerger test
-     *
-     * @throws Exception
      */
     @Test
-    public void testBooleanArrayMerger() throws Exception {
+    public void testBooleanArrayMerger() {
         boolean[] arrayOne = {true, false};
         boolean[] arrayTwo = {false};
-        boolean[] result = MergerFactory.getMerger(boolean[].class).merge(arrayOne, arrayTwo);
+        boolean[] result = MergerFactory.getMerger(boolean[].class).merge(arrayOne, arrayTwo, null);
         Assert.assertEquals(3, result.length);
         boolean[] mergedResult = {true, false, false};
         for (int i = 0; i < mergedResult.length; i++) {
             Assert.assertEquals(mergedResult[i], result[i]);
         }
+
+        result = MergerFactory.getMerger(boolean[].class).merge(null);
+        Assert.assertEquals(0, result.length);
+
+        result = MergerFactory.getMerger(boolean[].class).merge(null, null);
+        Assert.assertEquals(0, result.length);
     }
 
     /**
      * ByteArrayMerger test
-     *
-     * @throws Exception
      */
     @Test
-    public void testByteArrayMerger() throws Exception {
+    public void testByteArrayMerger() {
         byte[] arrayOne = {1, 2};
         byte[] arrayTwo = {1, 32};
-        byte[] result = MergerFactory.getMerger(byte[].class).merge(arrayOne, arrayTwo);
+        byte[] result = MergerFactory.getMerger(byte[].class).merge(arrayOne, arrayTwo, null);
         Assert.assertEquals(4, result.length);
         byte[] mergedResult = {1, 2, 1, 32};
         for (int i = 0; i < mergedResult.length; i++) {
             Assert.assertEquals(mergedResult[i], result[i]);
         }
+
+        result = MergerFactory.getMerger(byte[].class).merge(null);
+        Assert.assertEquals(0, result.length);
+
+        result = MergerFactory.getMerger(byte[].class).merge(null, null);
+        Assert.assertEquals(0, result.length);
     }
 
     /**
      * CharArrayMerger test
-     *
-     * @throws Exception
      */
     @Test
-    public void testCharArrayMerger() throws Exception {
+    public void testCharArrayMerger() {
         char[] arrayOne = "hello".toCharArray();
         char[] arrayTwo = "world".toCharArray();
-        char[] result = MergerFactory.getMerger(char[].class).merge(arrayOne, arrayTwo);
+        char[] result = MergerFactory.getMerger(char[].class).merge(arrayOne, arrayTwo, null);
         Assert.assertEquals(10, result.length);
         char[] mergedResult = "helloworld".toCharArray();
         for (int i = 0; i < mergedResult.length; i++) {
             Assert.assertEquals(mergedResult[i], result[i]);
         }
+
+        result = MergerFactory.getMerger(char[].class).merge(null);
+        Assert.assertEquals(0, result.length);
+
+        result = MergerFactory.getMerger(char[].class).merge(null, null);
+        Assert.assertEquals(0, result.length);
     }
 
     /**
      * DoubleArrayMerger test
-     *
-     * @throws Exception
      */
     @Test
-    public void testDoubleArrayMerger() throws Exception {
+    public void testDoubleArrayMerger() {
         double[] arrayOne = {1.2d, 3.5d};
         double[] arrayTwo = {2d, 34d};
-        double[] result = MergerFactory.getMerger(double[].class).merge(arrayOne, arrayTwo);
+        double[] result = MergerFactory.getMerger(double[].class).merge(arrayOne, arrayTwo, null);
         Assert.assertEquals(4, result.length);
         double[] mergedResult = {1.2d, 3.5d, 2d, 34d};
         for (int i = 0; i < mergedResult.length; i++) {
             Assert.assertTrue(mergedResult[i] == result[i]);
         }
+
+        result = MergerFactory.getMerger(double[].class).merge(null);
+        Assert.assertEquals(0, result.length);
+
+        result = MergerFactory.getMerger(double[].class).merge(null, null);
+        Assert.assertEquals(0, result.length);
     }
 
     /**
      * FloatArrayMerger test
-     *
-     * @throws Exception
      */
     @Test
-    public void testFloatArrayMerger() throws Exception {
+    public void testFloatArrayMerger() {
         float[] arrayOne = {1.2f, 3.5f};
         float[] arrayTwo = {2f, 34f};
-        float[] result = MergerFactory.getMerger(float[].class).merge(arrayOne, arrayTwo);
+        float[] result = MergerFactory.getMerger(float[].class).merge(arrayOne, arrayTwo, null);
         Assert.assertEquals(4, result.length);
         double[] mergedResult = {1.2f, 3.5f, 2f, 34f};
         for (int i = 0; i < mergedResult.length; i++) {
             Assert.assertTrue(mergedResult[i] == result[i]);
         }
+
+        result = MergerFactory.getMerger(float[].class).merge(null);
+        Assert.assertEquals(0, result.length);
+
+        result = MergerFactory.getMerger(float[].class).merge(null, null);
+        Assert.assertEquals(0, result.length);
     }
 
     /**
      * IntArrayMerger test
-     *
-     * @throws Exception
      */
     @Test
-    public void testIntArrayMerger() throws Exception {
+    public void testIntArrayMerger() {
         int[] arrayOne = {1, 2};
         int[] arrayTwo = {2, 34};
-        int[] result = MergerFactory.getMerger(int[].class).merge(arrayOne, arrayTwo);
+        int[] result = MergerFactory.getMerger(int[].class).merge(arrayOne, arrayTwo, null);
         Assert.assertEquals(4, result.length);
         double[] mergedResult = {1, 2, 2, 34};
         for (int i = 0; i < mergedResult.length; i++) {
             Assert.assertTrue(mergedResult[i] == result[i]);
         }
+
+        result = MergerFactory.getMerger(int[].class).merge(null);
+        Assert.assertEquals(0, result.length);
+
+        result = MergerFactory.getMerger(int[].class).merge(null, null);
+        Assert.assertEquals(0, result.length);
     }
 
     /**
      * ListMerger test
-     *
-     * @throws Exception
      */
     @Test
-    public void testListMerger() throws Exception {
-        List<Object> list1 = new ArrayList<Object>(){{
+    public void testListMerger() {
+        List<Object> list1 = new ArrayList<Object>() {{
             add(null);
             add("1");
-            add("2"); 
+            add("2");
         }};
-        List<Object> list2 = new ArrayList<Object>(){{
+        List<Object> list2 = new ArrayList<Object>() {{
             add("3");
             add("4");
         }};
 
-        List result = MergerFactory.getMerger(List.class).merge(list1, list2);
+        List result = MergerFactory.getMerger(List.class).merge(list1, list2, null);
         Assert.assertEquals(5, result.size());
         ArrayList<String> expected = new ArrayList<String>() {{
             add(null);
@@ -189,67 +247,82 @@ public class ResultMergerTest {
             add("4");
         }};
         Assert.assertEquals(expected, result);
+
+        result = MergerFactory.getMerger(List.class).merge(null);
+        Assert.assertEquals(0, result.size());
+
+        result = MergerFactory.getMerger(List.class).merge(null, null);
+        Assert.assertEquals(0, result.size());
     }
 
     /**
      * LongArrayMerger test
-     *
-     * @throws Exception
      */
     @Test
-    public void testMapArrayMerger() throws Exception {
-        Map<Object, Object> mapOne = new HashMap() {{
+    public void testMapArrayMerger() {
+        Map<Object, Object> mapOne = new HashMap<Object, Object>() {{
             put("11", 222);
             put("223", 11);
         }};
-        Map<Object, Object> mapTwo = new HashMap() {{
+        Map<Object, Object> mapTwo = new HashMap<Object, Object>() {{
             put("3333", 3232);
             put("444", 2323);
         }};
-        Map<Object, Object> result = MergerFactory.getMerger(Map.class).merge(mapOne, mapTwo);
+        Map<Object, Object> result = MergerFactory.getMerger(Map.class).merge(mapOne, mapTwo, null);
         Assert.assertEquals(4, result.size());
-        Map<Object, Object> mergedResult = new HashMap() {{
+        Map<String, Integer> mergedResult = new HashMap<String, Integer>() {{
             put("11", 222);
             put("223", 11);
             put("3333", 3232);
             put("444", 2323);
         }};
         Assert.assertEquals(mergedResult, result);
+
+        result = MergerFactory.getMerger(Map.class).merge(null);
+        Assert.assertEquals(0, result.size());
+
+        result = MergerFactory.getMerger(Map.class).merge(null, null);
+        Assert.assertEquals(0, result.size());
     }
 
     /**
      * LongArrayMerger test
-     *
-     * @throws Exception
      */
     @Test
-    public void testLongArrayMerger() throws Exception {
+    public void testLongArrayMerger() {
         long[] arrayOne = {1l, 2l};
         long[] arrayTwo = {2l, 34l};
-        long[] result = MergerFactory.getMerger(long[].class).merge(arrayOne, arrayTwo);
+        long[] result = MergerFactory.getMerger(long[].class).merge(arrayOne, arrayTwo, null);
         Assert.assertEquals(4, result.length);
         double[] mergedResult = {1l, 2l, 2l, 34l};
         for (int i = 0; i < mergedResult.length; i++) {
             Assert.assertTrue(mergedResult[i] == result[i]);
         }
+
+        result = MergerFactory.getMerger(long[].class).merge(null);
+        Assert.assertEquals(0, result.length);
+
+        result = MergerFactory.getMerger(long[].class).merge(null, null);
+        Assert.assertEquals(0, result.length);
     }
 
     /**
      * SetMerger test
-     *
-     * @throws Exception
      */
     @Test
-    public void testSetMerger() throws Exception {
-        Set<Object> set1 = new HashSet<Object>();
-        set1.add(null);
-        set1.add("1");
-        set1.add("2");
-        Set<Object> set2 = new HashSet<Object>();
-        set2.add("2");
-        set2.add("3");
+    public void testSetMerger() {
+        Set<Object> set1 = new HashSet<Object>() {{
+            add(null);
+            add("1");
+            add("2");
+        }};
 
-        Set result = MergerFactory.getMerger(Set.class).merge(set1, set2);
+        Set<Object> set2 = new HashSet<Object>() {{
+            add("2");
+            add("3");
+        }};
+
+        Set result = MergerFactory.getMerger(Set.class).merge(set1, set2, null);
 
         Assert.assertEquals(4, result.size());
         Assert.assertEquals(new HashSet<String>() {
@@ -260,22 +333,32 @@ public class ResultMergerTest {
                 add("3");
             }
         }, result);
+
+        result = MergerFactory.getMerger(Set.class).merge(null);
+        Assert.assertEquals(0, result.size());
+
+        result = MergerFactory.getMerger(Set.class).merge(null, null);
+        Assert.assertEquals(0, result.size());
     }
 
     /**
      * ShortArrayMerger test
-     *
-     * @throws Exception
      */
     @Test
-    public void testShortArrayMerger() throws Exception {
+    public void testShortArrayMerger() {
         short[] arrayOne = {1, 2};
         short[] arrayTwo = {2, 34};
-        short[] result = MergerFactory.getMerger(short[].class).merge(arrayOne, arrayTwo);
+        short[] result = MergerFactory.getMerger(short[].class).merge(arrayOne, arrayTwo, null);
         Assert.assertEquals(4, result.length);
         double[] mergedResult = {1, 2, 2, 34};
         for (int i = 0; i < mergedResult.length; i++) {
             Assert.assertTrue(mergedResult[i] == result[i]);
         }
+
+        result = MergerFactory.getMerger(short[].class).merge(null);
+        Assert.assertEquals(0, result.length);
+
+        result = MergerFactory.getMerger(short[].class).merge(null, null);
+        Assert.assertEquals(0, result.length);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This patch can standardize semantics of all mergers :  merge arguments can be null , and all the others should have same type . 

For ArrayMerger , as its argument type is  Object[]... items ,  so we can avoid checking whether item[i] is
an Array . Also , in order to avoid problems like 
```
        class Person{};
        class Teacher extends Person{};
        Person[] a= {new Person()};
        Teacher[] b= {new Teacher()};
        Object[] result = ArrayMerger.INSTANCE.merge(a,b);
```
we can require all elements to have the same type , al least the user should pass in the same type

For MergerFactory , if the required class is not in cache , we can throw an user friendly Exception 

For test case , I add some exception case , and fix an ArrayMerger case , also add some null argument
test case . 


## Brief changelog

dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/*
dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/merger/ResultMergerTest


## Verifying this change

mvn clean install -DskipTests
