### PR TITLE
Fix thrift protocol, use path to locate exporter.

### DIFF
--- a/dubbo-rpc/dubbo-rpc-thrift/src/main/java/org/apache/dubbo/rpc/protocol/thrift/ThriftCodec.java
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/main/java/org/apache/dubbo/rpc/protocol/thrift/ThriftCodec.java
@@ -163,6 +163,7 @@ public class ThriftCodec implements Codec2 {
 
         // version
         String serviceName;
+        String path;
         long id;
 
         TMessage message;
@@ -171,6 +172,7 @@ public class ThriftCodec implements Codec2 {
             protocol.readI16();
             protocol.readByte();
             serviceName = protocol.readString();
+            path = protocol.readString();
             id = protocol.readI64();
             message = protocol.readMessageBegin();
         } catch (TException e) {
@@ -181,6 +183,7 @@ public class ThriftCodec implements Codec2 {
 
             RpcInvocation result = new RpcInvocation();
             result.setAttachment(Constants.INTERFACE_KEY, serviceName);
+            result.setAttachment(Constants.PATH_KEY, path);
             result.setMethodName(message.name);
 
             String argsClassName = ExtensionLoader.getExtensionLoader(ClassNameGenerator.class)
@@ -496,6 +499,8 @@ public class ThriftCodec implements Codec2 {
             protocol.writeByte(VERSION);
             // service name
             protocol.writeString(serviceName);
+            // path
+            protocol.writeString(inv.getAttachment(Constants.PATH_KEY));
             // dubbo request id
             protocol.writeI64(request.getId());
             protocol.getTransport().flush();

--- a/dubbo-rpc/dubbo-rpc-thrift/src/main/java/org/apache/dubbo/rpc/protocol/thrift/ThriftProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/main/java/org/apache/dubbo/rpc/protocol/thrift/ThriftProtocol.java
@@ -63,9 +63,9 @@ public class ThriftProtocol extends AbstractProtocol {
 
             if (msg instanceof Invocation) {
                 Invocation inv = (Invocation) msg;
-                String serviceName = inv.getAttachments().get(Constants.INTERFACE_KEY);
+                String path = inv.getAttachments().get(Constants.PATH_KEY);
                 String serviceKey = serviceKey(channel.getLocalAddress().getPort(),
-                        serviceName, null, null);
+                        path, null, null);
                 DubboExporter<?> exporter = (DubboExporter<?>) exporterMap.get(serviceKey);
                 if (exporter == null) {
                     throw new RemotingException(channel,


### PR DESCRIPTION
## What is the purpose of the change

* Thrift uses `path -> exporter` when exporting, but during invoke it uses interface to find exporter, which may fail when path and interface are not the same.

also see #3017 

## Brief changelog

XXXXX

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
