### PR TITLE
[Dubbo-619] Fix consumer will generate wrong stackTrace

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/RpcResultTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/RpcResultTest.java
@@ -1,0 +1,61 @@
+package org.apache.dubbo.rpc;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class RpcResultTest {
+    @Test
+    public void testRecreateWithNormalException() {
+        NullPointerException npe = new NullPointerException();
+        RpcResult rpcResult = new RpcResult(npe);
+        try {
+            rpcResult.recreate();
+            fail();
+        } catch (Throwable throwable) {
+            StackTraceElement[] stackTrace = throwable.getStackTrace();
+            Assert.assertNotNull(stackTrace);
+            Assert.assertTrue(stackTrace.length > 1);
+        }
+    }
+
+    /**
+     * please run this test in Run mode
+     */
+    @Test
+    public void testRecreateWithEmptyStackTraceException() {
+        // begin to construct a NullPointerException with empty stackTrace
+        Throwable throwable = null;
+        Long begin = System.currentTimeMillis();
+        while (System.currentTimeMillis() - begin < 60000) {
+            try {
+                ((Object) null).getClass();
+            } catch (Exception e) {
+                if (e.getStackTrace().length == 0) {
+                    throwable = e;
+                    break;
+                }
+            }
+        }
+        /**
+         * may be there is -XX:-OmitStackTraceInFastThrow or run in Debug mode
+         */
+        if (throwable == null) {
+            System.out.println("###testRecreateWithEmptyStackTraceException fail to construct NPE");
+            return;
+        }
+        // end construct a NullPointerException with empty stackTrace
+
+        RpcResult rpcResult = new RpcResult(throwable);
+        try {
+            rpcResult.recreate();
+            fail();
+        } catch (Throwable t) {
+            StackTraceElement[] stackTrace = t.getStackTrace();
+            Assert.assertNotNull(stackTrace);
+            Assert.assertTrue(stackTrace.length == 0);
+        }
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/RpcResultTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/RpcResultTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.rpc;
 
 


### PR DESCRIPTION
Fix #619
Recur this bug in https://github.com/zhaixiaoxiang/dubbo-examples/tree/master/hessian-npe-demo

## What is the purpose of the change

Fix Consumer will generate wrong stackTrace when provider throws exception with empty stackTrace. Please see https://www.yuque.com/fa902k/id5z6r/sr041v

## Brief changelog

update:
org.apache.dubbo.rpc.RpcResult

add:
org.apache.dubbo.rpc.RpcResultTest

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
