### PR TITLE
Fix random ut falling in DubboMonitorTest

### DIFF
--- a/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/DubboMonitorTest.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/test/java/org/apache/dubbo/monitor/dubbo/DubboMonitorTest.java
@@ -103,22 +103,23 @@ public class DubboMonitorTest {
                 .addParameter(MonitorService.CONCURRENT, 1)
                 .addParameter(MonitorService.MAX_CONCURRENT, 1);
         monitor.collect(statistics);
+        monitor.send();
         while (lastStatistics == null) {
             Thread.sleep(10);
         }
-        Assertions.assertEquals(lastStatistics.getParameter(MonitorService.APPLICATION), "morgan");
-        Assertions.assertEquals(lastStatistics.getProtocol(), "dubbo");
-        Assertions.assertEquals(lastStatistics.getHost(), "10.20.153.10");
-        Assertions.assertEquals(lastStatistics.getParameter(MonitorService.APPLICATION), "morgan");
-        Assertions.assertEquals(lastStatistics.getParameter(MonitorService.INTERFACE), "MemberService");
-        Assertions.assertEquals(lastStatistics.getParameter(MonitorService.METHOD), "findPerson");
-        Assertions.assertEquals(lastStatistics.getParameter(MonitorService.CONSUMER), "10.20.153.11");
-        Assertions.assertEquals(lastStatistics.getParameter(MonitorService.SUCCESS), "1");
-        Assertions.assertEquals(lastStatistics.getParameter(MonitorService.FAILURE), "0");
-        Assertions.assertEquals(lastStatistics.getParameter(MonitorService.ELAPSED), "3");
-        Assertions.assertEquals(lastStatistics.getParameter(MonitorService.MAX_ELAPSED), "3");
-        Assertions.assertEquals(lastStatistics.getParameter(MonitorService.CONCURRENT), "1");
-        Assertions.assertEquals(lastStatistics.getParameter(MonitorService.MAX_CONCURRENT), "1");
+        Assertions.assertEquals("morgan", lastStatistics.getParameter(MonitorService.APPLICATION));
+        Assertions.assertEquals("dubbo", lastStatistics.getProtocol());
+        Assertions.assertEquals("10.20.153.10", lastStatistics.getHost());
+        Assertions.assertEquals("morgan", lastStatistics.getParameter(MonitorService.APPLICATION));
+        Assertions.assertEquals("MemberService", lastStatistics.getParameter(MonitorService.INTERFACE));
+        Assertions.assertEquals("findPerson", lastStatistics.getParameter(MonitorService.METHOD));
+        Assertions.assertEquals("10.20.153.11", lastStatistics.getParameter(MonitorService.CONSUMER));
+        Assertions.assertEquals("1", lastStatistics.getParameter(MonitorService.SUCCESS));
+        Assertions.assertEquals("0", lastStatistics.getParameter(MonitorService.FAILURE));
+        Assertions.assertEquals("3", lastStatistics.getParameter(MonitorService.ELAPSED));
+        Assertions.assertEquals("3", lastStatistics.getParameter(MonitorService.MAX_ELAPSED));
+        Assertions.assertEquals("1", lastStatistics.getParameter(MonitorService.CONCURRENT));
+        Assertions.assertEquals("1", lastStatistics.getParameter(MonitorService.MAX_CONCURRENT));
         monitor.destroy();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Fix random ut falling in DubboMonitorTest
Fix wrong parameter order of `assertEquals("expected", "actual")`

## Brief changelog

`DubboMonitor#send()` may not executed after ` monitor.collect(statistics);`
Then subsequent assertion may fail.
So manual trigger `send()` after `collect()` in `DubboMonitorTest#testCount()`.

## Verifying this change

UT should always pass on jdk11

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
