### PR TITLE
[Dubbo-3169]Check future status before get(), return default value if not completed yet.

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncRpcResult.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AsyncRpcResult.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
  *
  * <p>
  * You should never rely on this class directly when using or extending Dubbo, the implementation of {@link AsyncRpcResult}
- * is only a workaround for compatibility purpose. It may be changed or even get removed from the next version.
+ * is only a workaround for compatibility purpose. It may be changed or even get removed from the next major version.
  * Please only use {@link Result} or {@link RpcResult}.
  *
  * Extending the {@link Filter} is one typical use case:
@@ -147,19 +147,15 @@ public class AsyncRpcResult extends AbstractResult {
     }
 
     public Result getRpcResult() {
-        Result result;
         try {
             if (resultFuture.isDone()) {
-                result = resultFuture.get();
-            } else {
-                result = new RpcResult();
+                return resultFuture.get();
             }
         } catch (Exception e) {
             // This should never happen;
-            logger.error("Got exception when trying to fetch the underlying result of AsyncRpcResult.", e);
-            result = new RpcResult();
+            logger.error("Got exception when trying to fetch the underlying result from AsyncRpcResult.", e);
         }
-        return result;
+        return new RpcResult();
     }
 
     @Override

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/SimpleAsyncRpcResult.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/SimpleAsyncRpcResult.java
@@ -20,6 +20,17 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * A sub class used for normal async invoke.
+ *
+ * <b>NOTICE!!</b>
+ *
+ * <p>
+ * You should never rely on this class directly when using or extending Dubbo, the implementation of {@link SimpleAsyncRpcResult}
+ * is only a workaround for compatibility purpose. It may be changed or even get removed from the next version.
+ * Please only use {@link Result} or {@link RpcResult}.
+ * </p>
+ *
+ * Check {@link AsyncRpcResult} for more details.
+ *
  * TODO AsyncRpcResult, AsyncNormalRpcResult should not be a parent-child hierarchy.
  */
 public class SimpleAsyncRpcResult extends AsyncRpcResult {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/SimpleAsyncRpcResult.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/SimpleAsyncRpcResult.java
@@ -25,7 +25,7 @@ import java.util.concurrent.CompletableFuture;
  *
  * <p>
  * You should never rely on this class directly when using or extending Dubbo, the implementation of {@link SimpleAsyncRpcResult}
- * is only a workaround for compatibility purpose. It may be changed or even get removed from the next version.
+ * is only a workaround for compatibility purpose. It may be changed or even get removed from the next major version.
  * Please only use {@link Result} or {@link RpcResult}.
  * </p>
  *


### PR DESCRIPTION
## What is the purpose of the change

* Check future status before get(), return the default value if not completed yet.
* Add comment to announce AsyncRpcResult as unstable and should only be used internally.

## Brief changelog

* AsyncRpcResult

## Verifying this change

run `dubbo-samples-async`

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
