### PR TITLE
Simple date format each time new object creation removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,33 @@ There's a [README](https://github.com/dubbo/dubbo-samples/blob/master/dubbo-samp
 ### Maven dependency
 
 ```xml
-<dependency>
-    <groupId>com.alibaba</groupId>
-    <artifactId>dubbo</artifactId>
-    <version>2.6.5</version>
-</dependency>
+<properties>
+    <dubbo.version>2.6.5</dubbo.version>
+</properties>
+    
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-dependencies-bom</artifactId>
+            <version>${dubbo.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>com.alibaba</groupId>
+        <artifactId>dubbo</artifactId>
+        <version>${dubbo.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-all</artifactId>
+    </dependency>
+</dependencies>
 ```
 
 ### Define service interfaces

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/ConditionRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/ConditionRouter.java
@@ -127,7 +127,7 @@ public class ConditionRouter implements Router {
                 values.add(content);
             }
             // The Value in the KV part, if Value have more than one items.
-            else if (",".equals(separator)) { // Should be seperateed by ','
+            else if (",".equals(separator)) { // Should be separated by ','
                 if (values == null || values.isEmpty()) {
                     throw new ParseException("Illegal route rule \""
                             + rule + "\", The error char '" + separator

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/script/ScriptRouterFactory.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/script/ScriptRouterFactory.java
@@ -25,7 +25,7 @@ import org.apache.dubbo.rpc.cluster.RouterFactory;
  * <p>
  * Example URLS used by Script Router Factory：
  * <ol>
- * <li> script://registyAddress?type=js&rule=xxxx
+ * <li> script://registryAddress?type=js&rule=xxxx
  * <li> script:///path/to/routerfile.js?type=js&rule=xxxx
  * <li> script://D:\path\to\routerfile.js?type=js&rule=xxxx
  * <li> script://C:/path/to/routerfile.js?type=js&rule=xxxx

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/wrapper/MockClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/wrapper/MockClusterInvoker.java
@@ -143,7 +143,7 @@ public class MockClusterInvoker<T> implements Invoker<T> {
         List<Invoker<T>> invokers = null;
         //TODO generic invoker？
         if (invocation instanceof RpcInvocation) {
-            //Note the implicit contract (although the description is added to the interface declaration, but extensibility is a problem. The practice placed in the attachement needs to be improved)
+            //Note the implicit contract (although the description is added to the interface declaration, but extensibility is a problem. The practice placed in the attachment needs to be improved)
             ((RpcInvocation) invocation).setAttachment(Constants.INVOCATION_NEED_MOCK, Boolean.TRUE.toString());
             //directory will return a list of normal invokers if Constants.INVOCATION_NEED_MOCK is present in invocation, otherwise, a list of mock invokers will return.
             try {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/compiler/support/ClassUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/compiler/support/ClassUtils.java
@@ -422,8 +422,8 @@ public class ClassUtils {
     public static <K, V> Map<K, V> toMap(Map.Entry<K, V>[] entries) {
         Map<K, V> map = new HashMap<K, V>();
         if (entries != null && entries.length > 0) {
-            for (Map.Entry<K, V> enrty : entries) {
-                map.put(enrty.getKey(), enrty.getValue());
+            for (Map.Entry<K, V> entry : entries) {
+                map.put(entry.getKey(), entry.getValue());
             }
         }
         return map;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/io/StreamUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/io/StreamUtils.java
@@ -189,7 +189,7 @@ public class StreamUtils {
             @Override
             public synchronized void reset() throws IOException {
                 if (!mInMarked) {
-                    throw new IOException("should mark befor reset!");
+                    throw new IOException("should mark before reset!");
                 }
 
                 mInReset = true;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/io/UnsafeByteArrayInputStream.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/io/UnsafeByteArrayInputStream.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * UnsafeByteArrayInputStrem.
+ * UnsafeByteArrayInputStream.
  */
 public class UnsafeByteArrayInputStream extends InputStream {
     protected byte mData[];

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/Assert.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/Assert.java
@@ -28,9 +28,9 @@ public abstract class Assert {
         }
     }
 
-    public static void notNull(Object obj, RuntimeException exeception) {
+    public static void notNull(Object obj, RuntimeException exception) {
         if (obj == null) {
-            throw exeception;
+            throw exception;
         }
     }
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
@@ -213,7 +213,7 @@ public class ConfigUtils {
      * <li>return empty Properties if no file found.
      * <li>merge multi properties file if found multi file
      * </ul>
-     * @throws IllegalStateException not allow multi-file, but multi-file exsit on class path.
+     * @throws IllegalStateException not allow multi-file, but multi-file exist on class path.
      */
     public static Properties loadProperties(String fileName, boolean allowMultiFile, boolean optional) {
         Properties properties = new Properties();

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
@@ -175,9 +175,9 @@ public class PojoUtils {
                 try {
                     Object fieldValue = field.get(pojo);
                     if (history.containsKey(pojo)) {
-                        Object pojoGenerilizedValue = history.get(pojo);
-                        if (pojoGenerilizedValue instanceof Map
-                                && ((Map) pojoGenerilizedValue).containsKey(field.getName())) {
+                        Object pojoGeneralizedValue = history.get(pojo);
+                        if (pojoGeneralizedValue instanceof Map
+                                && ((Map) pojoGeneralizedValue).containsKey(field.getName())) {
                             continue;
                         }
                     }

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/qos/command/CommandContext.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/qos/command/CommandContext.java
@@ -23,7 +23,7 @@ public class CommandContext extends org.apache.dubbo.qos.command.CommandContext 
     public CommandContext(org.apache.dubbo.qos.command.CommandContext context) {
         super(context.getCommandName(), context.getArgs(), context.isHttp());
         setRemote(context.getRemote());
-        setOrginRequest(context.getOrginRequest());
+        setOriginRequest(context.getOriginRequest());
     }
 
     public CommandContext(String commandName) {

--- a/dubbo-compatible/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/CompatibleServiceAnnotationBeanPostProcessor.java
+++ b/dubbo-compatible/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/CompatibleServiceAnnotationBeanPostProcessor.java
@@ -209,7 +209,7 @@ public class CompatibleServiceAnnotationBeanPostProcessor implements BeanDefinit
      * {@link Service} Annotation.
      *
      * @param scanner       {@link ClassPathBeanDefinitionScanner}
-     * @param packageToScan pachage to scan
+     * @param packageToScan package to scan
      * @param registry      {@link BeanDefinitionRegistry}
      * @return non-null
      * @since 2.5.8

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
@@ -509,7 +509,7 @@ public class ReferenceAnnotationBeanPostProcessor extends InstantiationAwareBean
     /**
      * Generate a key based on the annotation.
      *
-     * @param annotations annotatoin value
+     * @param annotations annotation value
      * @return unique key, never null will be returned.
      * @since 2.7.0
      */

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceAnnotationBeanPostProcessor.java
@@ -208,7 +208,7 @@ public class ServiceAnnotationBeanPostProcessor implements BeanDefinitionRegistr
      * {@link Service} Annotation.
      *
      * @param scanner       {@link ClassPathBeanDefinitionScanner}
-     * @param packageToScan pachage to scan
+     * @param packageToScan package to scan
      * @param registry      {@link BeanDefinitionRegistry}
      * @return non-null
      * @since 2.5.8

--- a/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/Cache.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/Cache.java
@@ -19,7 +19,7 @@ package org.apache.dubbo.cache;
 /**
  * Cache interface to support storing and retrieval of value against a lookup key. It has two operation <b>get</b> and <b>put</b>.
  * <li><b>put</b>-Storing value against a key.</li>
- * <li><b>get</b>-Retrival of object.</li>
+ * <li><b>get</b>-Retrieval of object.</li>
  * @see org.apache.dubbo.cache.support.lru.LruCache
  * @see org.apache.dubbo.cache.support.jcache.JCache
  * @see org.apache.dubbo.cache.support.expiring.ExpiringCache

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/CommandContext.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/CommandContext.java
@@ -24,7 +24,7 @@ public class CommandContext {
     private String[] args;
     private Channel remote;
     private boolean isHttp;
-    private Object orginRequest;
+    private Object originRequest;
 
     public CommandContext(String commandName) {
         this.commandName = commandName;
@@ -68,11 +68,11 @@ public class CommandContext {
         isHttp = http;
     }
 
-    public Object getOrginRequest() {
-        return orginRequest;
+    public Object getOriginRequest() {
+        return originRequest;
     }
 
-    public void setOrginRequest(Object orginRequest) {
-        this.orginRequest = orginRequest;
+    public void setOriginRequest(Object originRequest) {
+        this.originRequest = originRequest;
     }
 }

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/decoder/TelnetCommandDecoder.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/decoder/TelnetCommandDecoder.java
@@ -31,7 +31,7 @@ public class TelnetCommandDecoder {
                 String[] targetArgs = new String[array.length - 1];
                 System.arraycopy(array, 1, targetArgs, 0, array.length - 1);
                 commandContext = CommandContextFactory.newInstance( name, targetArgs,false);
-                commandContext.setOrginRequest(str);
+                commandContext.setOriginRequest(str);
             }
         }
 

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/CommandContextTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/command/CommandContextTest.java
@@ -33,23 +33,23 @@ public class CommandContextTest {
     public void test() throws Exception {
         CommandContext context = new CommandContext("test", new String[]{"hello"}, true);
         Object request = new Object();
-        context.setOrginRequest(request);
+        context.setOriginRequest(request);
         Channel channel = Mockito.mock(Channel.class);
         context.setRemote(channel);
         assertThat(context.getCommandName(), equalTo("test"));
         assertThat(context.getArgs(), arrayContaining("hello"));
-        assertThat(context.getOrginRequest(), is(request));
+        assertThat(context.getOriginRequest(), is(request));
         assertTrue(context.isHttp());
         assertThat(context.getRemote(), is(channel));
 
         context = new CommandContext("command");
         context.setRemote(channel);
-        context.setOrginRequest(request);
+        context.setOriginRequest(request);
         context.setArgs(new String[]{"world"});
         context.setHttp(false);
         assertThat(context.getCommandName(), equalTo("command"));
         assertThat(context.getArgs(), arrayContaining("world"));
-        assertThat(context.getOrginRequest(), is(request));
+        assertThat(context.getOriginRequest(), is(request));
         assertFalse(context.isHttp());
         assertThat(context.getRemote(), is(channel));
     }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
@@ -562,7 +562,7 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
                                 logger.debug("destroy invoker[" + invoker.getUrl() + "] success. ");
                             }
                         } catch (Exception e) {
-                            logger.warn("destroy invoker[" + invoker.getUrl() + "] faild. " + e.getMessage(), e);
+                            logger.warn("destroy invoker[" + invoker.getUrl() + "] failed. " + e.getMessage(), e);
                         }
                     }
                 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/FailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/FailbackRegistry.java
@@ -272,7 +272,7 @@ public abstract class FailbackRegistry extends AbstractRegistry {
                 }
                 throw new IllegalStateException("Failed to unregister " + url + " to registry " + getUrl().getAddress() + ", cause: " + t.getMessage(), t);
             } else {
-                logger.error("Failed to uregister " + url + ", waiting for retry, cause: " + t.getMessage(), t);
+                logger.error("Failed to unregister " + url + ", waiting for retry, cause: " + t.getMessage(), t);
             }
 
             // Record a failed registration request to a failed list, retry regularly

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/Response.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/Response.java
@@ -31,7 +31,7 @@ public class Response {
     public static final byte OK = 20;
 
     /**
-     * clien side timeout.
+     * client side timeout.
      */
     public static final byte CLIENT_TIMEOUT = 30;
 

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/DefaultFuture.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/DefaultFuture.java
@@ -265,7 +265,7 @@ public class DefaultFuture implements ResponseFuture {
             try {
                 callbackCopy.done(res.getResult());
             } catch (Exception e) {
-                logger.error("callback invoke error .reasult:" + res.getResult() + ",url:" + channel.getUrl(), e);
+                logger.error("callback invoke error .result:" + res.getResult() + ",url:" + channel.getUrl(), e);
             }
         } else if (res.getStatus() == Response.CLIENT_TIMEOUT || res.getStatus() == Response.SERVER_TIMEOUT) {
             try {

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/AbstractServer.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/AbstractServer.java
@@ -202,7 +202,7 @@ public abstract class AbstractServer extends AbstractEndpoint implements Server 
     public void disconnected(Channel ch) throws RemotingException {
         Collection<Channel> channels = getChannels();
         if (channels.isEmpty()) {
-            logger.warn("All clients has discontected from " + ch.getLocalAddress() + ". You can graceful shutdown now.");
+            logger.warn("All clients has disconnected from " + ch.getLocalAddress() + ". You can graceful shutdown now.");
         }
         super.disconnected(ch);
     }

--- a/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyBackedChannelBuffer.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyBackedChannelBuffer.java
@@ -261,7 +261,7 @@ public class NettyBackedChannelBuffer implements ChannelBuffer {
 
     @Override
     public void readBytes(ChannelBuffer dst, int length) {
-        // carefule
+        // careful
         if (length > dst.writableBytes()) {
             throw new IndexOutOfBoundsException();
         }

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyBackedChannelBuffer.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyBackedChannelBuffer.java
@@ -261,7 +261,7 @@ public class NettyBackedChannelBuffer implements ChannelBuffer {
     
     @Override
     public void readBytes(ChannelBuffer dst, int length) {
-        // carefule
+        // careful
         if (length > dst.writableBytes()) {
             throw new IndexOutOfBoundsException();
         }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncContext.java
@@ -42,7 +42,7 @@ public interface AsyncContext {
     void write(Object value);
 
     /**
-     * @return true if the aysnc context is started
+     * @return true if the async context is started
      */
     boolean isAsyncStarted();
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncContextImpl.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncContextImpl.java
@@ -26,7 +26,7 @@ public class AsyncContextImpl implements AsyncContext {
     private static final Logger logger = LoggerFactory.getLogger(AsyncContextImpl.class);
 
     private final AtomicBoolean started = new AtomicBoolean(false);
-    private final AtomicBoolean stoped = new AtomicBoolean(false);
+    private final AtomicBoolean stopped = new AtomicBoolean(false);
 
     private CompletableFuture<Object> future;
 
@@ -63,7 +63,7 @@ public class AsyncContextImpl implements AsyncContext {
 
     @Override
     public boolean stop() {
-        return stoped.compareAndSet(false, true);
+        return stopped.compareAndSet(false, true);
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/AccessLogFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/AccessLogFilter.java
@@ -75,6 +75,20 @@ public class AccessLogFilter implements Filter {
 
     private static final long LOG_OUTPUT_INTERVAL = 5000;
 
+    static ThreadLocal<SimpleDateFormat> FILE_DATE_FORMATTER= new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            return new SimpleDateFormat(FILE_DATE_FORMAT);
+        }
+    };
+
+    static ThreadLocal<SimpleDateFormat> MESSAGE_DATE_FORMATTER= new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            return new SimpleDateFormat(MESSAGE_DATE_FORMAT);
+        }
+    };
+
     private final ConcurrentMap<String, Set<String>> logQueue = new ConcurrentHashMap<String, Set<String>>();
 
     private final ScheduledExecutorService logScheduled = Executors.newScheduledThreadPool(2, new NamedThreadFactory("Dubbo-Access-Log", true));
@@ -113,7 +127,7 @@ public class AccessLogFilter implements Filter {
                 String version = invoker.getUrl().getParameter(Constants.VERSION_KEY);
                 String group = invoker.getUrl().getParameter(Constants.GROUP_KEY);
                 StringBuilder sn = new StringBuilder();
-                sn.append("[").append(new SimpleDateFormat(MESSAGE_DATE_FORMAT).format(new Date())).append("] ").append(context.getRemoteHost()).append(":").append(context.getRemotePort())
+                sn.append("[").append(MESSAGE_DATE_FORMATTER.get().format(new Date())).append("] ").append(context.getRemoteHost()).append(":").append(context.getRemotePort())
                         .append(" -> ").append(context.getLocalHost()).append(":").append(context.getLocalPort())
                         .append(" - ");
                 if (null != group && group.length() > 0) {
@@ -174,8 +188,8 @@ public class AccessLogFilter implements Filter {
                                 logger.debug("Append log to " + accesslog);
                             }
                             if (file.exists()) {
-                                String now = new SimpleDateFormat(FILE_DATE_FORMAT).format(new Date());
-                                String last = new SimpleDateFormat(FILE_DATE_FORMAT).format(new Date(file.lastModified()));
+                                String now = FILE_DATE_FORMATTER.get().format(new Date());
+                                String last = FILE_DATE_FORMATTER.get().format(new Date(file.lastModified()));
                                 if (!now.equals(last)) {
                                     File archive = new File(file.getAbsolutePath() + "." + last);
                                     file.renameTo(archive);

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/AccessLogFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/AccessLogFilter.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licaenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/tps/DefaultTPSLimiter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/tps/DefaultTPSLimiter.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /**
- * DefaultTPSLimiter is a default implementation for tps filter. It is an in memory based implementation for stroring
+ * DefaultTPSLimiter is a default implementation for tps filter. It is an in memory based implementation for storing
  * tps information. It internally use
  *
  * @see org.apache.dubbo.rpc.filter.TpsLimitFilter

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/AccessLogData.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/AccessLogData.java
@@ -19,7 +19,9 @@ package org.apache.dubbo.rpc.support;
 import com.alibaba.fastjson.JSON;
 import org.apache.dubbo.common.utils.StringUtils;
 
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,13 +30,14 @@ import java.util.Map;
  * dynamic value e.g. time stamp, local jmv machine host address etc. It does not allow any null or empty key.
  */
 public final class AccessLogData {
-
+    /**
+     * Access log keys
+      */
     private enum KEYS {
-        VERSION, GROUP, SERVICE, METHOD_NAME, INVOCATION_TIME, TYPES, ARGUMENTS,
-        REMOTE_HOST, REMOTE_PORT, LOCAL_HOST, LOCAL_PORT
+        VERSION, GROUP, SERVICE, METHOD_NAME, INVOCATION_TIME, TYPES
+        ,ARGUMENTS, REMOTE_HOST, REMOTE_PORT, LOCAL_HOST, LOCAL_PORT
     }
 
-    ;
     /**
      * This is used to store log data in key val format.
      */
@@ -56,6 +59,13 @@ public final class AccessLogData {
         return new AccessLogData();
     }
 
+    /**
+     * Sets the access log key
+     * @param accessLogKey
+     */
+    public void setAccessLogKey(String accessLogKey) {
+
+    }
     /**
      * Add version information.
      *
@@ -88,7 +98,7 @@ public final class AccessLogData {
      *
      * @param invocationTime
      */
-    public void setInvocationTime(String invocationTime) {
+    public void setInvocationTime(Date invocationTime) {
         set(KEYS.INVOCATION_TIME, invocationTime);
     }
 
@@ -155,12 +165,20 @@ public final class AccessLogData {
         set(KEYS.ARGUMENTS, arguments != null ? Arrays.copyOf(arguments, arguments.length) : null);
     }
 
+    /**
+     * Return gthe service of access log entry
+     * @return
+     */
+    public String getServiceName() {
+        return get(KEYS.SERVICE).toString();
+    }
 
-    public String getLogMessage() {
+
+    public String getLogMessage(SimpleDateFormat sdf) {
         StringBuilder sn = new StringBuilder();
 
         sn.append("[")
-                .append(get(KEYS.INVOCATION_TIME))
+                .append(sdf.format(get(KEYS.INVOCATION_TIME)))
                 .append("] ")
                 .append(get(KEYS.REMOTE_HOST))
                 .append(":")

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/AccessLogData.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/AccessLogData.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licaenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/AccessLogData.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/AccessLogData.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licaenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.support;
+
+import com.alibaba.fastjson.JSON;
+import org.apache.dubbo.common.utils.StringUtils;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * AccessLogData is a container for log event data. In internally uses map and store each filed of log as value. It does not generate any
+ * dynamic value e.g. time stamp, local jmv machine host address etc. It does not allow any null or empty key.
+ */
+public final class AccessLogData {
+
+    private enum KEYS {
+        VERSION, GROUP, SERVICE, METHOD_NAME, INVOCATION_TIME, TYPES, ARGUMENTS,
+        REMOTE_HOST, REMOTE_PORT, LOCAL_HOST, LOCAL_PORT
+    }
+
+    ;
+    /**
+     * This is used to store log data in key val format.
+     */
+    private Map<KEYS, Object> data;
+
+    /**
+     * Default constructor.
+     */
+    private AccessLogData() {
+        data = new HashMap<>();
+    }
+
+    /**
+     * Get new instance of log data.
+     *
+     * @return instance of AccessLogData
+     */
+    public static AccessLogData newLogData() {
+        return new AccessLogData();
+    }
+
+    /**
+     * Add version information.
+     *
+     * @param version
+     */
+    public void setVersion(String version) {
+        set(KEYS.VERSION, version);
+    }
+
+    /**
+     * Add service name.
+     *
+     * @param serviceName
+     */
+    public void setServiceName(String serviceName) {
+        set(KEYS.SERVICE, serviceName);
+    }
+
+    /**
+     * Add group name
+     *
+     * @param group
+     */
+    public void setGroup(String group) {
+        set(KEYS.GROUP, group);
+    }
+
+    /**
+     * Set the invocation date. As an argument it accept date string.
+     *
+     * @param invocationTime
+     */
+    public void setInvocationTime(String invocationTime) {
+        set(KEYS.INVOCATION_TIME, invocationTime);
+    }
+
+    /**
+     * Set caller remote host
+     *
+     * @param remoteHost
+     */
+    public void setRemoteHost(String remoteHost) {
+        set(KEYS.REMOTE_HOST, remoteHost);
+    }
+
+    /**
+     * Set caller remote port.
+     *
+     * @param remotePort
+     */
+    public void setRemotePort(Integer remotePort) {
+        set(KEYS.REMOTE_PORT, remotePort);
+    }
+
+    /**
+     * Set local host
+     *
+     * @param localHost
+     */
+    public void setLocalHost(String localHost) {
+        set(KEYS.LOCAL_HOST, localHost);
+    }
+
+    /**
+     * Set local port of exported service
+     *
+     * @param localPort
+     */
+    public void setLocalPort(Integer localPort) {
+        set(KEYS.LOCAL_PORT, localPort);
+    }
+
+    /**
+     * Set target method name.
+     *
+     * @param methodName
+     */
+    public void setMethodName(String methodName) {
+        set(KEYS.METHOD_NAME, methodName);
+    }
+
+    /**
+     * Set invocation's method's input parameter's types
+     *
+     * @param types
+     */
+    public void setTypes(Class[] types) {
+        set(KEYS.TYPES, types != null ? Arrays.copyOf(types, types.length) : null);
+    }
+
+    /**
+     * Sets invocation arguments
+     *
+     * @param arguments
+     */
+    public void setArguments(Object[] arguments) {
+        set(KEYS.ARGUMENTS, arguments != null ? Arrays.copyOf(arguments, arguments.length) : null);
+    }
+
+
+    public String getLogMessage() {
+        StringBuilder sn = new StringBuilder();
+
+        sn.append("[")
+                .append(get(KEYS.INVOCATION_TIME))
+                .append("] ")
+                .append(get(KEYS.REMOTE_HOST))
+                .append(":")
+                .append(get(KEYS.REMOTE_PORT))
+                .append(" -> ")
+                .append(get(KEYS.LOCAL_HOST))
+                .append(":")
+                .append(get(KEYS.LOCAL_PORT))
+                .append(" - ");
+
+        String group = get(KEYS.GROUP) != null ? get(KEYS.GROUP).toString() : "";
+        if (StringUtils.isNotEmpty(group.toString())) {
+            sn.append(group).append("/");
+        }
+
+        sn.append(get(KEYS.SERVICE));
+
+        String version = get(KEYS.VERSION) != null ? get(KEYS.VERSION).toString() : "";
+        if (StringUtils.isNotEmpty(version.toString())) {
+            sn.append(":").append(version);
+        }
+
+        sn.append(" ");
+        sn.append(get(KEYS.METHOD_NAME));
+
+        sn.append("(");
+        Class<?>[] types = get(KEYS.TYPES) != null? (Class<?>[]) get(KEYS.TYPES) : new Class[0];
+        boolean first = true;
+        for (Class<?> type : types) {
+            if (first) {
+                first = false;
+            } else {
+                sn.append(",");
+            }
+            sn.append(type.getName());
+        }
+        sn.append(") ");
+
+
+        Object[] args = get(KEYS.ARGUMENTS) !=null ? (Object[]) get(KEYS.ARGUMENTS) : null;
+        if (args != null && args.length > 0) {
+            sn.append(JSON.toJSONString(args));
+        }
+
+        return sn.toString();
+    }
+
+    /**
+     * Return value of key
+     *
+     * @param key
+     * @return
+     */
+    private Object get(KEYS key) {
+        return data.get(key);
+    }
+
+    /**
+     * Add log key along with his value.
+     *
+     * @param key   Any not null or non empty string
+     * @param value Any object including null.
+     */
+    private void set(KEYS key, Object value) {
+        data.put(key, value);
+    }
+
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/AccessLogFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/AccessLogFilterTest.java
@@ -56,11 +56,31 @@ public class AccessLogFilterTest {
     }
 
     @Test
+    public void testDefaultWithMultipleLog() throws InterruptedException {
+        URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1");
+        Invoker<AccessLogFilterTest> invoker = new MyInvoker<AccessLogFilterTest>(url);
+        Invocation invocation = new MockInvocation();
+        accessLogFilter.invoke(invoker, invocation);
+        Thread.sleep(7000);
+    }
+
+    @Test
     public void testCustom() {
         URL url = URL.valueOf("test://test:11/test?accesslog=custom-access.log");
         Invoker<AccessLogFilterTest> invoker = new MyInvoker<AccessLogFilterTest>(url);
         Invocation invocation = new MockInvocation();
         accessLogFilter.invoke(invoker, invocation);
+    }
+
+    @Test
+    public void testCustomWithMultipleLog() throws InterruptedException {
+        URL url = URL.valueOf("test://test:11/test?accesslog=custom-access.log");
+        Invoker<AccessLogFilterTest> invoker = new MyInvoker<AccessLogFilterTest>(url);
+        Invocation invocation = new MockInvocation();
+        for(int i=0;i<10;i++) {
+            accessLogFilter.invoke(invoker, invocation);
+        }
+        Thread.sleep(7000);
     }
 
 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboInvoker.java
@@ -97,7 +97,7 @@ public class DubboInvoker<T> extends AbstractInvoker<T> {
 
                 Result result;
                 if (isAsyncFuture) {
-                    // register resultCallback, sometimes we need the asyn result being processed by the filter chain.
+                    // register resultCallback, sometimes we need the async result being processed by the filter chain.
                     result = new AsyncRpcResult(futureAdapter, futureAdapter.getResultFuture(), false);
                 } else {
                     result = new SimpleAsyncRpcResult(futureAdapter, futureAdapter.getResultFuture(), false);

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/ReferenceCountExchangeClient.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/ReferenceCountExchangeClient.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 final class ReferenceCountExchangeClient implements ExchangeClient {
 
     private final URL url;
-    private final AtomicInteger refenceCount = new AtomicInteger(0);
+    private final AtomicInteger referenceCount = new AtomicInteger(0);
 
     //    private final ExchangeHandler handler;
     private final ConcurrentMap<String, LazyConnectExchangeClient> ghostClientMap;
@@ -45,7 +45,7 @@ final class ReferenceCountExchangeClient implements ExchangeClient {
 
     public ReferenceCountExchangeClient(ExchangeClient client, ConcurrentMap<String, LazyConnectExchangeClient> ghostClientMap) {
         this.client = client;
-        refenceCount.incrementAndGet();
+        referenceCount.incrementAndGet();
         this.url = client.getUrl();
         if (ghostClientMap == null) {
             throw new IllegalStateException("ghostClientMap can not be null, url: " + url);
@@ -148,7 +148,7 @@ final class ReferenceCountExchangeClient implements ExchangeClient {
 
     @Override
     public void close(int timeout) {
-        if (refenceCount.decrementAndGet() <= 0) {
+        if (referenceCount.decrementAndGet() <= 0) {
             if (timeout == 0) {
                 client.close();
             } else {
@@ -189,6 +189,6 @@ final class ReferenceCountExchangeClient implements ExchangeClient {
     }
 
     public void incrementAndGetCount() {
-        refenceCount.incrementAndGet();
+        referenceCount.incrementAndGet();
     }
 }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/ListTelnetHandler.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/ListTelnetHandler.java
@@ -46,7 +46,7 @@ public class ListTelnetHandler implements TelnetHandler {
                     detail = true;
                 } else {
                     if (service != null && service.length() > 0) {
-                        return "Invaild parameter " + part;
+                        return "Invalid parameter " + part;
                     }
                     service = part;
                 }


### PR DESCRIPTION
## What is the purpose of the change
AcceLogFilter message creation and last and current check was performing by each time simple date formate object creation. In this version of code I have use the ThreadLocal for each thread wise to create simple date format object instead of each call

https://github.com/apache/incubator-dubbo/issues/3026

## Brief changelog

XXXXX

## Verifying this change

Runnig UT and verifying generated access log.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue] (https://github.com/apache/incubator-dubbo/issues/3026) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
