### PR TITLE
use netty4 as default transporter for 2.6.6 #3029

### DIFF
--- a/dependencies-bom/pom.xml
+++ b/dependencies-bom/pom.xml
@@ -75,7 +75,7 @@
         <spring_version>4.3.16.RELEASE</spring_version>
         <javassist_version>3.20.0-GA</javassist_version>
         <netty_version>3.2.5.Final</netty_version>
-        <netty4_version>4.0.35.Final</netty4_version>
+        <netty4_version>4.1.25.Final</netty4_version>
         <mina_version>1.1.7</mina_version>
         <grizzly_version>2.1.4</grizzly_version>
         <httpclient_version>4.5.3</httpclient_version>

--- a/dubbo-config/dubbo-config-api/pom.xml
+++ b/dubbo-config/dubbo-config-api/pom.xml
@@ -85,7 +85,7 @@
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>
-            <artifactId>dubbo-remoting-netty</artifactId>
+            <artifactId>dubbo-remoting-netty4</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>

--- a/dubbo-config/dubbo-config-spring/pom.xml
+++ b/dubbo-config/dubbo-config-spring/pom.xml
@@ -86,7 +86,7 @@
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>
-            <artifactId>dubbo-remoting-netty</artifactId>
+            <artifactId>dubbo-remoting-netty4</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>

--- a/dubbo-demo/dubbo-demo-consumer/pom.xml
+++ b/dubbo-demo/dubbo-demo-consumer/pom.xml
@@ -52,7 +52,7 @@
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>
-            <artifactId>dubbo-remoting-netty</artifactId>
+            <artifactId>dubbo-remoting-netty4</artifactId>
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>

--- a/dubbo-demo/dubbo-demo-provider/pom.xml
+++ b/dubbo-demo/dubbo-demo-provider/pom.xml
@@ -53,7 +53,7 @@
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>
-            <artifactId>dubbo-remoting-netty</artifactId>
+            <artifactId>dubbo-remoting-netty4</artifactId>
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>

--- a/dubbo-monitor/dubbo-monitor-default/pom.xml
+++ b/dubbo-monitor/dubbo-monitor-default/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>
-            <artifactId>dubbo-remoting-netty</artifactId>
+            <artifactId>dubbo-remoting-netty4</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>

--- a/dubbo-registry/dubbo-registry-default/pom.xml
+++ b/dubbo-registry/dubbo-registry-default/pom.xml
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>
-            <artifactId>dubbo-remoting-netty</artifactId>
+            <artifactId>dubbo-remoting-netty4</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>

