### PR TITLE
fix #2842. remove duplicate SPI definitions for 2.7.x

### DIFF
--- a/dubbo-all/pom.xml
+++ b/dubbo-all/pom.xml
@@ -614,6 +614,18 @@
                                     </resource>
                                 </transformer>
                             </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>org.apache.dubbo:dubbo</artifact>
+                                    <excludes>
+                                        <!-- These two line is optional, it can remove some warn log -->
+                                        <exclude>com/**</exclude>
+                                        <exclude>org/**</exclude>
+                                        <!-- This one is required -->
+                                        <exclude>META-INF/dubbo/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                         </configuration>
                     </execution>
                 </executions>

--- a/dubbo-container/dubbo-container-api/pom.xml
+++ b/dubbo-container/dubbo-container-api/pom.xml
@@ -47,7 +47,6 @@
                             <mainClass>org.apache.dubbo.container.Main</mainClass>
                         </manifest>
                     </archive>
-                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -389,7 +389,6 @@
                             <Implementation-Version>${project.version}</Implementation-Version>
                         </manifestEntries>
                     </archive>
-                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
fix #2842. remove duplicate SPI definitions for 2.7.x