### PR TITLE
Backport patch for #3327

### DIFF
--- a/dubbo-monitor/dubbo-monitor-default/src/test/java/com/alibaba/dubbo/monitor/dubbo/DubboMonitorTest.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/test/java/com/alibaba/dubbo/monitor/dubbo/DubboMonitorTest.java
@@ -103,22 +103,23 @@ public class DubboMonitorTest {
                 .addParameter(MonitorService.CONCURRENT, 1)
                 .addParameter(MonitorService.MAX_CONCURRENT, 1);
         monitor.collect(statistics);
+        monitor.send();
         while (lastStatistics == null) {
             Thread.sleep(10);
         }
-        Assert.assertEquals(lastStatistics.getParameter(MonitorService.APPLICATION), "morgan");
-        Assert.assertEquals(lastStatistics.getProtocol(), "dubbo");
-        Assert.assertEquals(lastStatistics.getHost(), "10.20.153.10");
-        Assert.assertEquals(lastStatistics.getParameter(MonitorService.APPLICATION), "morgan");
-        Assert.assertEquals(lastStatistics.getParameter(MonitorService.INTERFACE), "MemberService");
-        Assert.assertEquals(lastStatistics.getParameter(MonitorService.METHOD), "findPerson");
-        Assert.assertEquals(lastStatistics.getParameter(MonitorService.CONSUMER), "10.20.153.11");
-        Assert.assertEquals(lastStatistics.getParameter(MonitorService.SUCCESS), "1");
-        Assert.assertEquals(lastStatistics.getParameter(MonitorService.FAILURE), "0");
-        Assert.assertEquals(lastStatistics.getParameter(MonitorService.ELAPSED), "3");
-        Assert.assertEquals(lastStatistics.getParameter(MonitorService.MAX_ELAPSED), "3");
-        Assert.assertEquals(lastStatistics.getParameter(MonitorService.CONCURRENT), "1");
-        Assert.assertEquals(lastStatistics.getParameter(MonitorService.MAX_CONCURRENT), "1");
+        Assert.assertEquals("morgan", lastStatistics.getParameter(MonitorService.APPLICATION));
+        Assert.assertEquals("dubbo", lastStatistics.getProtocol());
+        Assert.assertEquals("10.20.153.10", lastStatistics.getHost());
+        Assert.assertEquals("morgan", lastStatistics.getParameter(MonitorService.APPLICATION));
+        Assert.assertEquals("MemberService", lastStatistics.getParameter(MonitorService.INTERFACE));
+        Assert.assertEquals("findPerson", lastStatistics.getParameter(MonitorService.METHOD));
+        Assert.assertEquals("10.20.153.11", lastStatistics.getParameter(MonitorService.CONSUMER));
+        Assert.assertEquals("1", lastStatistics.getParameter(MonitorService.SUCCESS));
+        Assert.assertEquals("0", lastStatistics.getParameter(MonitorService.FAILURE));
+        Assert.assertEquals("3", lastStatistics.getParameter(MonitorService.ELAPSED));
+        Assert.assertEquals("3", lastStatistics.getParameter(MonitorService.MAX_ELAPSED));
+        Assert.assertEquals("1", lastStatistics.getParameter(MonitorService.CONCURRENT));
+        Assert.assertEquals("1", lastStatistics.getParameter(MonitorService.MAX_CONCURRENT));
         monitor.destroy();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Although branch `2.6.x` haven't support jdk11 yet, I think we can still backport this patch (#3327) on it.
DubboMonitorTest is under different package for 2.6.x, so a separated PR is needed.

## Brief changelog

Update `DubboMonitorTest.java`

## Verifying this change

UT pass on branch 2.6.x

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
