### PR TITLE
fix #2842.  remove duplicate SPI definitions

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -535,6 +535,18 @@
                                     </resource>
                                 </transformer>
                             </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>com.alibaba:dubbo</artifact>
+                                    <excludes>
+                                        <!-- These two line is optional, it can remove some warn log -->
+                                        <exclude>com/**</exclude>
+                                        <exclude>org/**</exclude>
+                                        <!-- This one is required -->
+                                        <exclude>META-INF/dubbo/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Download the shade source， and add some log or you can directly debug:
org.apache.maven.plugins.shade.mojo.ShadeMojo#execute

The dubbo.jar will generate from some jars including dubbo.jar itself.
When you run `mvn clean install -DskipTests` , it willl work well.  Because the original dubbo.jar is deleted.

After that if you run `mvn install -DskipTests`, it will merge two part files . one part  is from many other jar(netty, netty4, mina etc.), and one is from dubbo.jar.  The shade plugin will merge this file into one.(org.apache.maven.plugins.shade.resource.AppendingTransformer in pom.xml)

```
netty=com.alibaba.dubbo.remoting.transport.netty.NettyTransporter
netty4=com.alibaba.dubbo.remoting.transport.netty4.NettyTransporter
mina=com.alibaba.dubbo.remoting.transport.mina.MinaTransporter
grizzly=com.alibaba.dubbo.remoting.transport.grizzly.GrizzlyTransporter

netty=com.alibaba.dubbo.remoting.transport.netty.NettyTransporter
netty4=com.alibaba.dubbo.remoting.transport.netty4.NettyTransporter
mina=com.alibaba.dubbo.remoting.transport.mina.MinaTransporter
grizzly=com.alibaba.dubbo.remoting.transport.grizzly.GrizzlyTransporter

```
If you run commond at third time , it will generate 3 times.

There are two ways to resolve this issue.
* Force rerun maven-jar-plugin before shade plugin.
* filter some files merge in shade plugin.


