### PR TITLE
prefer jax-rs annotation on impl and compatible with old version

### DIFF
--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/RestProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/RestProtocol.java
@@ -90,7 +90,7 @@ public class RestProtocol extends AbstractProxyProtocol {
     @Override
     protected <T> Runnable doExport(T impl, Class<T> type, URL url) throws RpcException {
         String addr = getAddr(url);
-        Class implClass = ApplicationModel.getProviderModel(url.getServiceKey()).getServiceInterfaceClass();
+        Class implClass = ApplicationModel.getProviderModel(url.getServiceKey()).getServiceInstance().getClass();
         RestServer server = servers.get(addr);
         if (server == null) {
             server = serverFactory.createServer(url.getParameter(Constants.SERVER_KEY, DEFAULT_SERVER));


### PR DESCRIPTION
As Luo's advice,

The jax-rs annoations should be preferred to implemation class as the reasons below
1) compatible to old dubbo version
2) Dubbo REST provider can be used without using of Dubbo Conumser for REST (User may access the rest API from JS client directly).
3) Interface should be kept clean without the pullation of REST annoatation.
