### PR TITLE
Limit the times of registry retry.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
@@ -488,9 +488,19 @@ public class Constants {
     public static final String REGISTRY_RETRY_PERIOD_KEY = "retry.period";
 
     /**
+     * Most retry times
+     */
+    public static final String REGISTRY_RETRY_TIMES_KEY = "retry.times";
+
+    /**
      * Default value for the period of retry interval in milliseconds: 5000
      */
     public static final int DEFAULT_REGISTRY_RETRY_PERIOD = 5 * 1000;
+
+    /**
+     * Default value for the times of retry: 3
+     */
+    public static final int DEFAULT_REGISTRY_RETRY_TIMES = 3;
 
     /**
      * Reconnection period in milliseconds for register center


### PR DESCRIPTION
The default value is 3. 
Limiting the number of retries prevents memory leaks in some extreme cases.
