### PR TITLE
change the configurtion to work default with multicast address

### DIFF
--- a/dubbo-demo/dubbo-demo-consumer/src/main/resources/META-INF/spring/dubbo-demo-consumer.xml
+++ b/dubbo-demo/dubbo-demo-consumer/src/main/resources/META-INF/spring/dubbo-demo-consumer.xml
@@ -23,7 +23,7 @@
 
     <dubbo:application name="demo-consumer"/>
 
-    <dubbo:registry address="zookeeper://127.0.0.1:2181"/>
+    <dubbo:registry address="multicast://224.5.6.7:1234"/>
 
     <!-- generate proxy for the remote service, then demoService can be used in the same way as the
     local regular interface -->


### PR DESCRIPTION
## What is the purpose of the change

Making changes in dubbo-demo-consumer.xml to use multicast as provider is configured to multicast. So that dubbo demo user can use the sample without any external configuration.

## Brief changelog

Making changes in dubbo-demo-consumer.xml to use multicast as provider is configured to multicast. So that dubbo demo user can use the sample without any external configuration.

## Verifying this change

Running locally dubbo-demo provider and consumer and seeing the request-response messages.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
