### PR TITLE
fix issue-2948:spring boot external config invalid

### DIFF
--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/PropertySourcesUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/PropertySourcesUtils.java
@@ -55,7 +55,7 @@ public abstract class PropertySourcesUtils {
                     if (name.startsWith(normalizedPrefix)) {
                         String subName = name.substring(normalizedPrefix.length());
                         String value = propertyResolver.getProperty(name);
-                        subProperties.put(subName, value);
+                        subProperties.putIfAbsent(subName, value);
                     }
                 }
             }


### PR DESCRIPTION
### Environment

* Dubbo version: 2.6.0
* Operating System version: Red Hat Enterprise Linux Server release 6.3
* Java version: 1.8.0_92

### Steps to reproduce this issue

Spring Boot使用外部配置文件,没有起作用,还是使用的包内application.properties