### PR TITLE
import a pojo ServiceMeta which is used as service level info and  a addressListener to extends

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/ServiceMetada.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/ServiceMetada.java
@@ -1,4 +1,4 @@
-package org.apache.dubbo.common;/*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -14,6 +14,7 @@ package org.apache.dubbo.common;/*
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.dubbo.common;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/ServiceMetada.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/ServiceMetada.java
@@ -1,0 +1,71 @@
+package org.apache.dubbo.common;/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * data related to service level such as name, version, classloader of business service,
+ * security info, etc. Also with a AttributeMap for extension.
+ */
+public class ServiceMetada {
+
+    private final String serviceName;
+    private final String version;
+    private final String group;
+
+    /* will be transferred to remote side */
+    private final Map<String, Object> attachments = new ConcurrentHashMap<String, Object>();
+    /* used locally*/
+    private final Map<String, Object> attributeMap = new ConcurrentHashMap<String, Object>();
+
+    public ServiceMetada(String serviceName, String version, String group) {
+        this.serviceName = serviceName;
+        this.version = version;
+        this.group = group;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public Map<String, Object> getAttachments() {
+        return attachments;
+    }
+
+    public Map<String, Object> getAttributeMap() {
+        return attributeMap;
+    }
+
+    public void addAttribute(String key, Object value) {
+        this.attributeMap.put(key, value);
+    }
+
+    public void addAttachment(String key, Object value) {
+        this.attributeMap.put(key, value);
+    }
+
+
+}

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/ServiceMetada.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/ServiceMetada.java
@@ -24,31 +24,21 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class ServiceMetada {
 
-    private final String serviceName;
-    private final String version;
-    private final String group;
+    private final String serviceKey;
+    private final Class<?> serviceType;
 
     /* will be transferred to remote side */
     private final Map<String, Object> attachments = new ConcurrentHashMap<String, Object>();
     /* used locally*/
     private final Map<String, Object> attributeMap = new ConcurrentHashMap<String, Object>();
 
-    public ServiceMetada(String serviceName, String version, String group) {
-        this.serviceName = serviceName;
-        this.version = version;
-        this.group = group;
+    public ServiceMetada(String serviceKey, Class<?> serviceType) {
+        this.serviceKey = serviceKey;
+        this.serviceType = serviceType;
     }
 
-    public String getServiceName() {
-        return serviceName;
-    }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public String getGroup() {
-        return group;
+    public String getServiceKey() {
+        return serviceKey;
     }
 
     public Map<String, Object> getAttachments() {

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/AddressListener.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/AddressListener.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.registry;
+
+import org.apache.dubbo.common.ServiceMetada;
+import org.apache.dubbo.common.URL;
+
+import java.util.List;
+
+public interface AddressListener {
+
+    /**
+     * processing when receiving the address list
+     *
+     * @param serviceMetadata
+     * @param addresses
+     */
+    void notify(ServiceMetada serviceMetadata, List<URL> addresses);
+
+}

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
@@ -248,8 +248,10 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
     public synchronized void notify(List<URL> urls) {
         ExtensionLoader<AddressListener> addressListenerExtensionLoader = ExtensionLoader.getExtensionLoader(AddressListener.class);
         Set<String> surpportedListeners = addressListenerExtensionLoader.getSupportedExtensions();
-        for (String addressListenerName : surpportedListeners) {
-            addressListenerExtensionLoader.getExtension(addressListenerName).notify(this.serviceMetada, urls);
+        if (surpportedListeners != null) {
+            for (String addressListenerName : surpportedListeners) {
+                addressListenerExtensionLoader.getExtension(addressListenerName).notify(this.serviceMetada, urls);
+            }
         }
 
         List<URL> categoryUrls = urls.stream()


### PR DESCRIPTION
## What is the purpose of the change

If URL is used for data transferred before loadbalancer decides the remote peer, we may interator all list of URL with low efficence because  URL as the core model of dubbo is a level of peer remote. So we need a service level model like this.

add a addressListner for adding more info to servicemetada according to URLs updates when registry directory got updated addresses

## Brief changelog

A new pojo class and a listener class are suggested to import.