--- a/dubbo-remoting/dubbo-remoting-netty/src/main/java/com/alibaba/dubbo/remoting/transport/netty/NettyTransporter.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/main/java/com/alibaba/dubbo/remoting/transport/netty/NettyTransporter.java
@@ -25,7 +25,7 @@ import com.alibaba.dubbo.remoting.Transporter;
 
 public class NettyTransporter implements Transporter {
 
-    public static final String NAME = "netty";
+    public static final String NAME = "netty3";
 
     @Override
     public Server bind(URL url, ChannelHandler listener) throws RemotingException {

--- a/dubbo-remoting/dubbo-remoting-netty/src/main/resources/META-INF/dubbo/internal/com.alibaba.dubbo.remoting.Transporter
+++ b/dubbo-remoting/dubbo-remoting-netty/src/main/resources/META-INF/dubbo/internal/com.alibaba.dubbo.remoting.Transporter
@@ -1,1 +1,1 @@
-netty=com.alibaba.dubbo.remoting.transport.netty.NettyTransporter
+netty3=com.alibaba.dubbo.remoting.transport.netty.NettyTransporter

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/com/alibaba/dubbo/remoting/exchange/support/header/HeartbeatHandlerTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/com/alibaba/dubbo/remoting/exchange/support/header/HeartbeatHandlerTest.java
@@ -56,7 +56,7 @@ public class HeartbeatHandlerTest {
 
     @Test
     public void testServerHeartbeat() throws Exception {
-        URL serverURL = URL.valueOf("header://localhost:55555");
+        URL serverURL = URL.valueOf("header://localhost:55555?transporter=netty3");
         serverURL = serverURL.addParameter(Constants.HEARTBEAT_KEY, 1000);
         TestHeartbeatHandler handler = new TestHeartbeatHandler();
         server = Exchangers.bind(serverURL, handler);
@@ -72,7 +72,7 @@ public class HeartbeatHandlerTest {
 
     @Test
     public void testHeartbeat() throws Exception {
-        URL serverURL = URL.valueOf("header://localhost:55555");
+        URL serverURL = URL.valueOf("header://localhost:55555?transporter=netty3");
         serverURL = serverURL.addParameter(Constants.HEARTBEAT_KEY, 1000);
         TestHeartbeatHandler handler = new TestHeartbeatHandler();
         server = Exchangers.bind(serverURL, handler);
@@ -89,7 +89,7 @@ public class HeartbeatHandlerTest {
     @Test
     public void testClientHeartbeat() throws Exception {
         FakeChannelHandlers.setTestingChannelHandlers();
-        URL serverURL = URL.valueOf("header://localhost:55555");
+        URL serverURL = URL.valueOf("header://localhost:55555?transporter=netty3");
         TestHeartbeatHandler handler = new TestHeartbeatHandler();
         server = Exchangers.bind(serverURL, handler);
         System.out.println("Server bind successfully");

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/com/alibaba/dubbo/remoting/transport/netty/ClientReconnectTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/com/alibaba/dubbo/remoting/transport/netty/ClientReconnectTest.java
@@ -80,7 +80,7 @@ public class ClientReconnectTest {
     public void testReconnectWarnLog() throws RemotingException, InterruptedException {
         int port = NetUtils.getAvailablePort();
         DubboAppender.doStart();
-        String url = "exchange://127.0.0.2:" + port + "/client.reconnect.test?check=false&"
+        String url = "exchange://127.0.0.2:" + port + "/client.reconnect.test?check=false&client=netty3&"
                 + Constants.RECONNECT_KEY + "=" + 1; //1ms reconnect, ensure that there is enough frequency to reconnect
         try {
             Exchangers.connect(url);
@@ -97,12 +97,12 @@ public class ClientReconnectTest {
     }
 
     public Client startClient(int port, int reconnectPeriod) throws RemotingException {
-        final String url = "exchange://127.0.0.1:" + port + "/client.reconnect.test?check=false&" + Constants.RECONNECT_KEY + "=" + reconnectPeriod;
+        final String url = "exchange://127.0.0.1:" + port + "/client.reconnect.test?check=false&client=netty3&" + Constants.RECONNECT_KEY + "=" + reconnectPeriod;
         return Exchangers.connect(url);
     }
 
     public Server startServer(int port) throws RemotingException {
-        final String url = "exchange://127.0.0.1:" + port + "/client.reconnect.test";
+        final String url = "exchange://127.0.0.1:" + port + "/client.reconnect.test?server=netty3";
         return Exchangers.bind(url, new HandlerAdapter());
     }
 

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/com/alibaba/dubbo/remoting/transport/netty/ClientsTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/com/alibaba/dubbo/remoting/transport/netty/ClientsTest.java
@@ -47,7 +47,7 @@ public class ClientsTest {
 
     @Test
     public void testGetTransport3() {
-        String name = "netty";
+        String name = "netty3";
         assertEquals(NettyTransporter.class, ExtensionLoader.getExtensionLoader(Transporter.class).getExtension(name).getClass());
     }
 

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/com/alibaba/dubbo/remoting/transport/netty/NettyClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/com/alibaba/dubbo/remoting/transport/netty/NettyClientTest.java
@@ -39,7 +39,7 @@ public class NettyClientTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        server = Exchangers.bind(URL.valueOf("exchange://localhost:10001?server=netty"), new TelnetServerHandler());
+        server = Exchangers.bind(URL.valueOf("exchange://localhost:10001?server=netty3"), new TelnetServerHandler());
     }
 
     @AfterClass
@@ -52,7 +52,7 @@ public class NettyClientTest {
     }
 
     public static void main(String[] args) throws RemotingException, InterruptedException {
-        ExchangeChannel client = Exchangers.connect(URL.valueOf("exchange://10.20.153.10:20880?client=netty&heartbeat=1000"));
+        ExchangeChannel client = Exchangers.connect(URL.valueOf("exchange://10.20.153.10:20880?client=netty3&heartbeat=1000"));
         Thread.sleep(60 * 1000 * 50);
     }
 
@@ -60,7 +60,7 @@ public class NettyClientTest {
     public void testClientClose() throws Exception {
         List<ExchangeChannel> clients = new ArrayList<ExchangeChannel>(100);
         for (int i = 0; i < 100; i++) {
-            ExchangeChannel client = Exchangers.connect(URL.valueOf("exchange://localhost:10001?client=netty"));
+            ExchangeChannel client = Exchangers.connect(URL.valueOf("exchange://localhost:10001?client=netty3"));
             Thread.sleep(5);
             clients.add(client);
         }
@@ -73,7 +73,7 @@ public class NettyClientTest {
     @Test
     public void testServerClose() throws Exception {
         for (int i = 0; i < 100; i++) {
-            Server aServer = Exchangers.bind(URL.valueOf("exchange://localhost:" + (5000 + i) + "?client=netty"), new TelnetServerHandler());
+            Server aServer = Exchangers.bind(URL.valueOf("exchange://localhost:" + (5000 + i) + "?server=netty3"), new TelnetServerHandler());
             aServer.close();
         }
     }

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/com/alibaba/dubbo/remoting/transport/netty/NettyClientToServerTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/com/alibaba/dubbo/remoting/transport/netty/NettyClientToServerTest.java
@@ -29,11 +29,11 @@ import com.alibaba.dubbo.remoting.exchange.support.Replier;
 public class NettyClientToServerTest extends ClientToServerTest {
 
     protected ExchangeServer newServer(int port, Replier<?> receiver) throws RemotingException {
-        return Exchangers.bind(URL.valueOf("exchange://localhost:" + port + "?server=netty"), receiver);
+        return Exchangers.bind(URL.valueOf("exchange://localhost:" + port + "?server=netty3"), receiver);
     }
 
     protected ExchangeChannel newClient(int port) throws RemotingException {
-        return Exchangers.connect(URL.valueOf("exchange://localhost:" + port + "?client=netty&timeout=3000"));
+        return Exchangers.connect(URL.valueOf("exchange://localhost:" + port + "?client=netty3&timeout=3000"));
     }
 
 }

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/com/alibaba/dubbo/remoting/transport/netty/NettyStringTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/com/alibaba/dubbo/remoting/transport/netty/NettyStringTest.java
@@ -38,8 +38,8 @@ public class NettyStringTest {
         //int port = (int) (1000 * Math.random() + 10000);
         int port = 10001;
         System.out.println(port);
-        server = Exchangers.bind(URL.valueOf("telnet://0.0.0.0:" + port + "?server=netty"), new TelnetServerHandler());
-        client = Exchangers.connect(URL.valueOf("telnet://127.0.0.1:" + port + "?client=netty"), new TelnetClientHandler());
+        server = Exchangers.bind(URL.valueOf("telnet://0.0.0.0:" + port + "?server=netty3"), new TelnetServerHandler());
+        client = Exchangers.connect(URL.valueOf("telnet://127.0.0.1:" + port + "?client=netty3"), new TelnetClientHandler());
     }
 
     @AfterClass

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyTransporter.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/com/alibaba/dubbo/remoting/transport/netty4/NettyTransporter.java
@@ -25,7 +25,7 @@ import com.alibaba.dubbo.remoting.Transporter;
 
 public class NettyTransporter implements Transporter {
 
-    public static final String NAME = "netty4";
+    public static final String NAME = "netty";
 
     @Override
     public Server bind(URL url, ChannelHandler listener) throws RemotingException {

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/resources/META-INF/dubbo/internal/com.alibaba.dubbo.remoting.Transporter
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/resources/META-INF/dubbo/internal/com.alibaba.dubbo.remoting.Transporter
@@ -1,1 +1,1 @@
-netty4=com.alibaba.dubbo.remoting.transport.netty4.NettyTransporter
+netty4=com.alibaba.dubbo.remoting.transport.netty4.NettyTransporternetty=com.alibaba.dubbo.remoting.transport.netty4.NettyTransporter

--- a/dubbo-remoting/dubbo-remoting-p2p/pom.xml
+++ b/dubbo-remoting/dubbo-remoting-p2p/pom.xml
@@ -34,5 +34,11 @@
             <artifactId>dubbo-remoting-api</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-remoting-netty4</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-rpc/dubbo-rpc-dubbo/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-dubbo/pom.xml
@@ -52,7 +52,7 @@
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>
-            <artifactId>dubbo-remoting-netty</artifactId>
+            <artifactId>dubbo-remoting-netty4</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
@@ -63,8 +63,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.mina</groupId>
-            <artifactId>mina-core</artifactId>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dubbo-rpc/dubbo-rpc-thrift/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-thrift/pom.xml
@@ -46,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>
-            <artifactId>dubbo-remoting-netty</artifactId>
+            <artifactId>dubbo-remoting-netty4</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
## What is the purpose of the change

make netty4 as default in dubbo 2.6.6
## Brief changelog
apply #2049 to 2.6.x branch

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
