### PR TITLE
Telnet use Exporter's key to find the Exporter

### DIFF
--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboExporter.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboExporter.java
@@ -43,4 +43,7 @@ public class DubboExporter<T> extends AbstractExporter<T> {
         exporterMap.remove(key);
     }
 
+    public String getKey() {
+        return key;
+    }
 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/ChangeTelnetHandler.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/ChangeTelnetHandler.java
@@ -21,6 +21,7 @@ import org.apache.dubbo.remoting.Channel;
 import org.apache.dubbo.remoting.telnet.TelnetHandler;
 import org.apache.dubbo.remoting.telnet.support.Help;
 import org.apache.dubbo.rpc.Exporter;
+import org.apache.dubbo.rpc.protocol.dubbo.DubboExporter;
 import org.apache.dubbo.rpc.protocol.dubbo.DubboProtocol;
 
 /**
@@ -45,9 +46,7 @@ public class ChangeTelnetHandler implements TelnetHandler {
         } else {
             boolean found = false;
             for (Exporter<?> exporter : DubboProtocol.getDubboProtocol().getExporters()) {
-                if (message.equals(exporter.getInvoker().getInterface().getSimpleName())
-                        || message.equals(exporter.getInvoker().getInterface().getName())
-                        || message.equals(exporter.getInvoker().getUrl().getPath())) {
+                if (message.equals(((DubboExporter) exporter).getKey())) {
                     found = true;
                     break;
                 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/CountTelnetHandler.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/CountTelnetHandler.java
@@ -27,6 +27,7 @@ import org.apache.dubbo.remoting.telnet.support.TelnetUtils;
 import org.apache.dubbo.rpc.Exporter;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcStatus;
+import org.apache.dubbo.rpc.protocol.dubbo.DubboExporter;
 import org.apache.dubbo.rpc.protocol.dubbo.DubboProtocol;
 
 import java.lang.reflect.Method;
@@ -72,9 +73,7 @@ public class CountTelnetHandler implements TelnetHandler {
         final int t = Integer.parseInt(times);
         Invoker<?> invoker = null;
         for (Exporter<?> exporter : DubboProtocol.getDubboProtocol().getExporters()) {
-            if (service.equals(exporter.getInvoker().getInterface().getSimpleName())
-                    || service.equals(exporter.getInvoker().getInterface().getName())
-                    || service.equals(exporter.getInvoker().getUrl().getPath())) {
+            if (service.equals(((DubboExporter) exporter).getKey())) {
                 invoker = exporter.getInvoker();
                 break;
             }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/InvokeTelnetHandler.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/InvokeTelnetHandler.java
@@ -27,6 +27,7 @@ import org.apache.dubbo.rpc.Exporter;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.rpc.RpcInvocation;
+import org.apache.dubbo.rpc.protocol.dubbo.DubboExporter;
 import org.apache.dubbo.rpc.protocol.dubbo.DubboProtocol;
 
 import com.alibaba.fastjson.JSON;
@@ -188,9 +189,7 @@ public class InvokeTelnetHandler implements TelnetHandler {
                     break;
                 }
             } else {
-                if (service.equals(exporter.getInvoker().getInterface().getSimpleName())
-                        || service.equals(exporter.getInvoker().getInterface().getName())
-                        || service.equals(exporter.getInvoker().getUrl().getPath())) {
+                if (service.equals(((DubboExporter) exporter).getKey())) {
                     invokeMethod = findMethod(exporter, method, list, paramClasses);
                     invoker = exporter.getInvoker();
                     break;

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/ListTelnetHandler.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/ListTelnetHandler.java
@@ -23,6 +23,7 @@ import org.apache.dubbo.remoting.telnet.TelnetHandler;
 import org.apache.dubbo.remoting.telnet.support.Help;
 import org.apache.dubbo.rpc.Exporter;
 import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.protocol.dubbo.DubboExporter;
 import org.apache.dubbo.rpc.protocol.dubbo.DubboProtocol;
 
 import java.lang.reflect.Method;
@@ -62,7 +63,7 @@ public class ListTelnetHandler implements TelnetHandler {
                 if (buf.length() > 0) {
                     buf.append("\r\n");
                 }
-                buf.append(exporter.getInvoker().getInterface().getName());
+                buf.append(((DubboExporter) exporter).getKey());
                 if (detail) {
                     buf.append(" -> ");
                     buf.append(exporter.getInvoker().getUrl());
@@ -71,9 +72,7 @@ public class ListTelnetHandler implements TelnetHandler {
         } else {
             Invoker<?> invoker = null;
             for (Exporter<?> exporter : DubboProtocol.getDubboProtocol().getExporters()) {
-                if (service.equals(exporter.getInvoker().getInterface().getSimpleName())
-                        || service.equals(exporter.getInvoker().getInterface().getName())
-                        || service.equals(exporter.getInvoker().getUrl().getPath())) {
+                if (service.equals(((DubboExporter) exporter).getKey())) {
                     invoker = exporter.getInvoker();
                     break;
                 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/TraceTelnetHandler.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/TraceTelnetHandler.java
@@ -23,6 +23,7 @@ import org.apache.dubbo.remoting.telnet.TelnetHandler;
 import org.apache.dubbo.remoting.telnet.support.Help;
 import org.apache.dubbo.rpc.Exporter;
 import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.protocol.dubbo.DubboExporter;
 import org.apache.dubbo.rpc.protocol.dubbo.DubboProtocol;
 import org.apache.dubbo.rpc.protocol.dubbo.filter.TraceFilter;
 
@@ -62,9 +63,7 @@ public class TraceTelnetHandler implements TelnetHandler {
         }
         Invoker<?> invoker = null;
         for (Exporter<?> exporter : DubboProtocol.getDubboProtocol().getExporters()) {
-            if (service.equals(exporter.getInvoker().getInterface().getSimpleName())
-                    || service.equals(exporter.getInvoker().getInterface().getName())
-                    || service.equals(exporter.getInvoker().getUrl().getPath())) {
+            if (service.equals(((DubboExporter) exporter).getKey())) {
                 invoker = exporter.getInvoker();
                 break;
             }


### PR DESCRIPTION
## What is the purpose of the change

Fix https://github.com/apache/incubator-dubbo/issues/2988

Telnet use Exporter's key to find the Exporter . Not used getSimpleName or InterfaceName, because they are not unique， Exporter's key is unique to one Exporter。

## Brief changelog

Telnet use Exporter's key to find the Exporter

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
