### PR TITLE
Release resource after use in ConfigParserTest

### DIFF
--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/configurator/parser/ConfigParserTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/configurator/parser/ConfigParserTest.java
@@ -27,6 +27,7 @@ import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
@@ -35,129 +36,133 @@ import java.util.List;
  */
 public class ConfigParserTest {
 
-    private String streamToString(InputStream stream) {
-        try {
-            byte[] bytes = new byte[stream.available()];
-            stream.read(bytes);
-            return new String(bytes);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return null;
+    private String streamToString(InputStream stream) throws IOException {
+        byte[] bytes = new byte[stream.available()];
+        stream.read(bytes);
+        return new String(bytes);
     }
 
     @Test
-    public void snakeYamlBasicTest() {
-        InputStream yamlStream = this.getClass().getResourceAsStream("/ServiceNoApp.yml");
+    public void snakeYamlBasicTest() throws IOException {
+        try(InputStream yamlStream = this.getClass().getResourceAsStream("/ServiceNoApp.yml")) {
 
-        Constructor constructor = new Constructor(ConfiguratorConfig.class);
-        TypeDescription carDescription = new TypeDescription(ConfiguratorConfig.class);
-        carDescription.addPropertyParameters("items", ConfigItem.class);
-        constructor.addTypeDescription(carDescription);
+            Constructor constructor = new Constructor(ConfiguratorConfig.class);
+            TypeDescription carDescription = new TypeDescription(ConfiguratorConfig.class);
+            carDescription.addPropertyParameters("items", ConfigItem.class);
+            constructor.addTypeDescription(carDescription);
 
-        Yaml yaml = new Yaml(constructor);
-        ConfiguratorConfig config = yaml.load(yamlStream);
-        System.out.println(config);
+            Yaml yaml = new Yaml(constructor);
+            ConfiguratorConfig config = yaml.load(yamlStream);
+            System.out.println(config);
+        }
     }
 
     @Test
     public void parseConfiguratorsServiceNoAppTest() throws Exception {
-        InputStream yamlStream = this.getClass().getResourceAsStream("/ServiceNoApp.yml");
-        List<URL> urls = ConfigParser.parseConfigurators(streamToString(yamlStream));
-        Assert.assertNotNull(urls);
-        Assert.assertEquals(2, urls.size());
-        URL url = urls.get(0);
-        Assert.assertEquals(url.getAddress(), "127.0.0.1:20880");
-        Assert.assertEquals(url.getParameter(Constants.WEIGHT_KEY, 0), 222);
+        try(InputStream yamlStream = this.getClass().getResourceAsStream("/ServiceNoApp.yml")) {
+            List<URL> urls = ConfigParser.parseConfigurators(streamToString(yamlStream));
+            Assert.assertNotNull(urls);
+            Assert.assertEquals(2, urls.size());
+            URL url = urls.get(0);
+            Assert.assertEquals(url.getAddress(), "127.0.0.1:20880");
+            Assert.assertEquals(url.getParameter(Constants.WEIGHT_KEY, 0), 222);
+        }
     }
 
     @Test
     public void parseConfiguratorsServiceGroupVersionTest() throws Exception {
-        InputStream yamlStream = this.getClass().getResourceAsStream("/ServiceGroupVersion.yml");
-        List<URL> urls = ConfigParser.parseConfigurators(streamToString(yamlStream));
-        Assert.assertNotNull(urls);
-        Assert.assertEquals(1, urls.size());
-        URL url = urls.get(0);
-        Assert.assertEquals("testgroup", url.getParameter(Constants.GROUP_KEY));
-        Assert.assertEquals("1.0.0", url.getParameter(Constants.VERSION_KEY));
+        try(InputStream yamlStream = this.getClass().getResourceAsStream("/ServiceGroupVersion.yml")) {
+            List<URL> urls = ConfigParser.parseConfigurators(streamToString(yamlStream));
+            Assert.assertNotNull(urls);
+            Assert.assertEquals(1, urls.size());
+            URL url = urls.get(0);
+            Assert.assertEquals("testgroup", url.getParameter(Constants.GROUP_KEY));
+            Assert.assertEquals("1.0.0", url.getParameter(Constants.VERSION_KEY));
+        }
     }
 
     @Test
-    public void parseConfiguratorsServiceMultiAppsTest() {
-        InputStream yamlStream = this.getClass().getResourceAsStream("/ServiceMultiApps.yml");
-        List<URL> urls = ConfigParser.parseConfigurators(streamToString(yamlStream));
-        Assert.assertNotNull(urls);
-        Assert.assertEquals(4, urls.size());
-        URL url = urls.get(0);
-        Assert.assertEquals("127.0.0.1", url.getAddress());
-        Assert.assertEquals(6666, url.getParameter(Constants.TIMEOUT_KEY, 0));
-        Assert.assertNotNull(url.getParameter(Constants.APPLICATION_KEY));
+    public void parseConfiguratorsServiceMultiAppsTest() throws IOException {
+        try(InputStream yamlStream = this.getClass().getResourceAsStream("/ServiceMultiApps.yml")) {
+            List<URL> urls = ConfigParser.parseConfigurators(streamToString(yamlStream));
+            Assert.assertNotNull(urls);
+            Assert.assertEquals(4, urls.size());
+            URL url = urls.get(0);
+            Assert.assertEquals("127.0.0.1", url.getAddress());
+            Assert.assertEquals(6666, url.getParameter(Constants.TIMEOUT_KEY, 0));
+            Assert.assertNotNull(url.getParameter(Constants.APPLICATION_KEY));
+        }
     }
 
     @Test(expected = IllegalStateException.class)
-    public void parseConfiguratorsServiceNoRuleTest() {
-        InputStream yamlStream = this.getClass().getResourceAsStream("/ServiceNoRule.yml");
-        ConfigParser.parseConfigurators(streamToString(yamlStream));
-        Assert.fail();
+    public void parseConfiguratorsServiceNoRuleTest() throws IOException {
+        try(InputStream yamlStream = this.getClass().getResourceAsStream("/ServiceNoRule.yml")) {
+            ConfigParser.parseConfigurators(streamToString(yamlStream));
+            Assert.fail();
+        }
     }
 
     @Test
-    public void parseConfiguratorsAppMultiServicesTest() {
-        InputStream yamlStream = this.getClass().getResourceAsStream("/AppMultiServices.yml");
-        String yamlFile = streamToString(yamlStream);
-        List<URL> urls = ConfigParser.parseConfigurators(yamlFile);
-        Assert.assertNotNull(urls);
-        Assert.assertEquals(4, urls.size());
-        URL url = urls.get(0);
-        Assert.assertEquals("127.0.0.1", url.getAddress());
-        Assert.assertEquals("service1", url.getServiceInterface());
-        Assert.assertEquals(6666, url.getParameter(Constants.TIMEOUT_KEY, 0));
-        Assert.assertEquals("random", url.getParameter(Constants.LOADBALANCE_KEY));
-        Assert.assertEquals(url.getParameter(Constants.APPLICATION_KEY), "demo-consumer");
+    public void parseConfiguratorsAppMultiServicesTest() throws IOException {
+        try(InputStream yamlStream = this.getClass().getResourceAsStream("/AppMultiServices.yml")) {
+            String yamlFile = streamToString(yamlStream);
+            List<URL> urls = ConfigParser.parseConfigurators(yamlFile);
+            Assert.assertNotNull(urls);
+            Assert.assertEquals(4, urls.size());
+            URL url = urls.get(0);
+            Assert.assertEquals("127.0.0.1", url.getAddress());
+            Assert.assertEquals("service1", url.getServiceInterface());
+            Assert.assertEquals(6666, url.getParameter(Constants.TIMEOUT_KEY, 0));
+            Assert.assertEquals("random", url.getParameter(Constants.LOADBALANCE_KEY));
+            Assert.assertEquals(url.getParameter(Constants.APPLICATION_KEY), "demo-consumer");
+        }
     }
 
 
     @Test
-    public void parseConfiguratorsAppAnyServicesTest() {
-        InputStream yamlStream = this.getClass().getResourceAsStream("/AppAnyServices.yml");
-        List<URL> urls = ConfigParser.parseConfigurators(streamToString(yamlStream));
-        Assert.assertNotNull(urls);
-        Assert.assertEquals(2, urls.size());
-        URL url = urls.get(0);
-        Assert.assertEquals("127.0.0.1", url.getAddress());
-        Assert.assertEquals("*", url.getServiceInterface());
-        Assert.assertEquals(6666, url.getParameter(Constants.TIMEOUT_KEY, 0));
-        Assert.assertEquals("random", url.getParameter(Constants.LOADBALANCE_KEY));
-        Assert.assertEquals(url.getParameter(Constants.APPLICATION_KEY), "demo-consumer");
+    public void parseConfiguratorsAppAnyServicesTest() throws IOException {
+        try(InputStream yamlStream = this.getClass().getResourceAsStream("/AppAnyServices.yml")) {
+            List<URL> urls = ConfigParser.parseConfigurators(streamToString(yamlStream));
+            Assert.assertNotNull(urls);
+            Assert.assertEquals(2, urls.size());
+            URL url = urls.get(0);
+            Assert.assertEquals("127.0.0.1", url.getAddress());
+            Assert.assertEquals("*", url.getServiceInterface());
+            Assert.assertEquals(6666, url.getParameter(Constants.TIMEOUT_KEY, 0));
+            Assert.assertEquals("random", url.getParameter(Constants.LOADBALANCE_KEY));
+            Assert.assertEquals(url.getParameter(Constants.APPLICATION_KEY), "demo-consumer");
+        }
     }
 
     @Test
-    public void parseConfiguratorsAppNoServiceTest() {
-        InputStream yamlStream = this.getClass().getResourceAsStream("/AppNoService.yml");
-        List<URL> urls = ConfigParser.parseConfigurators(streamToString(yamlStream));
-        Assert.assertNotNull(urls);
-        Assert.assertEquals(1, urls.size());
-        URL url = urls.get(0);
-        Assert.assertEquals("127.0.0.1", url.getAddress());
-        Assert.assertEquals("*", url.getServiceInterface());
-        Assert.assertEquals(6666, url.getParameter(Constants.TIMEOUT_KEY, 0));
-        Assert.assertEquals("random", url.getParameter(Constants.LOADBALANCE_KEY));
-        Assert.assertEquals(url.getParameter(Constants.APPLICATION_KEY), "demo-consumer");
+    public void parseConfiguratorsAppNoServiceTest() throws IOException {
+        try(InputStream yamlStream = this.getClass().getResourceAsStream("/AppNoService.yml")) {
+            List<URL> urls = ConfigParser.parseConfigurators(streamToString(yamlStream));
+            Assert.assertNotNull(urls);
+            Assert.assertEquals(1, urls.size());
+            URL url = urls.get(0);
+            Assert.assertEquals("127.0.0.1", url.getAddress());
+            Assert.assertEquals("*", url.getServiceInterface());
+            Assert.assertEquals(6666, url.getParameter(Constants.TIMEOUT_KEY, 0));
+            Assert.assertEquals("random", url.getParameter(Constants.LOADBALANCE_KEY));
+            Assert.assertEquals(url.getParameter(Constants.APPLICATION_KEY), "demo-consumer");
+        }
     }
 
     @Test
-    public void parseConsumerSpecificProvidersTest() {
-        InputStream yamlStream = this.getClass().getResourceAsStream("/ConsumerSpecificProviders.yml");
-        List<URL> urls = ConfigParser.parseConfigurators(streamToString(yamlStream));
-        Assert.assertNotNull(urls);
-        Assert.assertEquals(1, urls.size());
-        URL url = urls.get(0);
-        Assert.assertEquals("127.0.0.1", url.getAddress());
-        Assert.assertEquals("*", url.getServiceInterface());
-        Assert.assertEquals(6666, url.getParameter(Constants.TIMEOUT_KEY, 0));
-        Assert.assertEquals("random", url.getParameter(Constants.LOADBALANCE_KEY));
-        Assert.assertEquals("127.0.0.1:20880", url.getParameter(Constants.OVERRIDE_PROVIDERS_KEY));
-        Assert.assertEquals(url.getParameter(Constants.APPLICATION_KEY), "demo-consumer");
+    public void parseConsumerSpecificProvidersTest() throws IOException {
+        try(InputStream yamlStream = this.getClass().getResourceAsStream("/ConsumerSpecificProviders.yml")) {
+            List<URL> urls = ConfigParser.parseConfigurators(streamToString(yamlStream));
+            Assert.assertNotNull(urls);
+            Assert.assertEquals(1, urls.size());
+            URL url = urls.get(0);
+            Assert.assertEquals("127.0.0.1", url.getAddress());
+            Assert.assertEquals("*", url.getServiceInterface());
+            Assert.assertEquals(6666, url.getParameter(Constants.TIMEOUT_KEY, 0));
+            Assert.assertEquals("random", url.getParameter(Constants.LOADBALANCE_KEY));
+            Assert.assertEquals("127.0.0.1:20880", url.getParameter(Constants.OVERRIDE_PROVIDERS_KEY));
+            Assert.assertEquals(url.getParameter(Constants.APPLICATION_KEY), "demo-consumer");
+        }
     }
 
 }


### PR DESCRIPTION
## What is the purpose of the change

Release resource after use in ConfigParserTest

This change was first introduced by #2905 ,
but somehow it was accidentally lost during merge `dev-metadata` branch.

## Brief changelog

The `yamlStream` should be closed after test method.

## Verifying this change

run unit tests

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
