### PR TITLE
Bring back redis auth UT

### DIFF
--- a/dubbo-rpc/dubbo-rpc-redis/src/test/java/org/apache/dubbo/rpc/protocol/redis/RedisProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-redis/src/test/java/org/apache/dubbo/rpc/protocol/redis/RedisProtocolTest.java
@@ -55,7 +55,8 @@ public class RedisProtocolTest {
     @BeforeEach
     public void setUp(TestInfo testInfo) {
         int redisPort = NetUtils.getAvailablePort();
-        if (testInfo.getTestMethod().equals("testAuthRedis") || testInfo.getTestMethod().equals("testWrongAuthRedis")) {
+        String methodName = testInfo.getTestMethod().get().getName();
+        if ("testAuthRedis".equals(methodName) || ("testWrongAuthRedis".equals(methodName))) {
             String password = "123456";
             this.redisServer = RedisServer.builder().port(redisPort).setting("requirepass " + password).build();
             this.registryUrl = URL.valueOf("redis://username:" + password + "@localhost:" + redisPort + "?db.index=0");
@@ -135,7 +136,7 @@ public class RedisProtocolTest {
     public void testExport() {
         Assertions.assertThrows(UnsupportedOperationException.class, () -> protocol.export(protocol.refer(IDemoService.class, registryUrl)));
     }
-    @Disabled
+
     @Test
     public void testAuthRedis() {
         // default db.index=0
@@ -197,8 +198,8 @@ public class RedisProtocolTest {
 
         refer.destroy();
     }
-    @Disabled
-    //@Test
+
+    @Test
     public void testWrongAuthRedis() {
         String password = "1234567";
         this.registryUrl = this.registryUrl.setPassword(password);


### PR DESCRIPTION
## What is the purpose of the change

Unit Test about auth test in RedisProtocolTest.java is disabled, bring it back.

## Brief changelog

RedisProtocolTest.java
enable `testAuthRedis ` and `testWrongAuthRedis `

## Verifying this change

UT pass

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
