### PR TITLE
Extract compareTo impl to Router interface and concrete Router only responsible for provide priority.

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/Router.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/Router.java
@@ -85,4 +85,19 @@ public interface Router extends Comparable<Router> {
      * @return router's priority
      */
     int getPriority();
+
+    @Override
+    default int compareTo(Router o) {
+        if (o == null) {
+            throw new IllegalArgumentException();
+        }
+        if (this.getPriority() == o.getPriority()) {
+            if (o.getUrl() == null) {
+                return -1;
+            }
+            return getUrl().toFullString().compareTo(o.getUrl().toFullString());
+        } else {
+            return getPriority() > o.getPriority() ? 1 : -1;
+        }
+    }
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/Router.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/Router.java
@@ -93,6 +93,9 @@ public interface Router extends Comparable<Router> {
         }
         if (this.getPriority() == o.getPriority()) {
             if (o.getUrl() == null) {
+                return 1;
+            }
+            if (getUrl() == null) {
                 return -1;
             }
             if (getUrl() == null) {

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/Router.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/Router.java
@@ -95,6 +95,9 @@ public interface Router extends Comparable<Router> {
             if (o.getUrl() == null) {
                 return -1;
             }
+            if (getUrl() == null) {
+                return 1;
+            }
             return getUrl().toFullString().compareTo(o.getUrl().toFullString());
         } else {
             return getPriority() > o.getPriority() ? 1 : -1;

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/Router.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/Router.java
@@ -98,9 +98,6 @@ public interface Router extends Comparable<Router> {
             if (getUrl() == null) {
                 return -1;
             }
-            if (getUrl() == null) {
-                return 1;
-            }
             return getUrl().toFullString().compareTo(o.getUrl().toFullString());
         } else {
             return getPriority() > o.getPriority() ? 1 : -1;

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/AbstractRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/AbstractRouter.java
@@ -20,9 +20,6 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.configcenter.DynamicConfiguration;
 import org.apache.dubbo.rpc.cluster.Router;
 
-/**
- * TODO Extract more code to here if necessary
- */
 public abstract class AbstractRouter implements Router {
     protected int priority;
     protected boolean force = false;
@@ -63,11 +60,6 @@ public abstract class AbstractRouter implements Router {
 
     public void setForce(boolean force) {
         this.force = force;
-    }
-
-    @Override
-    public int compareTo(Router o) {
-        return (this.getPriority() >= o.getPriority()) ? 1 : -1;
     }
 
     public int getPriority() {

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mock/MockInvokersSelector.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mock/MockInvokersSelector.java
@@ -22,7 +22,6 @@ import org.apache.dubbo.common.utils.CollectionUtils;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcException;
-import org.apache.dubbo.rpc.cluster.Router;
 import org.apache.dubbo.rpc.cluster.router.AbstractRouter;
 
 import java.util.ArrayList;
@@ -95,15 +94,9 @@ public class MockInvokersSelector extends AbstractRouter {
         return hasMockProvider;
     }
 
-    /**
-     * Always stay on the top of the list
-     *
-     * @param o
-     * @return
-     */
     @Override
-    public int compareTo(Router o) {
-        return 1;
+    public int getPriority() {
+        return Integer.MAX_VALUE;
     }
 
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/script/ScriptRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/script/ScriptRouter.java
@@ -24,6 +24,7 @@ import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.cluster.Router;
 import org.apache.dubbo.rpc.cluster.router.AbstractRouter;
 
 import javax.script.Bindings;
@@ -119,5 +120,14 @@ public class ScriptRouter extends AbstractRouter {
     @Override
     public boolean isForce() {
         return url.getParameter(Constants.FORCE_KEY, false);
+    }
+
+    @Override
+    public int compareTo(Router o) {
+        if (o == null || o.getClass() != ScriptRouter.class) {
+            return 1;
+        }
+        ScriptRouter c = (ScriptRouter) o;
+        return this.priority == c.priority ? rule.compareTo(c.rule) : (this.priority > c.priority ? 1 : -1);
     }
 }

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/cluster/Router.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/cluster/Router.java
@@ -36,6 +36,8 @@ public interface Router extends org.apache.dubbo.rpc.cluster.Router {
                                                      com.alibaba.dubbo.rpc.Invocation invocation)
             throws com.alibaba.dubbo.rpc.RpcException;
 
+    int compareTo(Router o);
+
     // Add since 2.7.0
     @Override
     default <T> List<Invoker<T>> route(List<Invoker<T>> invokers, URL url, Invocation invocation) throws RpcException {
@@ -60,5 +62,10 @@ public interface Router extends org.apache.dubbo.rpc.cluster.Router {
     @Override
     default int getPriority() {
         return 1;
+    }
+
+    @Override
+    default int compareTo(org.apache.dubbo.rpc.cluster.Router o) {
+        return this.compareTo((Router)o);
     }
 }

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/cluster/Router.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/cluster/Router.java
@@ -36,8 +36,6 @@ public interface Router extends org.apache.dubbo.rpc.cluster.Router {
                                                      com.alibaba.dubbo.rpc.Invocation invocation)
             throws com.alibaba.dubbo.rpc.RpcException;
 
-    int compareTo(com.alibaba.dubbo.rpc.cluster.Router o);
-
     // Add since 2.7.0
     @Override
     default <T> List<Invoker<T>> route(List<Invoker<T>> invokers, URL url, Invocation invocation) throws RpcException {
@@ -62,10 +60,5 @@ public interface Router extends org.apache.dubbo.rpc.cluster.Router {
     @Override
     default int getPriority() {
         return 1;
-    }
-
-    @Override
-    default int compareTo(org.apache.dubbo.rpc.cluster.Router o) {
-        return compareTo((Router) o);
     }
 }

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/cluster/Router.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/rpc/cluster/Router.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Deprecated
-public interface Router extends org.apache.dubbo.rpc.cluster.Router {
+public interface Router extends org.apache.dubbo.rpc.cluster.Router{
 
     @Override
     com.alibaba.dubbo.common.URL getUrl();
@@ -65,7 +65,11 @@ public interface Router extends org.apache.dubbo.rpc.cluster.Router {
     }
 
     @Override
-    default int compareTo(org.apache.dubbo.rpc.cluster.Router o) {
+    default int compareTo (org.apache.dubbo.rpc.cluster.Router o) {
+        if (!(o instanceof Router)) {
+            return 1;
+        }
+
         return this.compareTo((Router)o);
     }
 }

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/rpc/cluster/CompatibleRouter2.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/rpc/cluster/CompatibleRouter2.java
@@ -27,8 +27,7 @@ import java.util.List;
 /**
  *
  */
-public class CompatibleRouter implements Router {
-
+public class CompatibleRouter2 implements Router {
     @Override
     public URL getUrl() {
         return null;

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/rpc/cluster/NewRouter.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/rpc/cluster/NewRouter.java
@@ -16,38 +16,39 @@
  */
 package org.apache.dubbo.rpc.cluster;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.RpcException;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
  *
  */
-public class RouterTest {
-
-    private static List<Router> routers = new ArrayList<>();
-
-    @BeforeClass
-    public static void setUp () {
-        CompatibleRouter compatibleRouter = new CompatibleRouter();
-        routers.add(compatibleRouter);
-        CompatibleRouter2 compatibleRouter2 = new CompatibleRouter2();
-        routers.add(compatibleRouter2);
-        NewRouter newRouter = new NewRouter();
-        routers.add(newRouter);
+public class NewRouter implements Router {
+    @Override
+    public URL getUrl() {
+        return null;
     }
 
-    @Test
-    public void testCompareTo () {
-        try {
-            Collections.sort(routers);
-            Assert.assertTrue(true);
-        } catch (Exception e) {
-            Assert.assertFalse(false);
-        }
+    @Override
+    public <T> List<Invoker<T>> route(List<Invoker<T>> invokers, URL url, Invocation invocation) throws RpcException {
+        return null;
+    }
+
+    @Override
+    public boolean isRuntime() {
+        return false;
+    }
+
+    @Override
+    public boolean isForce() {
+        return false;
+    }
+
+    @Override
+    public int getPriority() {
+        return 0;
     }
 }

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/rpc/cluster/RouterTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/rpc/cluster/RouterTest.java
@@ -16,31 +16,38 @@
  */
 package org.apache.dubbo.rpc.cluster;
 
-import com.alibaba.dubbo.common.URL;
-import com.alibaba.dubbo.rpc.Invocation;
-import com.alibaba.dubbo.rpc.Invoker;
-import com.alibaba.dubbo.rpc.RpcException;
 import com.alibaba.dubbo.rpc.cluster.Router;
 
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
  *
  */
-public class CompatibleRouter implements Router {
+public class RouterTest {
 
-    @Override
-    public URL getUrl() {
-        return null;
+    private static List<Router> routers = new ArrayList<>();
+
+    @BeforeClass
+    public static void setUp() {
+        CompatibleRouter compatibleRouter = new CompatibleRouter();
+        routers.add(compatibleRouter);
+        CompatibleRouter2 compatibleRouter2 = new CompatibleRouter2();
+        routers.add(compatibleRouter2);
     }
 
-    @Override
-    public <T> List<Invoker<T>> route(List<Invoker<T>> invokers, URL url, Invocation invocation) throws RpcException {
-        return null;
-    }
-
-    @Override
-    public int compareTo(Router o) {
-        return 0;
+    @Test
+    public void testCompareTo () {
+        try {
+            Collections.sort(routers);
+            Assert.assertTrue(true);
+        } catch (Exception e) {
+            Assert.assertFalse(false);
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Extract compareTo impl to Router interface and concrete Router only responsible for provide priority.

## Brief changelog

Add default compareTo implementation to Router interface
remove compateTo from impl class

## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
