### PR TITLE
fix potential concurrency issue in a simpler way for ActiveLimitFilter and ExecuteLimitFilter

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
@@ -47,18 +47,6 @@ public class RpcStatus {
     private final AtomicLong failedMaxElapsed = new AtomicLong();
     private final AtomicLong succeededMaxElapsed = new AtomicLong();
 
-    /**
-     * Semaphore used to control concurrency limit set by `executes`
-     */
-    private volatile Semaphore executesLimit;
-    private volatile int executesPermits;
-
-    /**
-     * Semaphore used to control concurrency limit set by `actives`
-     */
-    private volatile Semaphore activesLimit;
-    private volatile int activesPermits;
-
     private RpcStatus() {
     }
 
@@ -318,46 +306,9 @@ public class RpcStatus {
         return getTotal();
     }
 
-    /**
-     * Get the semaphore for thread number. Semaphore's permits is decided by {@link Constants#EXECUTES_KEY}
-     *
-     * @param maxThreadNum value of {@link Constants#EXECUTES_KEY}
-     * @return thread number semaphore
-     */
-    public Semaphore getSemaphore(int maxThreadNum) {
-        if(maxThreadNum <= 0) {
-            return null;
-        }
-
-        if (executesLimit == null || executesPermits != maxThreadNum) {
-            synchronized (this) {
-                if (executesLimit == null || executesPermits != maxThreadNum) {
-                    executesLimit = new Semaphore(maxThreadNum);
-                    executesPermits = maxThreadNum;
-                }
-            }
-        }
-
-        return executesLimit;
-    }
-
-
-    /**
-     * Get the semaphore for thread number. Semaphore's permits is decided by {@link Constants#ACTIVES_KEY}
-     *
-     * @param maxThreadNum value of {@link Constants#ACTIVES_KEY}
-     * @return thread number semaphore
-     */
-    public Semaphore getActivesSemaphore(int maxThreadNum) {
-        if (activesLimit == null || activesPermits != maxThreadNum) {
-            synchronized (this) {
-                if (activesLimit == null || activesPermits != maxThreadNum) {
-                    activesLimit = new Semaphore(maxThreadNum);
-                    activesPermits = maxThreadNum;
-                }
-            }
-        }
-
-        return activesLimit;
+    public boolean tryActive(int max) {
+        int result = active.incrementAndGet();
+        active.decrementAndGet();
+        return result <= max;
     }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
@@ -16,12 +16,10 @@
  */
 package org.apache.dubbo.rpc;
 
-import org.apache.dubbo.common.Constants;
 import org.apache.dubbo.common.URL;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
@@ -104,13 +104,16 @@ public class RpcStatus {
     /**
      * @param url
      */
-    public static void beginCount(URL url, String methodName) {
-        beginCount(getStatus(url));
-        beginCount(getStatus(url, methodName));
-    }
-
-    private static void beginCount(RpcStatus status) {
-        status.active.incrementAndGet();
+    public static boolean beginCount(URL url, String methodName, int max) {
+        RpcStatus appStatus = getStatus(url);
+        RpcStatus methodStatus = getStatus(url, methodName);
+        if (methodStatus.active.incrementAndGet() > max) {
+            methodStatus.active.decrementAndGet();
+            return false;
+        } else {
+            appStatus.active.incrementAndGet();
+            return true;
+        }
     }
 
     /**
@@ -304,9 +307,5 @@ public class RpcStatus {
         return getTotal();
     }
 
-    public boolean tryActive(int max) {
-        int result = active.incrementAndGet();
-        active.decrementAndGet();
-        return result <= max;
-    }
+
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
@@ -101,6 +101,10 @@ public class RpcStatus {
         }
     }
 
+    public static void beginCount(URL url, String methodName) {
+        beginCount(url, methodName, Integer.MAX_VALUE);
+    }
+
     /**
      * @param url
      */

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ActiveLimitFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ActiveLimitFilterTest.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.rpc.Filter;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.RpcStatus;
 import org.apache.dubbo.rpc.support.BlockMyInvoker;
 import org.apache.dubbo.rpc.support.MockInvocation;
 import org.apache.dubbo.rpc.support.MyInvoker;
@@ -105,6 +106,8 @@ public class ActiveLimitFilterTest {
         URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&actives="+maxActives+"&timeout="+timeout);
         final Invoker<ActiveLimitFilterTest> invoker = new BlockMyInvoker<ActiveLimitFilterTest>(url, blockTime);
         final Invocation invocation = new MockInvocation();
+        RpcStatus.removeStatus(url);
+        RpcStatus.removeStatus(url, invocation.getMethodName());
         for (int i = 0; i < totalThread; i++) {
             Thread thread = new Thread(new Runnable() {
                 public void run() {


### PR DESCRIPTION
## What is the purpose of the change

Fix potential concurrency issue in a simpler way for ActiveLimitFilter and ExecuteLimitFilter. The original changes are: d0e41e8733d0837653e5b2281f6d4b9f9508c2c1 and 2fad342ce1bd6afe683b001d063c82fb89237b48. The semaphores introduced on RpcStatus are a little bit confusing.

## Brief changelog

dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ActiveLimitFilter.java
dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ExecuteLimitFilter.java

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
