### PR TITLE
make loadbalance robust, add comments

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/LeastActiveLoadBalance.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/LeastActiveLoadBalance.java
@@ -46,12 +46,15 @@ public class LeastActiveLoadBalance extends AbstractLoadBalance {
         int leastCount = 0;
         // The index of invokers having the same least active value (leastActive)
         int[] leastIndexes = new int[length];
+        // the weight of every invokers
+        int[] weights = new int[length];
         // The sum of the warmup weights of all the least active invokes
         int totalWeight = 0;
         // The weight of the first least active invoke
         int firstWeight = 0;
         // Every least active invoker has the same weight value?
         boolean sameWeight = true;
+
 
         // Filter out all the least active invokers
         for (int i = 0; i < length; i++) {
@@ -60,6 +63,8 @@ public class LeastActiveLoadBalance extends AbstractLoadBalance {
             int active = RpcStatus.getStatus(invoker.getUrl(), invocation.getMethodName()).getActive();
             // Get the weight of the invoke configuration. The default value is 100.
             int afterWarmup = getWeight(invoker, invocation);
+            // save for later use
+            weights[i] = afterWarmup;
             // If it is the first invoker or the active number of the invoker is less than the current least active number
             if (leastActive == -1 || active < leastActive) {
                 // Reset the active number of the current invoker to the least active number
@@ -95,12 +100,12 @@ public class LeastActiveLoadBalance extends AbstractLoadBalance {
         if (!sameWeight && totalWeight > 0) {
             // If (not every invoker has the same weight & at least one invoker's weight>0), select randomly based on 
             // totalWeight.
-            int offsetWeight = ThreadLocalRandom.current().nextInt(totalWeight) + 1;
+            int offsetWeight = ThreadLocalRandom.current().nextInt(totalWeight);
             // Return a invoker based on the random value.
             for (int i = 0; i < leastCount; i++) {
                 int leastIndex = leastIndexes[i];
-                offsetWeight -= getWeight(invokers.get(leastIndex), invocation);
-                if (offsetWeight <= 0) {
+                offsetWeight -= weights[leastIndex];
+                if (offsetWeight < 0) {
                     return invokers.get(leastIndex);
                 }
             }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/RandomLoadBalance.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/RandomLoadBalance.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * random load balance.
- *
  */
 public class RandomLoadBalance extends AbstractLoadBalance {
 
@@ -33,13 +32,23 @@ public class RandomLoadBalance extends AbstractLoadBalance {
 
     @Override
     protected <T> Invoker<T> doSelect(List<Invoker<T>> invokers, URL url, Invocation invocation) {
-        int length = invokers.size(); // Number of invokers
-        boolean sameWeight = true; // Every invoker has the same weight?
+        // Number of invokers
+        int length = invokers.size();
+        // Every invoker has the same weight?
+        boolean sameWeight = true;
+        // the weight of every invokers
+        int[] weights = new int[length];
+        // the first invoker's weight
         int firstWeight = getWeight(invokers.get(0), invocation);
-        int totalWeight = firstWeight; // The sum of weights
+        weights[0] = firstWeight;
+        // The sum of weights
+        int totalWeight = firstWeight;
         for (int i = 1; i < length; i++) {
             int weight = getWeight(invokers.get(i), invocation);
-            totalWeight += weight; // Sum
+            // save for later use
+            weights[i] = weight;
+            // Sum
+            totalWeight += weight;
             if (sameWeight && weight != firstWeight) {
                 sameWeight = false;
             }
@@ -49,7 +58,7 @@ public class RandomLoadBalance extends AbstractLoadBalance {
             int offset = ThreadLocalRandom.current().nextInt(totalWeight);
             // Return a invoker based on the random value.
             for (int i = 0; i < length; i++) {
-                offset -= getWeight(invokers.get(i), invocation);
+                offset -= weights[i];
                 if (offset < 0) {
                     return invokers.get(i);
                 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/RoundRobinLoadBalance.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/RoundRobinLoadBalance.java
@@ -101,9 +101,7 @@ public class RoundRobinLoadBalance extends AbstractLoadBalance {
             String identifyString = invoker.getUrl().toIdentityString();
             WeightedRoundRobin weightedRoundRobin = map.get(identifyString);
             int weight = getWeight(invoker, invocation);
-            if (weight < 0) {
-                weight = 0;
-            }
+
             if (weightedRoundRobin == null) {
                 weightedRoundRobin = new WeightedRoundRobin();
                 weightedRoundRobin.setWeight(weight);

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ActiveLimitFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ActiveLimitFilter.java
@@ -25,6 +25,7 @@ import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.RpcException;
 import org.apache.dubbo.rpc.RpcStatus;
+
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 


### PR DESCRIPTION
## What is the purpose of the change

This patch can make random choose in LoadBalance more robust . 

As the getWeight method in AbstractLoadBalance uses System.currentTimeMillis(),
so in the random choose stage of  RandomLoadBalance ,the weight may change 
as System.currentTimeMillis() will get new time stamp.

simplified a little bit code in LeastActiveLoadBalance  

make getweight always return weight above zero 

Also add comments for AbstractLoadBalance 


## Brief changelog

org.apache.dubbo.rpc.cluster.loadbalance.AbstractLoadBalance
org.apache.dubbo.rpc.cluster.loadbalance.RandomLoadBalance
org.apache.dubbo.rpc.cluster.loadbalance.LeastActiveLoadBalance
org.apache.dubbo.rpc.cluster.loadbalance.RoundRobinLoadBalance

## Verifying this change

