### PR TITLE
use lazy-into to create sharedExecutor

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReport.java
@@ -24,13 +24,13 @@ import org.apache.dubbo.common.utils.JVMUtil;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Abort Policy.
@@ -78,43 +78,34 @@ public class AbortPolicyWithReport extends ThreadPoolExecutor.AbortPolicy {
             return;
         }
 
-        Executors.newSingleThreadExecutor().execute(new Runnable() {
-            @Override
-            public void run() {
-                String dumpPath = url.getParameter(Constants.DUMP_DIRECTORY, System.getProperty("user.home"));
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        pool.execute(() -> {
+            String dumpPath = url.getParameter(Constants.DUMP_DIRECTORY, System.getProperty("user.home"));
 
-                SimpleDateFormat sdf;
+            SimpleDateFormat sdf;
 
-                String os = System.getProperty("os.name").toLowerCase();
+            String os = System.getProperty("os.name").toLowerCase();
 
-                // window system don't support ":" in file name
-                if(os.contains("win")){
-                    sdf = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
-                }else {
-                    sdf = new SimpleDateFormat("yyyy-MM-dd_HH:mm:ss");
-                }
-
-                String dateStr = sdf.format(new Date());
-                FileOutputStream jstackStream = null;
-                try {
-                    jstackStream = new FileOutputStream(new File(dumpPath, "Dubbo_JStack.log" + "." + dateStr));
-                    JVMUtil.jstack(jstackStream);
-                } catch (Throwable t) {
-                    logger.error("dump jstack error", t);
-                } finally {
-                    guard.release();
-                    if (jstackStream != null) {
-                        try {
-                            jstackStream.flush();
-                            jstackStream.close();
-                        } catch (IOException e) {
-                        }
-                    }
-                }
-
-                lastPrintTime = System.currentTimeMillis();
+            // window system don't support ":" in file name
+            if (os.contains("win")) {
+                sdf = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
+            } else {
+                sdf = new SimpleDateFormat("yyyy-MM-dd_HH:mm:ss");
             }
+
+            String dateStr = sdf.format(new Date());
+            //try-with-resources
+            try (FileOutputStream jStackStream = new FileOutputStream(new File(dumpPath, "Dubbo_JStack.log" + "." + dateStr))) {
+                JVMUtil.jstack(jStackStream);
+            } catch (Throwable t) {
+                logger.error("dump jStack error", t);
+            } finally {
+                guard.release();
+            }
+            lastPrintTime = System.currentTimeMillis();
         });
+        //must shutdown thread pool ,if not will lead to OOM
+        pool.shutdown();
 
     }
 

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
@@ -17,20 +17,14 @@
 package org.apache.dubbo.common.threadpool.support;
 
 import org.apache.dubbo.common.URL;
-import org.junit.jupiter.api.Assertions;
+import org.apache.dubbo.common.threadpool.support.AbortPolicyWithReport;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
-
 
 public class AbortPolicyWithReportTest {
-
-    private static Integer val = 0;
     @Test
     public void jStackDumpTest() throws InterruptedException {
         URL url = URL.valueOf("dubbo://admin:hello1234@10.20.130.230:20880/context/path?dump.directory=/tmp&version=1.0.0&application=morgan&noValue");
@@ -49,28 +43,5 @@ public class AbortPolicyWithReportTest {
 
         Thread.sleep(1000);
 
-    }
-
-
-    @Test
-    public void testThreadPoolShutDown() throws InterruptedException {
-        Semaphore semaphore = new Semaphore(1);
-        semaphore.acquire();
-        ExecutorService pool = Executors.newSingleThreadExecutor();
-        pool.execute(() -> {
-            try {
-                //Simulated Time consuming calculation
-                TimeUnit.SECONDS.sleep(5);
-                val = 10;
-                System.out.println("计算完成");
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            } finally {
-                semaphore.release();
-            }
-        });
-        pool.shutdown();
-        semaphore.acquire();
-        Assertions.assertEquals(val, 10);
     }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/AbortPolicyWithReportTest.java
@@ -17,14 +17,20 @@
 package org.apache.dubbo.common.threadpool.support;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.common.threadpool.support.AbortPolicyWithReport;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
 
 public class AbortPolicyWithReportTest {
+
+    private static Integer val = 0;
     @Test
     public void jStackDumpTest() throws InterruptedException {
         URL url = URL.valueOf("dubbo://admin:hello1234@10.20.130.230:20880/context/path?dump.directory=/tmp&version=1.0.0&application=morgan&noValue");
@@ -43,5 +49,28 @@ public class AbortPolicyWithReportTest {
 
         Thread.sleep(1000);
 
+    }
+
+
+    @Test
+    public void testThreadPoolShutDown() throws InterruptedException {
+        Semaphore semaphore = new Semaphore(1);
+        semaphore.acquire();
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        pool.execute(() -> {
+            try {
+                //Simulated Time consuming calculation
+                TimeUnit.SECONDS.sleep(5);
+                val = 10;
+                System.out.println("计算完成");
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            } finally {
+                semaphore.release();
+            }
+        });
+        pool.shutdown();
+        semaphore.acquire();
+        Assertions.assertEquals(val, 10);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

use lazy-into to create sharedExecutor

## Brief changelog

Shared Executor is not used in most cases. I think we should use lazy initialization instead of hungry initialization.

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
