### PR TITLE
[Dubbo-3258] Replace explicit type parameters with diamond operator #3258

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ import java.io.IOException;
 public class Application {
 
     public static void main(String[] args) throws IOException {
-        ServiceConfig<GreetingService> serviceConfig = new ServiceConfig<GreetingService>();
+        ServiceConfig<GreetingService> serviceConfig = new ServiceConfig<>();
         serviceConfig.setApplication(new ApplicationConfig("first-dubbo-provider"));
         serviceConfig.setRegistry(new RegistryConfig("multicast://224.5.6.7:1234"));
         serviceConfig.setInterface(GreetingService.class);
@@ -145,7 +145,7 @@ import org.apache.dubbo.samples.api.GreetingService;
 
 public class Application {
     public static void main(String[] args) {
-        ReferenceConfig<GreetingService> referenceConfig = new ReferenceConfig<GreetingService>();
+        ReferenceConfig<GreetingService> referenceConfig = new ReferenceConfig<>();
         referenceConfig.setApplication(new ApplicationConfig("first-dubbo-consumer"));
         referenceConfig.setRegistry(new RegistryConfig("multicast://224.5.6.7:1234"));
         referenceConfig.setInterface(GreetingService.class);

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/configurator/AbstractConfigurator.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/configurator/AbstractConfigurator.java
@@ -103,7 +103,7 @@ public abstract class AbstractConfigurator implements Configurator {
                 String currentApplication = url.getParameter(Constants.APPLICATION_KEY, url.getUsername());
                 if (configApplication == null || Constants.ANY_VALUE.equals(configApplication)
                         || configApplication.equals(currentApplication)) {
-                    Set<String> conditionKeys = new HashSet<String>();
+                    Set<String> conditionKeys = new HashSet<>();
                     conditionKeys.add(Constants.CATEGORY_KEY);
                     conditionKeys.add(Constants.CHECK_KEY);
                     conditionKeys.add(Constants.DYNAMIC_KEY);

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/ConsistentHashLoadBalance.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/ConsistentHashLoadBalance.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ConcurrentMap;
 public class ConsistentHashLoadBalance extends AbstractLoadBalance {
     public static final String NAME = "consistenthash";
 
-    private final ConcurrentMap<String, ConsistentHashSelector<?>> selectors = new ConcurrentHashMap<String, ConsistentHashSelector<?>>();
+    private final ConcurrentMap<String, ConsistentHashSelector<?>> selectors = new ConcurrentHashMap<>();
 
     @SuppressWarnings("unchecked")
     @Override
@@ -64,7 +64,7 @@ public class ConsistentHashLoadBalance extends AbstractLoadBalance {
         private final int[] argumentIndex;
 
         ConsistentHashSelector(List<Invoker<T>> invokers, String methodName, int identityHashCode) {
-            this.virtualInvokers = new TreeMap<Long, Invoker<T>>();
+            this.virtualInvokers = new TreeMap<>();
             this.identityHashCode = identityHashCode;
             URL url = invokers.get(0).getUrl();
             this.replicaNumber = url.getMethodParameter(methodName, "hash.nodes", 160);

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/RoundRobinLoadBalance.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/loadbalance/RoundRobinLoadBalance.java
@@ -63,7 +63,7 @@ public class RoundRobinLoadBalance extends AbstractLoadBalance {
         }
     }
 
-    private ConcurrentMap<String, ConcurrentMap<String, WeightedRoundRobin>> methodWeightMap = new ConcurrentHashMap<String, ConcurrentMap<String, WeightedRoundRobin>>();
+    private ConcurrentMap<String, ConcurrentMap<String, WeightedRoundRobin>> methodWeightMap = new ConcurrentHashMap<>();
     private AtomicBoolean updateLock = new AtomicBoolean();
     
     /**
@@ -124,7 +124,7 @@ public class RoundRobinLoadBalance extends AbstractLoadBalance {
             if (updateLock.compareAndSet(false, true)) {
                 try {
                     // copy -> modify -> update reference
-                    ConcurrentMap<String, WeightedRoundRobin> newMap = new ConcurrentHashMap<String, WeightedRoundRobin>();
+                    ConcurrentMap<String, WeightedRoundRobin> newMap = new ConcurrentHashMap<>();
                     newMap.putAll(map);
                     Iterator<Entry<String, WeightedRoundRobin>> it = newMap.entrySet().iterator();
                     while (it.hasNext()) {

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/ListMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/ListMerger.java
@@ -31,7 +31,7 @@ public class ListMerger implements Merger<List<?>> {
         if (ArrayUtils.isEmpty(items)) {
             return Collections.emptyList();
         }
-        List<Object> result = new ArrayList<Object>();
+        List<Object> result = new ArrayList<>();
         for (List<?> item : items) {
             if (item != null) {
                 result.addAll(item);

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/MapMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/MapMerger.java
@@ -30,7 +30,7 @@ public class MapMerger implements Merger<Map<?, ?>> {
         if (ArrayUtils.isEmpty(items)) {
             return Collections.emptyMap();
         }
-        Map<Object, Object> result = new HashMap<Object, Object>();
+        Map<Object, Object> result = new HashMap<>();
         for (Map<?, ?> item : items) {
             if (item != null) {
                 result.putAll(item);

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/MergerFactory.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/MergerFactory.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ConcurrentMap;
 public class MergerFactory {
 
     private static final ConcurrentMap<Class<?>, Merger<?>> mergerCache =
-            new ConcurrentHashMap<Class<?>, Merger<?>>();
+            new ConcurrentHashMap<>();
 
     /**
      * Find the merger according to the returnType class, the merger will

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/SetMerger.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/merger/SetMerger.java
@@ -30,7 +30,7 @@ public class SetMerger implements Merger<Set<?>> {
         if (ArrayUtils.isEmpty(items)) {
             return Collections.emptySet();
         }
-        Set<Object> result = new HashSet<Object>();
+        Set<Object> result = new HashSet<>();
 
         for (Set<?> item : items) {
             if (item != null) {

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/ConditionRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/condition/ConditionRouter.java
@@ -77,7 +77,7 @@ public class ConditionRouter extends AbstractRouter implements Comparable<Router
             int i = rule.indexOf("=>");
             String whenRule = i < 0 ? null : rule.substring(0, i).trim();
             String thenRule = i < 0 ? rule.trim() : rule.substring(i + 2).trim();
-            Map<String, MatchPair> when = StringUtils.isBlank(whenRule) || "true".equals(whenRule) ? new HashMap<String, MatchPair>() : parseRule(whenRule);
+            Map<String, MatchPair> when = StringUtils.isBlank(whenRule) || "true".equals(whenRule) ? new HashMap<>() : parseRule(whenRule);
             Map<String, MatchPair> then = StringUtils.isBlank(thenRule) || "false".equals(thenRule) ? null : parseRule(thenRule);
             // NOTE: It should be determined on the business level whether the `When condition` can be empty or not.
             this.whenCondition = when;
@@ -89,7 +89,7 @@ public class ConditionRouter extends AbstractRouter implements Comparable<Router
 
     private static Map<String, MatchPair> parseRule(String rule)
             throws ParseException {
-        Map<String, MatchPair> condition = new HashMap<String, MatchPair>();
+        Map<String, MatchPair> condition = new HashMap<>();
         if (StringUtils.isBlank(rule)) {
             return condition;
         }
@@ -171,7 +171,7 @@ public class ConditionRouter extends AbstractRouter implements Comparable<Router
             if (!matchWhen(url, invocation)) {
                 return invokers;
             }
-            List<Invoker<T>> result = new ArrayList<Invoker<T>>();
+            List<Invoker<T>> result = new ArrayList<>();
             if (thenCondition == null) {
                 logger.warn("The current consumer in the service blacklist. consumer: " + NetUtils.getLocalHost() + ", service: " + url.getServiceKey());
                 return result;
@@ -251,8 +251,8 @@ public class ConditionRouter extends AbstractRouter implements Comparable<Router
     }
 
     protected static final class MatchPair {
-        final Set<String> matches = new HashSet<String>();
-        final Set<String> mismatches = new HashSet<String>();
+        final Set<String> matches = new HashSet<>();
+        final Set<String> mismatches = new HashSet<>();
 
         private boolean isMatch(String value, URL param) {
             if (!matches.isEmpty() && mismatches.isEmpty()) {

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mock/MockInvokersSelector.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/mock/MockInvokersSelector.java
@@ -60,7 +60,7 @@ public class MockInvokersSelector extends AbstractRouter {
         if (!hasMockProviders(invokers)) {
             return null;
         }
-        List<Invoker<T>> sInvokers = new ArrayList<Invoker<T>>(1);
+        List<Invoker<T>> sInvokers = new ArrayList<>(1);
         for (Invoker<T> invoker : invokers) {
             if (invoker.getUrl().getProtocol().equals(Constants.MOCK_PROTOCOL)) {
                 sInvokers.add(invoker);
@@ -73,7 +73,7 @@ public class MockInvokersSelector extends AbstractRouter {
         if (!hasMockProviders(invokers)) {
             return invokers;
         } else {
-            List<Invoker<T>> sInvokers = new ArrayList<Invoker<T>>(invokers.size());
+            List<Invoker<T>> sInvokers = new ArrayList<>(invokers.size());
             for (Invoker<T> invoker : invokers) {
                 if (!invoker.getUrl().getProtocol().equals(Constants.MOCK_PROTOCOL)) {
                     sInvokers.add(invoker);

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/script/ScriptRouter.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/router/script/ScriptRouter.java
@@ -98,7 +98,7 @@ public class ScriptRouter extends AbstractRouter {
             if (obj instanceof Invoker[]) {
                 invokersCopy = Arrays.asList((Invoker<T>[]) obj);
             } else if (obj instanceof Object[]) {
-                invokersCopy = new ArrayList<Invoker<T>>();
+                invokersCopy = new ArrayList<>();
                 for (Object inv : (Object[]) obj) {
                     invokersCopy.add((Invoker<T>) inv);
                 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/BroadcastCluster.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/BroadcastCluster.java
@@ -29,7 +29,7 @@ public class BroadcastCluster implements Cluster {
 
     @Override
     public <T> Invoker<T> join(Directory<T> directory) throws RpcException {
-        return new BroadcastClusterInvoker<T>(directory);
+        return new BroadcastClusterInvoker<>(directory);
     }
 
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/ClusterUtils.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/ClusterUtils.java
@@ -34,7 +34,7 @@ public class ClusterUtils {
     }
 
     public static URL mergeUrl(URL remoteUrl, Map<String, String> localMap) {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         Map<String, String> remoteMap = remoteUrl.getParameters();
 
         if (remoteMap != null && remoteMap.size() > 0) {

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackCluster.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailbackCluster.java
@@ -31,7 +31,7 @@ public class FailbackCluster implements Cluster {
 
     @Override
     public <T> Invoker<T> join(Directory<T> directory) throws RpcException {
-        return new FailbackClusterInvoker<T>(directory);
+        return new FailbackClusterInvoker<>(directory);
     }
 
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailfastCluster.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailfastCluster.java
@@ -31,7 +31,7 @@ public class FailfastCluster implements Cluster {
 
     @Override
     public <T> Invoker<T> join(Directory<T> directory) throws RpcException {
-        return new FailfastClusterInvoker<T>(directory);
+        return new FailfastClusterInvoker<>(directory);
     }
 
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailoverCluster.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailoverCluster.java
@@ -31,7 +31,7 @@ public class FailoverCluster implements Cluster {
 
     @Override
     public <T> Invoker<T> join(Directory<T> directory) throws RpcException {
-        return new FailoverClusterInvoker<T>(directory);
+        return new FailoverClusterInvoker<>(directory);
     }
 
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailoverClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailoverClusterInvoker.java
@@ -62,8 +62,8 @@ public class FailoverClusterInvoker<T> extends AbstractClusterInvoker<T> {
         }
         // retry loop.
         RpcException le = null; // last exception.
-        List<Invoker<T>> invoked = new ArrayList<Invoker<T>>(copyInvokers.size()); // invoked invokers.
-        Set<String> providers = new HashSet<String>(len);
+        List<Invoker<T>> invoked = new ArrayList<>(copyInvokers.size()); // invoked invokers.
+        Set<String> providers = new HashSet<>(len);
         for (int i = 0; i < len; i++) {
             //Reselect before retry to avoid a change of candidate `invokers`.
             //NOTE: if `invokers` changed, then `invoked` also lose accuracy.

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailsafeCluster.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/FailsafeCluster.java
@@ -31,7 +31,7 @@ public class FailsafeCluster implements Cluster {
 
     @Override
     public <T> Invoker<T> join(Directory<T> directory) throws RpcException {
-        return new FailsafeClusterInvoker<T>(directory);
+        return new FailsafeClusterInvoker<>(directory);
     }
 
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/ForkingCluster.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/ForkingCluster.java
@@ -31,7 +31,7 @@ public class ForkingCluster implements Cluster {
 
     @Override
     public <T> Invoker<T> join(Directory<T> directory) throws RpcException {
-        return new ForkingClusterInvoker<T>(directory);
+        return new ForkingClusterInvoker<>(directory);
     }
 
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/MergeableCluster.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/MergeableCluster.java
@@ -27,7 +27,7 @@ public class MergeableCluster implements Cluster {
 
     @Override
     public <T> Invoker<T> join(Directory<T> directory) throws RpcException {
-        return new MergeableClusterInvoker<T>(directory);
+        return new MergeableClusterInvoker<>(directory);
     }
 
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/MergeableClusterInvoker.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/MergeableClusterInvoker.java
@@ -86,7 +86,7 @@ public class MergeableClusterInvoker<T> extends AbstractClusterInvoker<T> {
             returnType = null;
         }
 
-        Map<String, Future<Result>> results = new HashMap<String, Future<Result>>();
+        Map<String, Future<Result>> results = new HashMap<>();
         for (final Invoker<T> invoker : invokers) {
             Future<Result> future = executor.submit(new Callable<Result>() {
                 @Override
@@ -99,7 +99,7 @@ public class MergeableClusterInvoker<T> extends AbstractClusterInvoker<T> {
 
         Object result = null;
 
-        List<Result> resultList = new ArrayList<Result>(results.size());
+        List<Result> resultList = new ArrayList<>(results.size());
 
         int timeout = getUrl().getMethodParameter(invocation.getMethodName(), Constants.TIMEOUT_KEY, Constants.DEFAULT_TIMEOUT);
         for (Map.Entry<String, Future<Result>> entry : results.entrySet()) {
@@ -163,7 +163,7 @@ public class MergeableClusterInvoker<T> extends AbstractClusterInvoker<T> {
                 resultMerger = ExtensionLoader.getExtensionLoader(Merger.class).getExtension(merger);
             }
             if (resultMerger != null) {
-                List<Object> rets = new ArrayList<Object>(resultList.size());
+                List<Object> rets = new ArrayList<>(resultList.size());
                 for (Result r : resultList) {
                     rets.add(r.getValue());
                 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/RegistryAwareCluster.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/RegistryAwareCluster.java
@@ -30,7 +30,7 @@ public class RegistryAwareCluster implements Cluster {
 
     @Override
     public <T> Invoker<T> join(Directory<T> directory) throws RpcException {
-        return new RegistryAwareClusterInvoker<T>(directory);
+        return new RegistryAwareClusterInvoker<>(directory);
     }
 
 }

--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/wrapper/MockClusterWrapper.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/wrapper/MockClusterWrapper.java
@@ -35,7 +35,7 @@ public class MockClusterWrapper implements Cluster {
 
     @Override
     public <T> Invoker<T> join(Directory<T> directory) throws RpcException {
-        return new MockClusterInvoker<T>(directory,
+        return new MockClusterInvoker<>(directory,
                 this.cluster.join(directory));
     }
 

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/StickyTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/StickyTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.mock;
 @SuppressWarnings("unchecked")
 public class StickyTest {
 
-    private List<Invoker<StickyTest>> invokers = new ArrayList<Invoker<StickyTest>>();
+    private List<Invoker<StickyTest>> invokers = new ArrayList<>();
 
 
     private Invoker<StickyTest> invoker1 = mock(Invoker.class);
@@ -68,7 +68,7 @@ public class StickyTest {
         invokers.add(invoker1);
         invokers.add(invoker2);
 
-        clusterinvoker = new StickyClusterInvoker<StickyTest>(dic);
+        clusterinvoker = new StickyClusterInvoker<>(dic);
 
         ExtensionLoader.resetExtensionLoader(LoadBalance.class);
     }

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/directory/MockDirInvocation.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/directory/MockDirInvocation.java
@@ -41,7 +41,7 @@ public class MockDirInvocation implements Invocation {
     }
 
     public Map<String, String> getAttachments() {
-        Map<String, String> attachments = new HashMap<String, String>();
+        Map<String, String> attachments = new HashMap<>();
         attachments.put(Constants.PATH_KEY, "dubbo");
         attachments.put(Constants.GROUP_KEY, "dubbo");
         attachments.put(Constants.VERSION_KEY, "1.0.0");

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/directory/StaticDirectoryTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/directory/StaticDirectoryTest.java
@@ -44,12 +44,12 @@ public class StaticDirectoryTest {
     @Test
     public void testStaticDirectory() {
         Router router = new ConditionRouterFactory().getRouter(getRouteUrl(" => " + " host = " + NetUtils.getLocalHost()));
-        List<Router> routers = new ArrayList<Router>();
+        List<Router> routers = new ArrayList<>();
         routers.add(router);
-        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
-        Invoker<String> invoker1 = new MockInvoker<String>(URL.valueOf("dubbo://10.20.3.3:20880/com.foo.BarService"));
-        Invoker<String> invoker2 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
-        Invoker<String> invoker3 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
+        List<Invoker<String>> invokers = new ArrayList<>();
+        Invoker<String> invoker1 = new MockInvoker<>(URL.valueOf("dubbo://10.20.3.3:20880/com.foo.BarService"));
+        Invoker<String> invoker2 = new MockInvoker<>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
+        Invoker<String> invoker3 = new MockInvoker<>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
         invokers.add(invoker1);
         invokers.add(invoker2);
         invokers.add(invoker3);

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/LoadBalanceBaseTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/LoadBalanceBaseTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.mock;
 @SuppressWarnings({"unchecked", "rawtypes"})
 public class LoadBalanceBaseTest {
     Invocation invocation;
-    List<Invoker<LoadBalanceBaseTest>> invokers = new ArrayList<Invoker<LoadBalanceBaseTest>>();
+    List<Invoker<LoadBalanceBaseTest>> invokers = new ArrayList<>();
     Invoker<LoadBalanceBaseTest> invoker1;
     Invoker<LoadBalanceBaseTest> invoker2;
     Invoker<LoadBalanceBaseTest> invoker3;
@@ -117,7 +117,7 @@ public class LoadBalanceBaseTest {
     }
 
     public Map<Invoker, AtomicLong> getInvokeCounter(int runs, String loadbalanceName) {
-        Map<Invoker, AtomicLong> counter = new ConcurrentHashMap<Invoker, AtomicLong>();
+        Map<Invoker, AtomicLong> counter = new ConcurrentHashMap<>();
         LoadBalance lb = getLoadBalance(loadbalanceName);
         for (Invoker invoker : invokers) {
             counter.put(invoker, new AtomicLong(0));
@@ -203,7 +203,7 @@ public class LoadBalanceBaseTest {
         }
     }
 
-    protected List<Invoker<LoadBalanceBaseTest>> weightInvokers = new ArrayList<Invoker<LoadBalanceBaseTest>>();
+    protected List<Invoker<LoadBalanceBaseTest>> weightInvokers = new ArrayList<>();
     protected Invoker<LoadBalanceBaseTest> weightInvoker1;
     protected Invoker<LoadBalanceBaseTest> weightInvoker2;
     protected Invoker<LoadBalanceBaseTest> weightInvoker3;
@@ -253,7 +253,7 @@ public class LoadBalanceBaseTest {
     }
     
     protected Map<Invoker, InvokeResult> getWeightedInvokeResult(int runs, String loadbalanceName) {
-        Map<Invoker, InvokeResult> counter = new ConcurrentHashMap<Invoker, InvokeResult>();
+        Map<Invoker, InvokeResult> counter = new ConcurrentHashMap<>();
         AbstractLoadBalance lb = getLoadBalance(loadbalanceName);
         int totalWeight = 0;
         for (int i = 0; i < weightInvokers.size(); i ++) {

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RoundRobinLoadBalanceTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/RoundRobinLoadBalanceTest.java
@@ -58,10 +58,10 @@ public class RoundRobinLoadBalanceTest extends LoadBalanceBaseTest {
 
     @Test
     public void testSelectByWeight() {
-        final Map<Invoker, InvokeResult> totalMap = new HashMap<Invoker, InvokeResult>();
+        final Map<Invoker, InvokeResult> totalMap = new HashMap<>();
         final AtomicBoolean shouldBegin = new AtomicBoolean(false);
         final int runs = 10000;
-        List<Thread> threads = new ArrayList<Thread>();
+        List<Thread> threads = new ArrayList<>();
         int threadNum = 10;
         for (int i = 0; i < threadNum; i++) {
             threads.add(new Thread() {

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/condition/ConditionRouterTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/condition/ConditionRouterTest.java
@@ -85,7 +85,7 @@ public class ConditionRouterTest {
 
     @Test
     public void testRoute_matchFilter() {
-        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
+        List<Invoker<String>> invokers = new ArrayList<>();
         Invoker<String> invoker1 = new MockInvoker<String>(URL.valueOf(
                 "dubbo://10.20.3.3:20880/com.foo.BarService?default.serialization=fastjson"));
         Invoker<String> invoker2 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost()
@@ -154,8 +154,8 @@ public class ConditionRouterTest {
                 URL.valueOf("consumer://1.1.1.1/com.foo.BarService?methods=getFoo"), invocation);
         Assertions.assertEquals(true, matchWhen);
         // Test filter condition
-        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
-        Invoker<String> invoker1 = new MockInvoker<String>(URL.valueOf("dubbo://10.20.3.3:20880/com.foo.BarService"));
+        List<Invoker<String>> invokers = new ArrayList<>();
+        Invoker<String> invoker1 = new MockInvoker<>(URL.valueOf("dubbo://10.20.3.3:20880/com.foo.BarService"));
         Invoker<String> invoker2 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost()
                 + ":20880/com.foo.BarService"));
         Invoker<String> invoker3 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost()
@@ -183,7 +183,7 @@ public class ConditionRouterTest {
     @Test
     public void testRoute_ReturnFalse() {
         Router router = new ConditionRouterFactory().getRouter(getRouteUrl("host = " + NetUtils.getLocalHost() + " => false"));
-        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
+        List<Invoker<String>> invokers = new ArrayList<>();
         invokers.add(new MockInvoker<String>());
         invokers.add(new MockInvoker<String>());
         invokers.add(new MockInvoker<String>());
@@ -194,7 +194,7 @@ public class ConditionRouterTest {
     @Test
     public void testRoute_ReturnEmpty() {
         Router router = new ConditionRouterFactory().getRouter(getRouteUrl("host = " + NetUtils.getLocalHost() + " => "));
-        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
+        List<Invoker<String>> invokers = new ArrayList<>();
         invokers.add(new MockInvoker<String>());
         invokers.add(new MockInvoker<String>());
         invokers.add(new MockInvoker<String>());
@@ -205,7 +205,7 @@ public class ConditionRouterTest {
     @Test
     public void testRoute_ReturnAll() {
         Router router = new ConditionRouterFactory().getRouter(getRouteUrl("host = " + NetUtils.getLocalHost() + " => " + " host = " + NetUtils.getLocalHost()));
-        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
+        List<Invoker<String>> invokers = new ArrayList<>();
         invokers.add(new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService")));
         invokers.add(new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService")));
         invokers.add(new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService")));
@@ -216,10 +216,10 @@ public class ConditionRouterTest {
     @Test
     public void testRoute_HostFilter() {
         Router router = new ConditionRouterFactory().getRouter(getRouteUrl("host = " + NetUtils.getLocalHost() + " => " + " host = " + NetUtils.getLocalHost()));
-        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
-        Invoker<String> invoker1 = new MockInvoker<String>(URL.valueOf("dubbo://10.20.3.3:20880/com.foo.BarService"));
-        Invoker<String> invoker2 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
-        Invoker<String> invoker3 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
+        List<Invoker<String>> invokers = new ArrayList<>();
+        Invoker<String> invoker1 = new MockInvoker<>(URL.valueOf("dubbo://10.20.3.3:20880/com.foo.BarService"));
+        Invoker<String> invoker2 = new MockInvoker<>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
+        Invoker<String> invoker3 = new MockInvoker<>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
         invokers.add(invoker1);
         invokers.add(invoker2);
         invokers.add(invoker3);
@@ -232,10 +232,10 @@ public class ConditionRouterTest {
     @Test
     public void testRoute_Empty_HostFilter() {
         Router router = new ConditionRouterFactory().getRouter(getRouteUrl(" => " + " host = " + NetUtils.getLocalHost()));
-        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
-        Invoker<String> invoker1 = new MockInvoker<String>(URL.valueOf("dubbo://10.20.3.3:20880/com.foo.BarService"));
-        Invoker<String> invoker2 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
-        Invoker<String> invoker3 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
+        List<Invoker<String>> invokers = new ArrayList<>();
+        Invoker<String> invoker1 = new MockInvoker<>(URL.valueOf("dubbo://10.20.3.3:20880/com.foo.BarService"));
+        Invoker<String> invoker2 = new MockInvoker<>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
+        Invoker<String> invoker3 = new MockInvoker<>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
         invokers.add(invoker1);
         invokers.add(invoker2);
         invokers.add(invoker3);
@@ -248,10 +248,10 @@ public class ConditionRouterTest {
     @Test
     public void testRoute_False_HostFilter() {
         Router router = new ConditionRouterFactory().getRouter(getRouteUrl("true => " + " host = " + NetUtils.getLocalHost()));
-        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
-        Invoker<String> invoker1 = new MockInvoker<String>(URL.valueOf("dubbo://10.20.3.3:20880/com.foo.BarService"));
-        Invoker<String> invoker2 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
-        Invoker<String> invoker3 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
+        List<Invoker<String>> invokers = new ArrayList<>();
+        Invoker<String> invoker1 = new MockInvoker<>(URL.valueOf("dubbo://10.20.3.3:20880/com.foo.BarService"));
+        Invoker<String> invoker2 = new MockInvoker<>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
+        Invoker<String> invoker3 = new MockInvoker<>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
         invokers.add(invoker1);
         invokers.add(invoker2);
         invokers.add(invoker3);
@@ -264,10 +264,10 @@ public class ConditionRouterTest {
     @Test
     public void testRoute_Placeholder() {
         Router router = new ConditionRouterFactory().getRouter(getRouteUrl("host = " + NetUtils.getLocalHost() + " => " + " host = $host"));
-        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
-        Invoker<String> invoker1 = new MockInvoker<String>(URL.valueOf("dubbo://10.20.3.3:20880/com.foo.BarService"));
-        Invoker<String> invoker2 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
-        Invoker<String> invoker3 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
+        List<Invoker<String>> invokers = new ArrayList<>();
+        Invoker<String> invoker1 = new MockInvoker<>(URL.valueOf("dubbo://10.20.3.3:20880/com.foo.BarService"));
+        Invoker<String> invoker2 = new MockInvoker<>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
+        Invoker<String> invoker3 = new MockInvoker<>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
         invokers.add(invoker1);
         invokers.add(invoker2);
         invokers.add(invoker3);
@@ -280,10 +280,10 @@ public class ConditionRouterTest {
     @Test
     public void testRoute_NoForce() {
         Router router = new ConditionRouterFactory().getRouter(getRouteUrl("host = " + NetUtils.getLocalHost() + " => " + " host = 1.2.3.4"));
-        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
-        Invoker<String> invoker1 = new MockInvoker<String>(URL.valueOf("dubbo://10.20.3.3:20880/com.foo.BarService"));
-        Invoker<String> invoker2 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
-        Invoker<String> invoker3 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
+        List<Invoker<String>> invokers = new ArrayList<>();
+        Invoker<String> invoker1 = new MockInvoker<>(URL.valueOf("dubbo://10.20.3.3:20880/com.foo.BarService"));
+        Invoker<String> invoker2 = new MockInvoker<>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
+        Invoker<String> invoker3 = new MockInvoker<>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
         invokers.add(invoker1);
         invokers.add(invoker2);
         invokers.add(invoker3);
@@ -294,10 +294,10 @@ public class ConditionRouterTest {
     @Test
     public void testRoute_Force() {
         Router router = new ConditionRouterFactory().getRouter(getRouteUrl("host = " + NetUtils.getLocalHost() + " => " + " host = 1.2.3.4").addParameter(Constants.FORCE_KEY, String.valueOf(true)));
-        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
-        Invoker<String> invoker1 = new MockInvoker<String>(URL.valueOf("dubbo://10.20.3.3:20880/com.foo.BarService"));
-        Invoker<String> invoker2 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
-        Invoker<String> invoker3 = new MockInvoker<String>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
+        List<Invoker<String>> invokers = new ArrayList<>();
+        Invoker<String> invoker1 = new MockInvoker<>(URL.valueOf("dubbo://10.20.3.3:20880/com.foo.BarService"));
+        Invoker<String> invoker2 = new MockInvoker<>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
+        Invoker<String> invoker3 = new MockInvoker<>(URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":20880/com.foo.BarService"));
         invokers.add(invoker1);
         invokers.add(invoker2);
         invokers.add(invoker3);

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/file/FileRouterEngineTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/file/FileRouterEngineTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.mock;
 @SuppressWarnings("unchecked")
 public class FileRouterEngineTest {
     private static boolean isScriptUnsupported = new ScriptEngineManager().getEngineByName("javascript") == null;
-    List<Invoker<FileRouterEngineTest>> invokers = new ArrayList<Invoker<FileRouterEngineTest>>();
+    List<Invoker<FileRouterEngineTest>> invokers = new ArrayList<>();
     Invoker<FileRouterEngineTest> invoker1 = mock(Invoker.class);
     Invoker<FileRouterEngineTest> invoker2 = mock(Invoker.class);
     Invocation invocation;

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/script/ScriptRouterTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/router/script/ScriptRouterTest.java
@@ -51,7 +51,7 @@ public class ScriptRouterTest {
     @Test
     public void testRouteReturnAll() {
         Router router = new ScriptRouterFactory().getRouter(getRouteUrl("function route(op1,op2){return op1} route(invokers)"));
-        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
+        List<Invoker<String>> invokers = new ArrayList<>();
         invokers.add(new MockInvoker<String>());
         invokers.add(new MockInvoker<String>());
         invokers.add(new MockInvoker<String>());
@@ -71,10 +71,10 @@ public class ScriptRouterTest {
         String script = "function route(invokers,invocation,context){" + rule + "} route(invokers,invocation,context)";
         Router router = new ScriptRouterFactory().getRouter(getRouteUrl(script));
 
-        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
-        Invoker<String> invoker1 = new MockInvoker<String>(false);
-        Invoker<String> invoker2 = new MockInvoker<String>(true);
-        Invoker<String> invoker3 = new MockInvoker<String>(true);
+        List<Invoker<String>> invokers = new ArrayList<>();
+        Invoker<String> invoker1 = new MockInvoker<>(false);
+        Invoker<String> invoker2 = new MockInvoker<>(true);
+        Invoker<String> invoker3 = new MockInvoker<>(true);
         invokers.add(invoker1);
         invokers.add(invoker2);
         invokers.add(invoker3);
@@ -86,10 +86,10 @@ public class ScriptRouterTest {
 
     @Test
     public void testRouteHostFilter() {
-        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
-        MockInvoker<String> invoker1 = new MockInvoker<String>(URL.valueOf("dubbo://10.134.108.1:20880/com.dubbo.HelloService"));
-        MockInvoker<String> invoker2 = new MockInvoker<String>(URL.valueOf("dubbo://10.134.108.2:20880/com.dubbo.HelloService"));
-        MockInvoker<String> invoker3 = new MockInvoker<String>(URL.valueOf("dubbo://10.134.108.3:20880/com.dubbo.HelloService"));
+        List<Invoker<String>> invokers = new ArrayList<>();
+        MockInvoker<String> invoker1 = new MockInvoker<>(URL.valueOf("dubbo://10.134.108.1:20880/com.dubbo.HelloService"));
+        MockInvoker<String> invoker2 = new MockInvoker<>(URL.valueOf("dubbo://10.134.108.2:20880/com.dubbo.HelloService"));
+        MockInvoker<String> invoker3 = new MockInvoker<>(URL.valueOf("dubbo://10.134.108.3:20880/com.dubbo.HelloService"));
         invokers.add(invoker1);
         invokers.add(invoker2);
         invokers.add(invoker3);
@@ -115,10 +115,10 @@ public class ScriptRouterTest {
 
     @Test
     public void testRoute_throwException() {
-        List<Invoker<String>> invokers = new ArrayList<Invoker<String>>();
-        MockInvoker<String> invoker1 = new MockInvoker<String>(URL.valueOf("dubbo://10.134.108.1:20880/com.dubbo.HelloService"));
-        MockInvoker<String> invoker2 = new MockInvoker<String>(URL.valueOf("dubbo://10.134.108.2:20880/com.dubbo.HelloService"));
-        MockInvoker<String> invoker3 = new MockInvoker<String>(URL.valueOf("dubbo://10.134.108.3:20880/com.dubbo.HelloService"));
+        List<Invoker<String>> invokers = new ArrayList<>();
+        MockInvoker<String> invoker1 = new MockInvoker<>(URL.valueOf("dubbo://10.134.108.1:20880/com.dubbo.HelloService"));
+        MockInvoker<String> invoker2 = new MockInvoker<>(URL.valueOf("dubbo://10.134.108.2:20880/com.dubbo.HelloService"));
+        MockInvoker<String> invoker3 = new MockInvoker<>(URL.valueOf("dubbo://10.134.108.3:20880/com.dubbo.HelloService"));
         invokers.add(invoker1);
         invokers.add(invoker2);
         invokers.add(invoker3);

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/AbstractClusterInvokerTest.java
@@ -56,8 +56,8 @@ import static org.mockito.Mockito.mock;
  */
 @SuppressWarnings("rawtypes")
 public class AbstractClusterInvokerTest {
-    List<Invoker<IHelloService>> invokers = new ArrayList<Invoker<IHelloService>>();
-    List<Invoker<IHelloService>> selectedInvokers = new ArrayList<Invoker<IHelloService>>();
+    List<Invoker<IHelloService>> invokers = new ArrayList<>();
+    List<Invoker<IHelloService>> selectedInvokers = new ArrayList<>();
     AbstractClusterInvoker<IHelloService> cluster;
     AbstractClusterInvoker<IHelloService> cluster_nocheck;
     StaticDirectory<IHelloService> dic;
@@ -120,7 +120,7 @@ public class AbstractClusterInvokerTest {
         given(mockedInvoker1.getUrl()).willReturn(turl.setPort(999).setProtocol("mock"));
 
         invokers.add(invoker1);
-        dic = new StaticDirectory<IHelloService>(url, invokers, null);
+        dic = new StaticDirectory<>(url, invokers, null);
         cluster = new AbstractClusterInvoker(dic) {
             @Override
             protected Result doInvoke(Invocation invocation, List invokers, LoadBalance loadbalance)
@@ -423,7 +423,7 @@ public class AbstractClusterInvokerTest {
         LoadBalance lb = ExtensionLoader.getExtensionLoader(LoadBalance.class).getExtension(RoundRobinLoadBalance.NAME);
         initlistsize5();
 
-        Map<Invoker, AtomicLong> counter = new ConcurrentHashMap<Invoker, AtomicLong>();
+        Map<Invoker, AtomicLong> counter = new ConcurrentHashMap<>();
         for (Invoker invoker : invokers) {
             counter.put(invoker, new AtomicLong(0));
         }
@@ -462,7 +462,7 @@ public class AbstractClusterInvokerTest {
 
     @Test()
     public void testTimeoutExceptionCode() {
-        List<Invoker<DemoService>> invokers = new ArrayList<Invoker<DemoService>>();
+        List<Invoker<DemoService>> invokers = new ArrayList<>();
         invokers.add(new Invoker<DemoService>() {
 
             @Override
@@ -487,22 +487,22 @@ public class AbstractClusterInvokerTest {
             public void destroy() {
             }
         });
-        Directory<DemoService> directory = new StaticDirectory<DemoService>(invokers);
-        FailoverClusterInvoker<DemoService> failoverClusterInvoker = new FailoverClusterInvoker<DemoService>(directory);
+        Directory<DemoService> directory = new StaticDirectory<>(invokers);
+        FailoverClusterInvoker<DemoService> failoverClusterInvoker = new FailoverClusterInvoker<>(directory);
         try {
             failoverClusterInvoker.invoke(new RpcInvocation("sayHello", new Class<?>[0], new Object[0]));
             Assertions.fail();
         } catch (RpcException e) {
             Assertions.assertEquals(RpcException.TIMEOUT_EXCEPTION, e.getCode());
         }
-        ForkingClusterInvoker<DemoService> forkingClusterInvoker = new ForkingClusterInvoker<DemoService>(directory);
+        ForkingClusterInvoker<DemoService> forkingClusterInvoker = new ForkingClusterInvoker<>(directory);
         try {
             forkingClusterInvoker.invoke(new RpcInvocation("sayHello", new Class<?>[0], new Object[0]));
             Assertions.fail();
         } catch (RpcException e) {
             Assertions.assertEquals(RpcException.TIMEOUT_EXCEPTION, e.getCode());
         }
-        FailfastClusterInvoker<DemoService> failfastClusterInvoker = new FailfastClusterInvoker<DemoService>(directory);
+        FailfastClusterInvoker<DemoService> failfastClusterInvoker = new FailfastClusterInvoker<>(directory);
         try {
             failfastClusterInvoker.invoke(new RpcInvocation("sayHello", new Class<?>[0], new Object[0]));
             Assertions.fail();

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailSafeClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailSafeClusterInvokerTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.mock;
  */
 @SuppressWarnings("unchecked")
 public class FailSafeClusterInvokerTest {
-    List<Invoker<DemoService>> invokers = new ArrayList<Invoker<DemoService>>();
+    List<Invoker<DemoService>> invokers = new ArrayList<>();
     URL url = URL.valueOf("test://test:11/test");
     Invoker<DemoService> invoker = mock(Invoker.class);
     RpcInvocation invocation = new RpcInvocation();
@@ -83,7 +83,7 @@ public class FailSafeClusterInvokerTest {
     @Test
     public void testInvokeExceptoin() {
         resetInvokerToException();
-        FailsafeClusterInvoker<DemoService> invoker = new FailsafeClusterInvoker<DemoService>(dic);
+        FailsafeClusterInvoker<DemoService> invoker = new FailsafeClusterInvoker<>(dic);
         invoker.invoke(invocation);
         Assertions.assertNull(RpcContext.getContext().getInvoker());
     }
@@ -93,7 +93,7 @@ public class FailSafeClusterInvokerTest {
 
         resetInvokerToNoException();
 
-        FailsafeClusterInvoker<DemoService> invoker = new FailsafeClusterInvoker<DemoService>(dic);
+        FailsafeClusterInvoker<DemoService> invoker = new FailsafeClusterInvoker<>(dic);
         Result ret = invoker.invoke(invocation);
         Assertions.assertSame(result, ret);
     }
@@ -110,7 +110,7 @@ public class FailSafeClusterInvokerTest {
 
         resetInvokerToNoException();
 
-        FailsafeClusterInvoker<DemoService> invoker = new FailsafeClusterInvoker<DemoService>(dic);
+        FailsafeClusterInvoker<DemoService> invoker = new FailsafeClusterInvoker<>(dic);
         LogUtil.start();
         invoker.invoke(invocation);
         assertTrue(LogUtil.findMessage("No provider") > 0);

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailbackClusterInvokerTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.mock;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class FailbackClusterInvokerTest {
 
-    List<Invoker<FailbackClusterInvokerTest>> invokers = new ArrayList<Invoker<FailbackClusterInvokerTest>>();
+    List<Invoker<FailbackClusterInvokerTest>> invokers = new ArrayList<>();
     URL url = URL.valueOf("test://test:11/test?retries=2&failbacktasks=2");
     Invoker<FailbackClusterInvokerTest> invoker = mock(Invoker.class);
     RpcInvocation invocation = new RpcInvocation();

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailfastClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailfastClusterInvokerTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.mock;
  */
 @SuppressWarnings("unchecked")
 public class FailfastClusterInvokerTest {
-    List<Invoker<FailfastClusterInvokerTest>> invokers = new ArrayList<Invoker<FailfastClusterInvokerTest>>();
+    List<Invoker<FailfastClusterInvokerTest>> invokers = new ArrayList<>();
     URL url = URL.valueOf("test://test:11/test");
     Invoker<FailfastClusterInvokerTest> invoker1 = mock(Invoker.class);
     RpcInvocation invocation = new RpcInvocation();
@@ -83,7 +83,7 @@ public class FailfastClusterInvokerTest {
     public void testInvokeExceptoin() {
         Assertions.assertThrows(RpcException.class, () -> {
             resetInvoker1ToException();
-            FailfastClusterInvoker<FailfastClusterInvokerTest> invoker = new FailfastClusterInvoker<FailfastClusterInvokerTest>(dic);
+            FailfastClusterInvoker<FailfastClusterInvokerTest> invoker = new FailfastClusterInvoker<>(dic);
             invoker.invoke(invocation);
             Assertions.assertSame(invoker1, RpcContext.getContext().getInvoker());
         });
@@ -94,7 +94,7 @@ public class FailfastClusterInvokerTest {
 
         resetInvoker1ToNoException();
 
-        FailfastClusterInvoker<FailfastClusterInvokerTest> invoker = new FailfastClusterInvoker<FailfastClusterInvokerTest>(dic);
+        FailfastClusterInvoker<FailfastClusterInvokerTest> invoker = new FailfastClusterInvoker<>(dic);
         Result ret = invoker.invoke(invocation);
         Assertions.assertSame(result, ret);
     }
@@ -113,7 +113,7 @@ public class FailfastClusterInvokerTest {
 
         resetInvoker1ToNoException();
 
-        FailfastClusterInvoker<FailfastClusterInvokerTest> invoker = new FailfastClusterInvoker<FailfastClusterInvokerTest>(dic);
+        FailfastClusterInvoker<FailfastClusterInvokerTest> invoker = new FailfastClusterInvoker<>(dic);
         try {
             invoker.invoke(invocation);
             fail();

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailoverClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/FailoverClusterInvokerTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.mock;
  */
 @SuppressWarnings("unchecked")
 public class FailoverClusterInvokerTest {
-    private List<Invoker<FailoverClusterInvokerTest>> invokers = new ArrayList<Invoker<FailoverClusterInvokerTest>>();
+    private List<Invoker<FailoverClusterInvokerTest>> invokers = new ArrayList<>();
     private int retries = 5;
     private URL url = URL.valueOf("test://test:11/test?retries=" + retries);
     private Invoker<FailoverClusterInvokerTest> invoker1 = mock(Invoker.class);
@@ -88,7 +88,7 @@ public class FailoverClusterInvokerTest {
         given(invoker2.getUrl()).willReturn(url);
         given(invoker2.getInterface()).willReturn(FailoverClusterInvokerTest.class);
 
-        FailoverClusterInvoker<FailoverClusterInvokerTest> invoker = new FailoverClusterInvoker<FailoverClusterInvokerTest>(dic);
+        FailoverClusterInvoker<FailoverClusterInvokerTest> invoker = new FailoverClusterInvoker<>(dic);
         try {
             invoker.invoke(invocation);
             fail();
@@ -110,7 +110,7 @@ public class FailoverClusterInvokerTest {
         given(invoker2.getUrl()).willReturn(url);
         given(invoker2.getInterface()).willReturn(FailoverClusterInvokerTest.class);
 
-        FailoverClusterInvoker<FailoverClusterInvokerTest> invoker = new FailoverClusterInvoker<FailoverClusterInvokerTest>(dic);
+        FailoverClusterInvoker<FailoverClusterInvokerTest> invoker = new FailoverClusterInvoker<>(dic);
         for (int i = 0; i < 100; i++) {
             Result ret = invoker.invoke(invocation);
             assertSame(result, ret);
@@ -129,7 +129,7 @@ public class FailoverClusterInvokerTest {
         given(invoker2.getUrl()).willReturn(url);
         given(invoker2.getInterface()).willReturn(FailoverClusterInvokerTest.class);
 
-        FailoverClusterInvoker<FailoverClusterInvokerTest> invoker = new FailoverClusterInvoker<FailoverClusterInvokerTest>(dic);
+        FailoverClusterInvoker<FailoverClusterInvokerTest> invoker = new FailoverClusterInvoker<>(dic);
         try {
             Result ret = invoker.invoke(invocation);
             assertSame(result, ret);
@@ -152,7 +152,7 @@ public class FailoverClusterInvokerTest {
         invokers.add(invoker1);
 
 
-        FailoverClusterInvoker<FailoverClusterInvokerTest> invoker = new FailoverClusterInvoker<FailoverClusterInvokerTest>(dic);
+        FailoverClusterInvoker<FailoverClusterInvokerTest> invoker = new FailoverClusterInvoker<>(dic);
         try {
             invoker.invoke(invocation);
             fail();
@@ -169,13 +169,13 @@ public class FailoverClusterInvokerTest {
     public void testInvokerDestroyAndReList() {
         final URL url = URL.valueOf("test://localhost/" + Demo.class.getName() + "?loadbalance=roundrobin&retries=" + retries);
         RpcException exception = new RpcException(RpcException.TIMEOUT_EXCEPTION);
-        MockInvoker<Demo> invoker1 = new MockInvoker<Demo>(Demo.class, url);
+        MockInvoker<Demo> invoker1 = new MockInvoker<>(Demo.class, url);
         invoker1.setException(exception);
 
-        MockInvoker<Demo> invoker2 = new MockInvoker<Demo>(Demo.class, url);
+        MockInvoker<Demo> invoker2 = new MockInvoker<>(Demo.class, url);
         invoker2.setException(exception);
 
-        final List<Invoker<Demo>> invokers = new ArrayList<Invoker<Demo>>();
+        final List<Invoker<Demo>> invokers = new ArrayList<>();
         invokers.add(invoker1);
         invokers.add(invoker2);
 
@@ -186,7 +186,7 @@ public class FailoverClusterInvokerTest {
                     invoker.destroy();
                 }
                 invokers.clear();
-                MockInvoker<Demo> invoker3 = new MockInvoker<Demo>(Demo.class, url);
+                MockInvoker<Demo> invoker3 = new MockInvoker<>(Demo.class, url);
                 invokers.add(invoker3);
                 return null;
             }
@@ -197,9 +197,9 @@ public class FailoverClusterInvokerTest {
         RpcInvocation inv = new RpcInvocation();
         inv.setMethodName("test");
 
-        Directory<Demo> dic = new MockDirectory<Demo>(url, invokers);
+        Directory<Demo> dic = new MockDirectory<>(url, invokers);
 
-        FailoverClusterInvoker<Demo> clusterinvoker = new FailoverClusterInvoker<Demo>(dic);
+        FailoverClusterInvoker<Demo> clusterinvoker = new FailoverClusterInvoker<>(dic);
         clusterinvoker.invoke(inv);
     }
 

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/ForkingClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/ForkingClusterInvokerTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.mock;
 @SuppressWarnings("unchecked")
 public class ForkingClusterInvokerTest {
 
-    private List<Invoker<ForkingClusterInvokerTest>> invokers = new ArrayList<Invoker<ForkingClusterInvokerTest>>();
+    private List<Invoker<ForkingClusterInvokerTest>> invokers = new ArrayList<>();
     private URL url = URL.valueOf("test://test:11/test?forks=2");
     private Invoker<ForkingClusterInvokerTest> invoker1 = mock(Invoker.class);
     private Invoker<ForkingClusterInvokerTest> invoker2 = mock(Invoker.class);

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/Menu.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/Menu.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 public class Menu {
 
-    private Map<String, List<String>> menus = new HashMap<String, List<String>>();
+    private Map<String, List<String>> menus = new HashMap<>();
 
     public Menu() {
     }
@@ -38,7 +38,7 @@ public class Menu {
     public void putMenuItem(String menu, String item) {
         List<String> items = menus.get(menu);
         if (item == null) {
-            items = new ArrayList<String>();
+            items = new ArrayList<>();
             menus.put(menu, items);
         }
         items.add(item);

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/MergeableClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/MergeableClusterInvokerTest.java
@@ -151,21 +151,21 @@ public class MergeableClusterInvokerTest {
         given(directory.getUrl()).willReturn(url);
         given(directory.getInterface()).willReturn(MenuService.class);
 
-        mergeableClusterInvoker = new MergeableClusterInvoker<MenuService>(directory);
+        mergeableClusterInvoker = new MergeableClusterInvoker<>(directory);
 
         // invoke
         Result result = mergeableClusterInvoker.invoke(invocation);
         Assertions.assertTrue(result.getValue() instanceof Menu);
         Menu menu = (Menu) result.getValue();
-        Map<String, List<String>> expected = new HashMap<String, List<String>>();
+        Map<String, List<String>> expected = new HashMap<>();
         merge(expected, firstMenuMap);
         merge(expected, secondMenuMap);
         assertEquals(expected.keySet(), menu.getMenus().keySet());
         for (Map.Entry<String, List<String>> entry : expected.entrySet()) {
             // FIXME: cannot guarantee the sequence of the merge result, check implementation in
             // MergeableClusterInvoker#invoke
-            List<String> values1 = new ArrayList<String>(entry.getValue());
-            List<String> values2 = new ArrayList<String>(menu.getMenus().get(entry.getKey()));
+            List<String> values1 = new ArrayList<>(entry.getValue());
+            List<String> values2 = new ArrayList<>(menu.getMenus().get(entry.getKey()));
             Collections.sort(values1);
             Collections.sort(values2);
             assertEquals(values1, values2);
@@ -216,7 +216,7 @@ public class MergeableClusterInvokerTest {
         given(directory.getUrl()).willReturn(url);
         given(directory.getInterface()).willReturn(MenuService.class);
 
-        mergeableClusterInvoker = new MergeableClusterInvoker<MenuService>(directory);
+        mergeableClusterInvoker = new MergeableClusterInvoker<>(directory);
 
         Result result = mergeableClusterInvoker.invoke(invocation);
         Assertions.assertNull(result.getValue());

--- a/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/wrapper/MockClusterInvokerTest.java
+++ b/dubbo-cluster/src/test/java/org/apache/dubbo/rpc/cluster/support/wrapper/MockClusterInvokerTest.java
@@ -41,7 +41,7 @@ import java.util.List;
 
 public class MockClusterInvokerTest {
 
-    List<Invoker<IHelloService>> invokers = new ArrayList<Invoker<IHelloService>>();
+    List<Invoker<IHelloService>> invokers = new ArrayList<>();
 
     @BeforeEach
     public void beforeMethod() {
@@ -651,7 +651,7 @@ public class MockClusterInvokerTest {
             invokers.add(mockInvoker);
         }
 
-        StaticDirectory<IHelloService> dic = new StaticDirectory<IHelloService>(durl, invokers, null);
+        StaticDirectory<IHelloService> dic = new StaticDirectory<>(durl, invokers, null);
         dic.buildRouterChain();
         AbstractClusterInvoker<IHelloService> cluster = new AbstractClusterInvoker(dic) {
             @Override

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/URL.java
@@ -166,9 +166,9 @@ class URL implements Serializable {
         }
         this.path = path;
         if (parameters == null) {
-            parameters = new HashMap<String, String>();
+            parameters = new HashMap<>();
         } else {
-            parameters = new HashMap<String, String>(parameters);
+            parameters = new HashMap<>(parameters);
         }
         this.parameters = Collections.unmodifiableMap(parameters);
     }
@@ -194,7 +194,7 @@ class URL implements Serializable {
         int i = url.indexOf("?"); // seperator between body and parameters
         if (i >= 0) {
             String[] parts = url.substring(i + 1).split("\\&");
-            parameters = new HashMap<String, String>();
+            parameters = new HashMap<>();
             for (String part : parts) {
                 part = part.trim();
                 if (part.length() > 0) {
@@ -265,7 +265,7 @@ class URL implements Serializable {
         if (reserveParams == null || reserveParams.length == 0) {
             return result;
         }
-        Map<String, String> newMap = new HashMap<String, String>(reserveParams.length);
+        Map<String, String> newMap = new HashMap<>(reserveParams.length);
         Map<String, String> oldMap = result.getParameters();
         for (String reserveParam : reserveParams) {
             String tmp = oldMap.get(reserveParam);
@@ -277,7 +277,7 @@ class URL implements Serializable {
     }
 
     public static URL valueOf(URL url, String[] reserveParams, String[] reserveParamPrefixs) {
-        Map<String, String> newMap = new HashMap<String, String>();
+        Map<String, String> newMap = new HashMap<>();
         Map<String, String> oldMap = url.getParameters();
         if (reserveParamPrefixs != null && reserveParamPrefixs.length != 0) {
             for (Map.Entry<String, String> entry : oldMap.entrySet()) {
@@ -425,7 +425,7 @@ class URL implements Serializable {
     }
 
     public List<URL> getBackupUrls() {
-        List<URL> urls = new ArrayList<URL>();
+        List<URL> urls = new ArrayList<>();
         urls.add(this);
         String[] backups = getParameter(Constants.BACKUP_KEY, new String[0]);
         if (backups != null && backups.length > 0) {
@@ -511,14 +511,14 @@ class URL implements Serializable {
 
     private Map<String, Number> getNumbers() {
         if (numbers == null) { // concurrent initialization is tolerant
-            numbers = new ConcurrentHashMap<String, Number>();
+            numbers = new ConcurrentHashMap<>();
         }
         return numbers;
     }
 
     private Map<String, URL> getUrls() {
         if (urls == null) { // concurrent initialization is tolerant
-            urls = new ConcurrentHashMap<String, URL>();
+            urls = new ConcurrentHashMap<>();
         }
         return urls;
     }
@@ -1005,7 +1005,7 @@ class URL implements Serializable {
             return this;
         }
 
-        Map<String, String> map = new HashMap<String, String>(getParameters());
+        Map<String, String> map = new HashMap<>(getParameters());
         map.put(key, value);
         return new URL(protocol, username, password, host, port, path, map);
     }
@@ -1018,7 +1018,7 @@ class URL implements Serializable {
         if (hasParameter(key)) {
             return this;
         }
-        Map<String, String> map = new HashMap<String, String>(getParameters());
+        Map<String, String> map = new HashMap<>(getParameters());
         map.put(key, value);
         return new URL(protocol, username, password, host, port, path, map);
     }
@@ -1054,7 +1054,7 @@ class URL implements Serializable {
             return this;
         }
 
-        Map<String, String> map = new HashMap<String, String>(getParameters());
+        Map<String, String> map = new HashMap<>(getParameters());
         map.putAll(parameters);
         return new URL(protocol, username, password, host, port, path, map);
     }
@@ -1063,7 +1063,7 @@ class URL implements Serializable {
         if (CollectionUtils.isEmptyMap(parameters)) {
             return this;
         }
-        Map<String, String> map = new HashMap<String, String>(parameters);
+        Map<String, String> map = new HashMap<>(parameters);
         map.putAll(getParameters());
         return new URL(protocol, username, password, host, port, path, map);
     }
@@ -1075,7 +1075,7 @@ class URL implements Serializable {
         if (pairs.length % 2 != 0) {
             throw new IllegalArgumentException("Map pairs can not be odd number.");
         }
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         int len = pairs.length / 2;
         for (int i = 0; i < len; i++) {
             map.put(pairs[2 * i], pairs[2 * i + 1]);
@@ -1108,7 +1108,7 @@ class URL implements Serializable {
         if (keys == null || keys.length == 0) {
             return this;
         }
-        Map<String, String> map = new HashMap<String, String>(getParameters());
+        Map<String, String> map = new HashMap<>(getParameters());
         for (String key : keys) {
             map.remove(key);
         }
@@ -1145,7 +1145,7 @@ class URL implements Serializable {
     }
 
     public Map<String, String> toMap() {
-        Map<String, String> map = new HashMap<String, String>(parameters);
+        Map<String, String> map = new HashMap<>(parameters);
         if (protocol != null) {
             map.put("protocol", protocol);
         }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Version.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Version.java
@@ -46,7 +46,7 @@ public final class Version {
      * performance than string.
      */
     private static final int LOWEST_VERSION_FOR_RESPONSE_ATTACHMENT = 2000200; // 2.0.2
-    private static final Map<String, Integer> VERSION2INT = new HashMap<String, Integer>();
+    private static final Map<String, Integer> VERSION2INT = new HashMap<>();
 
     static {
         // check if there's duplicated jar
@@ -208,7 +208,7 @@ public final class Version {
         try {
             // search in caller's classloader
             Enumeration<URL> urls = ClassHelper.getCallerClassLoader(Version.class).getResources(path);
-            Set<String> files = new HashSet<String>();
+            Set<String> files = new HashSet<>();
             while (urls.hasMoreElements()) {
                 URL url = urls.nextElement();
                 if (url != null) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/beanutil/JavaBeanDescriptor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/beanutil/JavaBeanDescriptor.java
@@ -59,7 +59,7 @@ public final class JavaBeanDescriptor implements Serializable, Iterable<Map.Entr
 
     private int type;
 
-    private Map<Object, Object> properties = new LinkedHashMap<Object, Object>();
+    private Map<Object, Object> properties = new LinkedHashMap<>();
 
     public JavaBeanDescriptor() {
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/beanutil/JavaBeanSerializeUtil.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/beanutil/JavaBeanSerializeUtil.java
@@ -34,7 +34,7 @@ import java.util.Map;
 public final class JavaBeanSerializeUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(JavaBeanSerializeUtil.class);
-    private static final Map<String, Class<?>> TYPES = new HashMap<String, Class<?>>();
+    private static final Map<String, Class<?>> TYPES = new HashMap<>();
     private static final String ARRAY_PREFIX = "[";
     private static final String REFERENCE_TYPE_PREFIX = "L";
     private static final String REFERENCE_TYPE_SUFFIX = ";";
@@ -73,7 +73,7 @@ public final class JavaBeanSerializeUtil {
         if (obj instanceof JavaBeanDescriptor) {
             return (JavaBeanDescriptor) obj;
         }
-        IdentityHashMap<Object, JavaBeanDescriptor> cache = new IdentityHashMap<Object, JavaBeanDescriptor>();
+        IdentityHashMap<Object, JavaBeanDescriptor> cache = new IdentityHashMap<>();
         JavaBeanDescriptor result = createDescriptorIfAbsent(obj, accessor, cache);
         return result;
     }
@@ -199,7 +199,7 @@ public final class JavaBeanSerializeUtil {
         if (beanDescriptor == null) {
             return null;
         }
-        IdentityHashMap<JavaBeanDescriptor, Object> cache = new IdentityHashMap<JavaBeanDescriptor, Object>();
+        IdentityHashMap<JavaBeanDescriptor, Object> cache = new IdentityHashMap<>();
         Object result = instantiateForDeserialize(beanDescriptor, loader, cache);
         deserializeInternal(result, beanDescriptor, loader, cache);
         return result;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/ClassGenerator.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/ClassGenerator.java
@@ -52,7 +52,7 @@ public final class ClassGenerator {
 
     private static final AtomicLong CLASS_NAME_COUNTER = new AtomicLong(0);
     private static final String SIMPLE_NAME_TAG = "<init>";
-    private static final Map<ClassLoader, ClassPool> POOL_MAP = new ConcurrentHashMap<ClassLoader, ClassPool>(); //ClassLoader - ClassPool
+    private static final Map<ClassLoader, ClassPool> POOL_MAP = new ConcurrentHashMap<>(); //ClassLoader - ClassPool
     private ClassPool mPool;
     private CtClass mCtc;
     private String mClassName;
@@ -131,7 +131,7 @@ public final class ClassGenerator {
 
     public ClassGenerator addInterface(String cn) {
         if (mInterfaces == null) {
-            mInterfaces = new HashSet<String>();
+            mInterfaces = new HashSet<>();
         }
         mInterfaces.add(cn);
         return this;
@@ -153,7 +153,7 @@ public final class ClassGenerator {
 
     public ClassGenerator addField(String code) {
         if (mFields == null) {
-            mFields = new ArrayList<String>();
+            mFields = new ArrayList<>();
         }
         mFields.add(code);
         return this;
@@ -177,7 +177,7 @@ public final class ClassGenerator {
 
     public ClassGenerator addMethod(String code) {
         if (mMethods == null) {
-            mMethods = new ArrayList<String>();
+            mMethods = new ArrayList<>();
         }
         mMethods.add(code);
         return this;
@@ -222,7 +222,7 @@ public final class ClassGenerator {
         String desc = name + ReflectUtils.getDescWithoutMethodName(m);
         addMethod(':' + desc);
         if (mCopyMethods == null) {
-            mCopyMethods = new ConcurrentHashMap<String, Method>(8);
+            mCopyMethods = new ConcurrentHashMap<>(8);
         }
         mCopyMethods.put(desc, m);
         return this;
@@ -230,7 +230,7 @@ public final class ClassGenerator {
 
     public ClassGenerator addConstructor(String code) {
         if (mConstructors == null) {
-            mConstructors = new LinkedList<String>();
+            mConstructors = new LinkedList<>();
         }
         mConstructors.add(code);
         return this;
@@ -269,7 +269,7 @@ public final class ClassGenerator {
         String desc = ReflectUtils.getDesc(c);
         addConstructor(":" + desc);
         if (mCopyConstructors == null) {
-            mCopyConstructors = new ConcurrentHashMap<String, Constructor<?>>(4);
+            mCopyConstructors = new ConcurrentHashMap<>(4);
         }
         mCopyConstructors.put(desc, c);
         return this;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Mixin.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Mixin.java
@@ -114,7 +114,7 @@ public abstract class Mixin {
             ccp.addConstructor(Modifier.PUBLIC, new Class<?>[]{Object[].class}, code.toString());
 
             // impl methods.
-            Set<String> worked = new HashSet<String>();
+            Set<String> worked = new HashSet<>();
             for (int i = 0; i < ics.length; i++) {
                 if (!Modifier.isPublic(ics[i].getModifiers())) {
                     String npkg = ics[i].getPackage().getName();

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Proxy.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Proxy.java
@@ -48,7 +48,7 @@ public abstract class Proxy {
     };
     private static final AtomicLong PROXY_CLASS_COUNTER = new AtomicLong(0);
     private static final String PACKAGE_NAME = Proxy.class.getPackage().getName();
-    private static final Map<ClassLoader, Map<String, Object>> ProxyCacheMap = new WeakHashMap<ClassLoader, Map<String, Object>>();
+    private static final Map<ClassLoader, Map<String, Object>> ProxyCacheMap = new WeakHashMap<>();
 
     private static final Object PendingGenerationMarker = new Object();
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Wrapper.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/bytecode/Wrapper.java
@@ -36,7 +36,7 @@ import java.util.regex.Matcher;
  * Wrapper.
  */
 public abstract class Wrapper {
-    private static final Map<Class<?>, Wrapper> WRAPPER_MAP = new ConcurrentHashMap<Class<?>, Wrapper>(); //class wrapper map
+    private static final Map<Class<?>, Wrapper> WRAPPER_MAP = new ConcurrentHashMap<>(); //class wrapper map
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
     private static final String[] OBJECT_METHODS = new String[]{"getClass", "hashCode", "toString", "equals"};
     private static final Wrapper OBJECT_WRAPPER = new Wrapper() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/compiler/support/ClassUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/compiler/support/ClassUtils.java
@@ -423,7 +423,7 @@ public class ClassUtils {
     }
 
     public static <K, V> Map<K, V> toMap(Map.Entry<K, V>[] entries) {
-        Map<K, V> map = new HashMap<K, V>();
+        Map<K, V> map = new HashMap<>();
         if (entries != null && entries.length > 0) {
             for (Map.Entry<K, V> entry : entries) {
                 map.put(entry.getKey(), entry.getValue());

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/compiler/support/JavassistCompiler.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/compiler/support/JavassistCompiler.java
@@ -54,8 +54,8 @@ public class JavassistCompiler extends AbstractCompiler {
         ClassPool pool = new ClassPool(true);
         pool.appendClassPath(new LoaderClassPath(ClassHelper.getCallerClassLoader(getClass())));
         Matcher matcher = IMPORT_PATTERN.matcher(source);
-        List<String> importPackages = new ArrayList<String>();
-        Map<String, String> fullNames = new HashMap<String, String>();
+        List<String> importPackages = new ArrayList<>();
+        Map<String, String> fullNames = new HashMap<>();
         while (matcher.find()) {
             String pkg = matcher.group(1);
             if (pkg.endsWith(".*")) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/compiler/support/JdkCompiler.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/compiler/support/JdkCompiler.java
@@ -57,7 +57,7 @@ public class JdkCompiler extends AbstractCompiler {
 
     private final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 
-    private final DiagnosticCollector<JavaFileObject> diagnosticCollector = new DiagnosticCollector<JavaFileObject>();
+    private final DiagnosticCollector<JavaFileObject> diagnosticCollector = new DiagnosticCollector<>();
 
     private final ClassLoaderImpl classLoader;
 
@@ -66,7 +66,7 @@ public class JdkCompiler extends AbstractCompiler {
     private volatile List<String> options;
 
     public JdkCompiler() {
-        options = new ArrayList<String>();
+        options = new ArrayList<>();
         options.add("-source");
         options.add("1.6");
         options.add("-target");
@@ -77,7 +77,7 @@ public class JdkCompiler extends AbstractCompiler {
                 && (!loader.getClass().getName().equals("sun.misc.Launcher$AppClassLoader"))) {
             try {
                 URLClassLoader urlClassLoader = (URLClassLoader) loader;
-                List<File> files = new ArrayList<File>();
+                List<File> files = new ArrayList<>();
                 for (URL url : urlClassLoader.getURLs()) {
                     files.add(new File(url.getFile()));
                 }
@@ -158,7 +158,7 @@ public class JdkCompiler extends AbstractCompiler {
 
         private final ClassLoaderImpl classLoader;
 
-        private final Map<URI, JavaFileObject> fileObjects = new HashMap<URI, JavaFileObject>();
+        private final Map<URI, JavaFileObject> fileObjects = new HashMap<>();
 
         public JavaFileManagerImpl(JavaFileManager fileManager, ClassLoaderImpl classLoader) {
             super(fileManager);
@@ -209,13 +209,13 @@ public class JdkCompiler extends AbstractCompiler {
             Iterable<JavaFileObject> result = super.list(location, packageName, kinds, recurse);
 
             ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-            List<URL> urlList = new ArrayList<URL>();
+            List<URL> urlList = new ArrayList<>();
             Enumeration<URL> e = contextClassLoader.getResources("com");
             while (e.hasMoreElements()) {
                 urlList.add(e.nextElement());
             }
 
-            ArrayList<JavaFileObject> files = new ArrayList<JavaFileObject>();
+            ArrayList<JavaFileObject> files = new ArrayList<>();
 
             if (location == StandardLocation.CLASS_PATH && kinds.contains(JavaFileObject.Kind.CLASS)) {
                 for (JavaFileObject file : fileObjects.values()) {
@@ -243,7 +243,7 @@ public class JdkCompiler extends AbstractCompiler {
 
     private final class ClassLoaderImpl extends ClassLoader {
 
-        private final Map<String, JavaFileObject> classes = new HashMap<String, JavaFileObject>();
+        private final Map<String, JavaFileObject> classes = new HashMap<>();
 
         ClassLoaderImpl(final ClassLoader parentClassLoader) {
             super(parentClassLoader);

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/concurrent/ExecutionList.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/concurrent/ExecutionList.java
@@ -51,7 +51,7 @@ public final class ExecutionList {
 
     private boolean executed;
 
-    private static final Executor DEFAULT_EXECUTOR = new ThreadPoolExecutor(1, 10, 60000L, TimeUnit.MILLISECONDS, new SynchronousQueue<Runnable>(), new NamedThreadFactory("DubboFutureCallbackDefault", true));
+    private static final Executor DEFAULT_EXECUTOR = new ThreadPoolExecutor(1, 10, 60000L, TimeUnit.MILLISECONDS, new SynchronousQueue<>(), new NamedThreadFactory("DubboFutureCallbackDefault", true));
 
     /**
      * Creates a new, empty {@link ExecutionList}.

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/config/CompositeConfiguration.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/config/CompositeConfiguration.java
@@ -32,7 +32,7 @@ public class CompositeConfiguration implements Configuration {
     /**
      * List holding all the configuration
      */
-    private List<Configuration> configList = new LinkedList<Configuration>();
+    private List<Configuration> configList = new LinkedList<>();
 
     public CompositeConfiguration() {
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/ExtensionLoader.java
@@ -70,9 +70,9 @@ public class ExtensionLoader<T> {
 
     private static final Pattern NAME_SEPARATOR = Pattern.compile("\\s*[,]+\\s*");
 
-    private static final ConcurrentMap<Class<?>, ExtensionLoader<?>> EXTENSION_LOADERS = new ConcurrentHashMap<Class<?>, ExtensionLoader<?>>();
+    private static final ConcurrentMap<Class<?>, ExtensionLoader<?>> EXTENSION_LOADERS = new ConcurrentHashMap<>();
 
-    private static final ConcurrentMap<Class<?>, Object> EXTENSION_INSTANCES = new ConcurrentHashMap<Class<?>, Object>();
+    private static final ConcurrentMap<Class<?>, Object> EXTENSION_INSTANCES = new ConcurrentHashMap<>();
 
     // ==============================
 
@@ -80,20 +80,20 @@ public class ExtensionLoader<T> {
 
     private final ExtensionFactory objectFactory;
 
-    private final ConcurrentMap<Class<?>, String> cachedNames = new ConcurrentHashMap<Class<?>, String>();
+    private final ConcurrentMap<Class<?>, String> cachedNames = new ConcurrentHashMap<>();
 
-    private final Holder<Map<String, Class<?>>> cachedClasses = new Holder<Map<String, Class<?>>>();
+    private final Holder<Map<String, Class<?>>> cachedClasses = new Holder<>();
 
-    private final Map<String, Object> cachedActivates = new ConcurrentHashMap<String, Object>();
-    private final ConcurrentMap<String, Holder<Object>> cachedInstances = new ConcurrentHashMap<String, Holder<Object>>();
-    private final Holder<Object> cachedAdaptiveInstance = new Holder<Object>();
+    private final Map<String, Object> cachedActivates = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Holder<Object>> cachedInstances = new ConcurrentHashMap<>();
+    private final Holder<Object> cachedAdaptiveInstance = new Holder<>();
     private volatile Class<?> cachedAdaptiveClass = null;
     private String cachedDefaultName;
     private volatile Throwable createAdaptiveInstanceError;
 
     private Set<Class<?>> cachedWrapperClasses;
 
-    private Map<String, IllegalStateException> exceptions = new ConcurrentHashMap<String, IllegalStateException>();
+    private Map<String, IllegalStateException> exceptions = new ConcurrentHashMap<>();
 
     private ExtensionLoader(Class<?> type) {
         this.type = type;
@@ -200,8 +200,8 @@ public class ExtensionLoader<T> {
      * @see org.apache.dubbo.common.extension.Activate
      */
     public List<T> getActivateExtension(URL url, String[] values, String group) {
-        List<T> exts = new ArrayList<T>();
-        List<String> names = values == null ? new ArrayList<String>(0) : Arrays.asList(values);
+        List<T> exts = new ArrayList<>();
+        List<String> names = values == null ? new ArrayList<>(0) : Arrays.asList(values);
         if (!names.contains(Constants.REMOVE_VALUE_PREFIX + Constants.DEFAULT_KEY)) {
             getExtensionClasses();
             for (Map.Entry<String, Object> entry : cachedActivates.entrySet()) {
@@ -230,7 +230,7 @@ public class ExtensionLoader<T> {
             }
             Collections.sort(exts, ActivateComparator.COMPARATOR);
         }
-        List<T> usrs = new ArrayList<T>();
+        List<T> usrs = new ArrayList<>();
         for (int i = 0; i < names.size(); i++) {
             String name = names.get(i);
             if (!name.startsWith(Constants.REMOVE_VALUE_PREFIX)
@@ -616,7 +616,7 @@ public class ExtensionLoader<T> {
             }
         }
 
-        Map<String, Class<?>> extensionClasses = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> extensionClasses = new HashMap<>();
         loadDirectory(extensionClasses, DUBBO_INTERNAL_DIRECTORY, type.getName());
         loadDirectory(extensionClasses, DUBBO_INTERNAL_DIRECTORY, type.getName().replace("org.apache", "com.alibaba"));
         loadDirectory(extensionClasses, DUBBO_DIRECTORY, type.getName());

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/extension/factory/AdaptiveExtensionFactory.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/extension/factory/AdaptiveExtensionFactory.java
@@ -34,7 +34,7 @@ public class AdaptiveExtensionFactory implements ExtensionFactory {
 
     public AdaptiveExtensionFactory() {
         ExtensionLoader<ExtensionFactory> loader = ExtensionLoader.getExtensionLoader(ExtensionFactory.class);
-        List<ExtensionFactory> list = new ArrayList<ExtensionFactory>();
+        List<ExtensionFactory> list = new ArrayList<>();
         for (String name : loader.getSupportedExtensions()) {
             list.add(loader.getExtension(name));
         }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/io/Bytes.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/io/Bytes.java
@@ -41,9 +41,9 @@ public class Bytes {
 
     private static final int MASK4 = 0x0f, MASK6 = 0x3f, MASK8 = 0xff;
 
-    private static final Map<Integer, byte[]> DECODE_TABLE_MAP = new ConcurrentHashMap<Integer, byte[]>();
+    private static final Map<Integer, byte[]> DECODE_TABLE_MAP = new ConcurrentHashMap<>();
 
-    private static ThreadLocal<MessageDigest> MD = new ThreadLocal<MessageDigest>();
+    private static ThreadLocal<MessageDigest> MD = new ThreadLocal<>();
 
     private Bytes() {
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/json/GenericJSONConverter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/json/GenericJSONConverter.java
@@ -36,8 +36,8 @@ import java.util.concurrent.atomic.AtomicLong;
 @Deprecated
 public class GenericJSONConverter implements JSONConverter {
     private static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
-    private static final Map<Class<?>, Encoder> GlobalEncoderMap = new HashMap<Class<?>, Encoder>();
-    private static final Map<Class<?>, Decoder> GlobalDecoderMap = new HashMap<Class<?>, Decoder>();
+    private static final Map<Class<?>, Encoder> GlobalEncoderMap = new HashMap<>();
+    private static final Map<Class<?>, Decoder> GlobalDecoderMap = new HashMap<>();
 
     static {
         // init encoder map.

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/json/J2oVisitor.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/json/J2oVisitor.java
@@ -65,7 +65,7 @@ class J2oVisitor implements JSONVisitor {
 
     private JSONConverter mConverter;
 
-    private Stack<Object> mStack = new Stack<Object>();
+    private Stack<Object> mStack = new Stack<>();
 
     J2oVisitor(Class<?> type, JSONConverter jc) {
         mType = type;
@@ -250,9 +250,9 @@ class J2oVisitor implements JSONVisitor {
                     throw new IllegalStateException(e.getMessage(), e);
                 }
             } else if (mType == ConcurrentMap.class) {
-                mValue = new ConcurrentHashMap<String, Object>();
+                mValue = new ConcurrentHashMap<>();
             } else {
-                mValue = new HashMap<String, Object>();
+                mValue = new HashMap<>();
             }
             mWrapper = null;
         } else {
@@ -347,13 +347,13 @@ class J2oVisitor implements JSONVisitor {
                         throw new IllegalStateException(e.getMessage(), e);
                     }
                 } else if (mType.isAssignableFrom(ArrayList.class)) { // List
-                    items = new ArrayList<Object>(count);
+                    items = new ArrayList<>(count);
                 } else if (mType.isAssignableFrom(HashSet.class)) { // Set
-                    items = new HashSet<Object>(count);
+                    items = new HashSet<>(count);
                 } else if (mType.isAssignableFrom(LinkedList.class)) { // Queue
-                    items = new LinkedList<Object>();
+                    items = new LinkedList<>();
                 } else { // Other
-                    items = new ArrayList<Object>(count);
+                    items = new ArrayList<>(count);
                 }
             } else {
                 throw new ParseException("Convert error, can not load json array data into class [" + mType.getName() + "].");

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/json/JSON.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/json/JSON.java
@@ -286,7 +286,7 @@ public class JSON {
 
         byte state = START;
         Object value = null, tmp;
-        Stack<Entry> stack = new Stack<Entry>();
+        Stack<Entry> stack = new Stack<>();
 
         do {
             switch (state) {
@@ -458,7 +458,7 @@ public class JSON {
 
         Object value = null;
         int state = START, index = 0;
-        Stack<int[]> states = new Stack<int[]>();
+        Stack<int[]> states = new Stack<>();
         boolean pv = false;
 
         handler.begin();

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/json/JSONArray.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/json/JSONArray.java
@@ -26,7 +26,7 @@ import java.util.List;
  */
 @Deprecated
 public class JSONArray implements JSONNode {
-    private List<Object> mArray = new ArrayList<Object>();
+    private List<Object> mArray = new ArrayList<>();
 
     /**
      * get.

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/json/JSONObject.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/json/JSONObject.java
@@ -26,7 +26,7 @@ import java.util.Map;
  */
 @Deprecated
 public class JSONObject implements JSONNode {
-    private Map<String, Object> mMap = new HashMap<String, Object>();
+    private Map<String, Object> mMap = new HashMap<>();
 
     /**
      * get.

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/json/JSONWriter.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/json/JSONWriter.java
@@ -42,7 +42,7 @@ public class JSONWriter {
 
     private State mState = new State(UNKNOWN);
 
-    private Stack<State> mStack = new Stack<State>();
+    private Stack<State> mStack = new Stack<>();
 
     public JSONWriter(Writer writer) {
         mWriter = writer;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/logger/LoggerFactory.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/logger/LoggerFactory.java
@@ -34,7 +34,7 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class LoggerFactory {
 
-    private static final ConcurrentMap<String, FailsafeLogger> LOGGERS = new ConcurrentHashMap<String, FailsafeLogger>();
+    private static final ConcurrentMap<String, FailsafeLogger> LOGGERS = new ConcurrentHashMap<>();
     private static volatile LoggerAdapter LOGGER_ADAPTER;
 
     // search common-used logging frameworks

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/store/support/SimpleDataStore.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/store/support/SimpleDataStore.java
@@ -28,16 +28,16 @@ public class SimpleDataStore implements DataStore {
 
     // <component name or id, <data-name, data-value>>
     private ConcurrentMap<String, ConcurrentMap<String, Object>> data =
-            new ConcurrentHashMap<String, ConcurrentMap<String, Object>>();
+            new ConcurrentHashMap<>();
 
     @Override
     public Map<String, Object> get(String componentName) {
         ConcurrentMap<String, Object> value = data.get(componentName);
         if (value == null) {
-            return new HashMap<String, Object>();
+            return new HashMap<>();
         }
 
-        return new HashMap<String, Object>(value);
+        return new HashMap<>(value);
     }
 
     @Override

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalThreadLocal.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalThreadLocal.java
@@ -89,7 +89,7 @@ public class InternalThreadLocal<V> {
         Object v = threadLocalMap.indexedVariable(variablesToRemoveIndex);
         Set<InternalThreadLocal<?>> variablesToRemove;
         if (v == InternalThreadLocalMap.UNSET || v == null) {
-            variablesToRemove = Collections.newSetFromMap(new IdentityHashMap<InternalThreadLocal<?>, Boolean>());
+            variablesToRemove = Collections.newSetFromMap(new IdentityHashMap<>());
             threadLocalMap.setIndexedVariable(variablesToRemoveIndex, variablesToRemove);
         } else {
             variablesToRemove = (Set<InternalThreadLocal<?>>) v;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalMap.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalMap.java
@@ -28,7 +28,7 @@ public final class InternalThreadLocalMap {
 
     private Object[] indexedVariables;
 
-    private static ThreadLocal<InternalThreadLocalMap> slowThreadLocalMap = new ThreadLocal<InternalThreadLocalMap>();
+    private static ThreadLocal<InternalThreadLocalMap> slowThreadLocalMap = new ThreadLocal<>();
 
     private static final AtomicInteger nextIndex = new AtomicInteger();
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/eager/EagerThreadPool.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/threadpool/support/eager/EagerThreadPool.java
@@ -42,7 +42,7 @@ public class EagerThreadPool implements ThreadPool {
         int alive = url.getParameter(Constants.ALIVE_KEY, Constants.DEFAULT_ALIVE);
 
         // init queue and executor
-        TaskQueue<Runnable> taskQueue = new TaskQueue<Runnable>(queues <= 0 ? 1 : queues);
+        TaskQueue<Runnable> taskQueue = new TaskQueue<>(queues <= 0 ? 1 : queues);
         EagerThreadPoolExecutor executor = new EagerThreadPoolExecutor(cores,
                 threads,
                 alive,

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/timer/HashedWheelTimer.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/timer/HashedWheelTimer.java
@@ -109,8 +109,8 @@ public class HashedWheelTimer implements Timer {
     private final HashedWheelBucket[] wheel;
     private final int mask;
     private final CountDownLatch startTimeInitialized = new CountDownLatch(1);
-    private final Queue<HashedWheelTimeout> timeouts = new ArrayBlockingQueue<HashedWheelTimeout>(1024);
-    private final Queue<HashedWheelTimeout> cancelledTimeouts = new ArrayBlockingQueue<HashedWheelTimeout>(1024);
+    private final Queue<HashedWheelTimeout> timeouts = new ArrayBlockingQueue<>(1024);
+    private final Queue<HashedWheelTimeout> cancelledTimeouts = new ArrayBlockingQueue<>(1024);
     private final AtomicLong pendingTimeouts = new AtomicLong(0);
     private final long maxPendingTimeouts;
 
@@ -420,7 +420,7 @@ public class HashedWheelTimer implements Timer {
     }
 
     private final class Worker implements Runnable {
-        private final Set<Timeout> unprocessedTimeouts = new HashSet<Timeout>();
+        private final Set<Timeout> unprocessedTimeouts = new HashSet<>();
 
         private long tick;
 

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ClassHelper.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ClassHelper.java
@@ -40,12 +40,12 @@ public class ClassHelper {
      * Map with primitive type name as key and corresponding primitive type as
      * value, for example: "int" -> "int.class".
      */
-    private static final Map<String, Class<?>> primitiveTypeNameMap = new HashMap<String, Class<?>>(16);
+    private static final Map<String, Class<?>> primitiveTypeNameMap = new HashMap<>(16);
     /**
      * Map with primitive wrapper type as key and corresponding primitive type
      * as value, for example: Integer.class -> int.class.
      */
-    private static final Map<Class<?>, Class<?>> primitiveWrapperTypeMap = new HashMap<Class<?>, Class<?>>(8);
+    private static final Map<Class<?>, Class<?>> primitiveWrapperTypeMap = new HashMap<>(8);
 
     private static final char PACKAGE_SEPARATOR_CHAR = '.';
 
@@ -59,7 +59,7 @@ public class ClassHelper {
         primitiveWrapperTypeMap.put(Long.class, long.class);
         primitiveWrapperTypeMap.put(Short.class, short.class);
 
-        Set<Class<?>> primitiveTypeNames = new HashSet<Class<?>>(16);
+        Set<Class<?>> primitiveTypeNames = new HashSet<>(16);
         primitiveTypeNames.addAll(primitiveWrapperTypeMap.values());
         primitiveTypeNames.addAll(Arrays
                 .asList(new Class<?>[]{boolean[].class, byte[].class, char[].class, double[].class,

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CompatibleTypeUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/CompatibleTypeUtils.java
@@ -158,12 +158,12 @@ public class CompatibleTypeUtils {
                 try {
                     collection = (Collection) type.newInstance();
                 } catch (Throwable e) {
-                    collection = new ArrayList<Object>();
+                    collection = new ArrayList<>();
                 }
             } else if (type == Set.class) {
-                collection = new HashSet<Object>();
+                collection = new HashSet<>();
             } else {
-                collection = new ArrayList<Object>();
+                collection = new ArrayList<>();
             }
             int length = Array.getLength(value);
             for (int i = 0; i < length; i++) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConcurrentHashSet.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConcurrentHashSet.java
@@ -32,11 +32,11 @@ public class ConcurrentHashSet<E> extends AbstractSet<E> implements Set<E>, java
     private final ConcurrentMap<E, Object> map;
 
     public ConcurrentHashSet() {
-        map = new ConcurrentHashMap<E, Object>();
+        map = new ConcurrentHashMap<>();
     }
 
     public ConcurrentHashSet(int initialCapacity) {
-        map = new ConcurrentHashMap<E, Object>(initialCapacity);
+        map = new ConcurrentHashMap<>(initialCapacity);
     }
 
     /**

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ConfigUtils.java
@@ -76,7 +76,7 @@ public class ConfigUtils {
      * @return result extension list
      */
     public static List<String> mergeValues(Class<?> type, String cfg, List<String> def) {
-        List<String> defaults = new ArrayList<String>();
+        List<String> defaults = new ArrayList<>();
         if (def != null) {
             for (String name : def) {
                 if (ExtensionLoader.getExtensionLoader(type).hasExtension(name)) {
@@ -85,7 +85,7 @@ public class ConfigUtils {
             }
         }
 
-        List<String> names = new ArrayList<String>();
+        List<String> names = new ArrayList<>();
 
         // add initial values
         String[] configs = (cfg == null || cfg.trim().length() == 0) ? new String[0] : Constants.COMMA_SPLIT_PATTERN.split(cfg);
@@ -233,10 +233,10 @@ public class ConfigUtils {
             return properties;
         }
 
-        List<java.net.URL> list = new ArrayList<java.net.URL>();
+        List<java.net.URL> list = new ArrayList<>();
         try {
             Enumeration<java.net.URL> urls = ClassHelper.getClassLoader().getResources(fileName);
-            list = new ArrayList<java.net.URL>();
+            list = new ArrayList<>();
             while (urls.hasMoreElements()) {
                 list.add(urls.nextElement());
             }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/DubboAppender.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/DubboAppender.java
@@ -26,7 +26,7 @@ public class DubboAppender extends ConsoleAppender {
 
     public static boolean available = false;
 
-    public static List<Log> logList = new ArrayList<Log>();
+    public static List<Log> logList = new ArrayList<>();
 
     public static void doStart() {
         available = true;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/IOUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/IOUtils.java
@@ -162,7 +162,7 @@ public class IOUtils {
      * @throws IOException
      */
     public static String[] readLines(InputStream is) throws IOException {
-        List<String> lines = new ArrayList<String>();
+        List<String> lines = new ArrayList<>();
         BufferedReader reader = new BufferedReader(new InputStreamReader(is));
         try {
             String line;

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/NetUtils.java
@@ -51,7 +51,7 @@ public class NetUtils {
     private static final Pattern ADDRESS_PATTERN = Pattern.compile("^\\d{1,3}(\\.\\d{1,3}){3}\\:\\d{1,5}$");
     private static final Pattern LOCAL_IP_PATTERN = Pattern.compile("127(\\.\\d{1,3}){3}$");
     private static final Pattern IP_PATTERN = Pattern.compile("\\d{1,3}(\\.\\d{1,3}){3,5}$");
-    private static final Map<String, String> hostNameCache = new LRUCache<String, String>(1000);
+    private static final Map<String, String> hostNameCache = new LRUCache<>(1000);
     private static volatile InetAddress LOCAL_ADDRESS = null;
 
     public static int getRandomPort() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/PojoUtils.java
@@ -61,8 +61,8 @@ import java.util.concurrent.ConcurrentSkipListMap;
 public class PojoUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(PojoUtils.class);
-    private static final ConcurrentMap<String, Method> NAME_METHODS_CACHE = new ConcurrentHashMap<String, Method>();
-    private static final ConcurrentMap<Class<?>, ConcurrentMap<String, Field>> CLASS_FIELD_CACHE = new ConcurrentHashMap<Class<?>, ConcurrentMap<String, Field>>();
+    private static final ConcurrentMap<String, Method> NAME_METHODS_CACHE = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<Class<?>, ConcurrentMap<String, Field>> CLASS_FIELD_CACHE = new ConcurrentHashMap<>();
 
     public static Object[] generalize(Object[] objs) {
         Object[] dests = new Object[objs.length];
@@ -145,7 +145,7 @@ public class PojoUtils {
         if (pojo instanceof Collection<?>) {
             Collection<Object> src = (Collection<Object>) pojo;
             int len = src.size();
-            Collection<Object> dest = (pojo instanceof List<?>) ? new ArrayList<Object>(len) : new HashSet<Object>(len);
+            Collection<Object> dest = (pojo instanceof List<?>) ? new ArrayList<>(len) : new HashSet<>(len);
             history.put(pojo, dest);
             for (Object obj : src) {
                 dest.add(generalize(obj, history));
@@ -161,7 +161,7 @@ public class PojoUtils {
             }
             return dest;
         }
-        Map<String, Object> map = new HashMap<String, Object>();
+        Map<String, Object> map = new HashMap<>();
         history.put(pojo, map);
         map.put("class", pojo.getClass().getName());
         for (Method method : pojo.getClass().getMethods()) {
@@ -228,7 +228,7 @@ public class PojoUtils {
                 value = map.get(methodName.substring(0, 1).toLowerCase() + methodName.substring(1));
             }
             if (value instanceof Map<?, ?> && !Map.class.isAssignableFrom(method.getReturnType())) {
-                value = realize0((Map<String, Object>) value, method.getReturnType(), null, new IdentityHashMap<Object, Object>());
+                value = realize0((Map<String, Object>) value, method.getReturnType(), null, new IdentityHashMap<>());
             }
             return value;
         }
@@ -237,10 +237,10 @@ public class PojoUtils {
     @SuppressWarnings("unchecked")
     private static Collection<Object> createCollection(Class<?> type, int len) {
         if (type.isAssignableFrom(ArrayList.class)) {
-            return new ArrayList<Object>(len);
+            return new ArrayList<>(len);
         }
         if (type.isAssignableFrom(HashSet.class)) {
-            return new HashSet<Object>(len);
+            return new HashSet<>(len);
         }
         if (!type.isInterface() && !Modifier.isAbstract(type.getModifiers())) {
             try {
@@ -249,7 +249,7 @@ public class PojoUtils {
                 // ignore
             }
         }
-        return new ArrayList<Object>();
+        return new ArrayList<>();
     }
 
     private static Map createMap(Map src) {
@@ -287,7 +287,7 @@ public class PojoUtils {
         }
 
         if (result == null) {
-            result = new HashMap<Object, Object>();
+            result = new HashMap<>();
         }
 
         return result;
@@ -592,7 +592,7 @@ public class PojoUtils {
         if (result != null) {
             ConcurrentMap<String, Field> fields = CLASS_FIELD_CACHE.get(cls);
             if (fields == null) {
-                fields = new ConcurrentHashMap<String, Field>();
+                fields = new ConcurrentHashMap<>();
                 CLASS_FIELD_CACHE.putIfAbsent(cls, fields);
             }
             fields = CLASS_FIELD_CACHE.get(cls);

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ReflectUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/ReflectUtils.java
@@ -116,11 +116,11 @@ public final class ReflectUtils {
 
     public static final Pattern IS_HAS_CAN_METHOD_DESC_PATTERN = Pattern.compile("(?:is|has|can)([A-Z][_a-zA-Z0-9]*)\\(\\)Z");
 
-    private static final ConcurrentMap<String, Class<?>> DESC_CLASS_CACHE = new ConcurrentHashMap<String, Class<?>>();
+    private static final ConcurrentMap<String, Class<?>> DESC_CLASS_CACHE = new ConcurrentHashMap<>();
 
-    private static final ConcurrentMap<String, Class<?>> NAME_CLASS_CACHE = new ConcurrentHashMap<String, Class<?>>();
+    private static final ConcurrentMap<String, Class<?>> NAME_CLASS_CACHE = new ConcurrentHashMap<>();
 
-    private static final ConcurrentMap<String, Method> Signature_METHODS_CACHE = new ConcurrentHashMap<String, Method>();
+    private static final ConcurrentMap<String, Method> Signature_METHODS_CACHE = new ConcurrentHashMap<>();
 
     private ReflectUtils() {
     }
@@ -833,7 +833,7 @@ public final class ReflectUtils {
             return EMPTY_CLASS_ARRAY;
         }
 
-        List<Class<?>> cs = new ArrayList<Class<?>>();
+        List<Class<?>> cs = new ArrayList<>();
         Matcher m = DESC_PATTERN.matcher(desc);
         while (m.find()) {
             cs.add(desc2class(cl, m.group()));
@@ -862,7 +862,7 @@ public final class ReflectUtils {
             return method;
         }
         if (parameterTypes == null) {
-            List<Method> finded = new ArrayList<Method>();
+            List<Method> finded = new ArrayList<>();
             for (Method m : clazz.getMethods()) {
                 if (m.getName().equals(methodName)) {
                     finded.add(m);
@@ -1063,7 +1063,7 @@ public final class ReflectUtils {
     }
 
     public static Map<String, Field> getBeanPropertyFields(Class cl) {
-        Map<String, Field> properties = new HashMap<String, Field>();
+        Map<String, Field> properties = new HashMap<>();
         for (; cl != null; cl = cl.getSuperclass()) {
             Field[] fields = cl.getDeclaredFields();
             for (Field field : fields) {
@@ -1082,7 +1082,7 @@ public final class ReflectUtils {
     }
 
     public static Map<String, Method> getBeanPropertyReadMethods(Class cl) {
-        Map<String, Method> properties = new HashMap<String, Method>();
+        Map<String, Method> properties = new HashMap<>();
         for (; cl != null; cl = cl.getSuperclass()) {
             Method[] methods = cl.getDeclaredMethods();
             for (Method method : methods) {

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/Stack.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/Stack.java
@@ -27,7 +27,7 @@ import java.util.List;
 public class Stack<E> {
     private int mSize = 0;
 
-    private List<E> mElements = new ArrayList<E>();
+    private List<E> mElements = new ArrayList<>();
 
     public Stack() {
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
@@ -577,7 +577,7 @@ public final class StringUtils {
             c = str.charAt(i);
             if (c == ch) {
                 if (list == null) {
-                    list = new ArrayList<String>();
+                    list = new ArrayList<>();
                 }
                 list.add(str.substring(ix, i));
                 ix = i + 1;
@@ -675,7 +675,7 @@ public final class StringUtils {
      */
     private static Map<String, String> parseKeyValuePair(String str, String itemSeparator) {
         String[] tmp = str.split(itemSeparator);
-        Map<String, String> map = new HashMap<String, String>(tmp.length);
+        Map<String, String> map = new HashMap<>(tmp.length);
         for (int i = 0; i < tmp.length; i++) {
             Matcher matcher = KVP_PATTERN.matcher(tmp[i]);
             if (!matcher.matches()) {
@@ -699,7 +699,7 @@ public final class StringUtils {
      */
     public static Map<String, String> parseQueryString(String qs) {
         if (isEmpty(qs)) {
-            return new HashMap<String, String>();
+            return new HashMap<>();
         }
         return parseKeyValuePair(qs, "\\&");
     }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/UrlUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/UrlUtils.java
@@ -71,7 +71,7 @@ public class UrlUtils {
         String defaultPassword = defaults == null ? null : defaults.get("password");
         int defaultPort = StringUtils.parseInteger(defaults == null ? null : defaults.get("port"));
         String defaultPath = defaults == null ? null : defaults.get("path");
-        Map<String, String> defaultParameters = defaults == null ? null : new HashMap<String, String>(defaults);
+        Map<String, String> defaultParameters = defaults == null ? null : new HashMap<>(defaults);
         if (defaultParameters != null) {
             defaultParameters.remove("protocol");
             defaultParameters.remove("username");
@@ -88,7 +88,7 @@ public class UrlUtils {
         String host = u.getHost();
         int port = u.getPort();
         String path = u.getPath();
-        Map<String, String> parameters = new HashMap<String, String>(u.getParameters());
+        Map<String, String> parameters = new HashMap<>(u.getParameters());
         if ((protocol == null || protocol.length() == 0) && defaultProtocol != null && defaultProtocol.length() > 0) {
             changed = true;
             protocol = defaultProtocol;
@@ -147,7 +147,7 @@ public class UrlUtils {
         if (addresses == null || addresses.length == 0) {
             return null; //here won't be empty
         }
-        List<URL> registries = new ArrayList<URL>();
+        List<URL> registries = new ArrayList<>();
         for (String addr : addresses) {
             registries.add(parseURL(addr, defaults));
         }
@@ -155,7 +155,7 @@ public class UrlUtils {
     }
 
     public static Map<String, Map<String, String>> convertRegister(Map<String, Map<String, String>> register) {
-        Map<String, Map<String, String>> newRegister = new HashMap<String, Map<String, String>>();
+        Map<String, Map<String, String>> newRegister = new HashMap<>();
         for (Map.Entry<String, Map<String, String>> entry : register.entrySet()) {
             String serviceName = entry.getKey();
             Map<String, String> serviceUrls = entry.getValue();
@@ -177,7 +177,7 @@ public class UrlUtils {
                     }
                     Map<String, String> newUrls = newRegister.get(name);
                     if (newUrls == null) {
-                        newUrls = new HashMap<String, String>();
+                        newUrls = new HashMap<>();
                         newRegister.put(name, newUrls);
                     }
                     newUrls.put(serviceUrl, StringUtils.toQueryString(params));
@@ -190,7 +190,7 @@ public class UrlUtils {
     }
 
     public static Map<String, String> convertSubscribe(Map<String, String> subscribe) {
-        Map<String, String> newSubscribe = new HashMap<String, String>();
+        Map<String, String> newSubscribe = new HashMap<>();
         for (Map.Entry<String, String> entry : subscribe.entrySet()) {
             String serviceName = entry.getKey();
             String serviceQuery = entry.getValue();
@@ -216,7 +216,7 @@ public class UrlUtils {
     }
 
     public static Map<String, Map<String, String>> revertRegister(Map<String, Map<String, String>> register) {
-        Map<String, Map<String, String>> newRegister = new HashMap<String, Map<String, String>>();
+        Map<String, Map<String, String>> newRegister = new HashMap<>();
         for (Map.Entry<String, Map<String, String>> entry : register.entrySet()) {
             String serviceName = entry.getKey();
             Map<String, String> serviceUrls = entry.getValue();
@@ -238,7 +238,7 @@ public class UrlUtils {
                     }
                     Map<String, String> newUrls = newRegister.get(name);
                     if (newUrls == null) {
-                        newUrls = new HashMap<String, String>();
+                        newUrls = new HashMap<>();
                         newRegister.put(name, newUrls);
                     }
                     newUrls.put(serviceUrl, StringUtils.toQueryString(params));
@@ -251,7 +251,7 @@ public class UrlUtils {
     }
 
     public static Map<String, String> revertSubscribe(Map<String, String> subscribe) {
-        Map<String, String> newSubscribe = new HashMap<String, String>();
+        Map<String, String> newSubscribe = new HashMap<>();
         for (Map.Entry<String, String> entry : subscribe.entrySet()) {
             String serviceName = entry.getKey();
             String serviceQuery = entry.getValue();
@@ -278,7 +278,7 @@ public class UrlUtils {
 
     public static Map<String, Map<String, String>> revertNotify(Map<String, Map<String, String>> notify) {
         if (notify != null && notify.size() > 0) {
-            Map<String, Map<String, String>> newNotify = new HashMap<String, Map<String, String>>();
+            Map<String, Map<String, String>> newNotify = new HashMap<>();
             for (Map.Entry<String, Map<String, String>> entry : notify.entrySet()) {
                 String serviceName = entry.getKey();
                 Map<String, String> serviceUrls = entry.getValue();
@@ -301,7 +301,7 @@ public class UrlUtils {
                             }
                             Map<String, String> newUrls = newNotify.get(name);
                             if (newUrls == null) {
-                                newUrls = new HashMap<String, String>();
+                                newUrls = new HashMap<>();
                                 newNotify.put(name, newUrls);
                             }
                             newUrls.put(url, StringUtils.toQueryString(params));
@@ -319,7 +319,7 @@ public class UrlUtils {
     //compatible for dubbo-2.0.0
     public static List<String> revertForbid(List<String> forbid, Set<URL> subscribed) {
         if (CollectionUtils.isNotEmpty(forbid)) {
-            List<String> newForbid = new ArrayList<String>();
+            List<String> newForbid = new ArrayList<>();
             for (String serviceName : forbid) {
                 if (!serviceName.contains(":") && !serviceName.contains("/")) {
                     for (URL url : subscribed) {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/URLTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/URLTest.java
@@ -162,7 +162,7 @@ public class URLTest {
         assertEquals(0, url.getPort());
         assertEquals("home/user1/router.js", url.getPath());
         assertEquals(2, url.getParameters().size());
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         params.put("p1", "v1");
         params.put("p2", "v2");
         assertEquals(params, url.getParameters());
@@ -175,7 +175,7 @@ public class URLTest {
         assertEquals(0, url.getPort());
         assertEquals("home/user1/router.js", url.getPath());
         assertEquals(2, url.getParameters().size());
-        params = new HashMap<String, String>();
+        params = new HashMap<>();
         params.put("p1", "v1");
         params.put("p2", "v2");
         assertEquals(params, url.getParameters());
@@ -291,7 +291,7 @@ public class URLTest {
     public void test_equals() throws Exception {
         URL url1 = URL.valueOf("dubbo://admin:hello1234@10.20.130.230:20880/context/path?version=1.0.0&application=morgan");
 
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         params.put("version", "1.0.0");
         params.put("application", "morgan");
         URL url2 = new URL("dubbo", "admin", "hello1234", "10.20.130.230", 20880, "context/path", params);
@@ -633,7 +633,7 @@ public class URLTest {
     @Test
     public void testAddParameters() throws Exception {
         URL url = URL.valueOf("dubbo://127.0.0.1:20880");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("version", null);
         url.addParameters(parameters);
     }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/beanutil/JavaBeanSerializeUtilTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/beanutil/JavaBeanSerializeUtilTest.java
@@ -303,12 +303,12 @@ public class JavaBeanSerializeUtilTest {
         bean.setType(Bean.class);
         bean.setArray(new Phone[]{});
 
-        Collection<Phone> collection = new ArrayList<Phone>();
+        Collection<Phone> collection = new ArrayList<>();
         bean.setCollection(collection);
         Phone phone = new Phone();
         collection.add(phone);
 
-        Map<String, FullAddress> map = new HashMap<String, FullAddress>();
+        Map<String, FullAddress> map = new HashMap<>();
         FullAddress address = new FullAddress();
         map.put("first", address);
         bean.setAddresses(map);
@@ -353,12 +353,12 @@ public class JavaBeanSerializeUtilTest {
         bean.setType(Bean.class);
         bean.setArray(new Phone[]{});
 
-        Collection<Phone> collection = new ArrayList<Phone>();
+        Collection<Phone> collection = new ArrayList<>();
         bean.setCollection(collection);
         Phone phone = new Phone();
         collection.add(phone);
 
-        Map<String, FullAddress> map = new HashMap<String, FullAddress>();
+        Map<String, FullAddress> map = new HashMap<>();
         FullAddress address = new FullAddress();
         map.put("first", address);
         bean.setAddresses(map);
@@ -493,7 +493,7 @@ public class JavaBeanSerializeUtilTest {
         bigPerson.setEmail("sm@1.com");
         bigPerson.setPenName("pname");
 
-        ArrayList<Phone> phones = new ArrayList<Phone>();
+        ArrayList<Phone> phones = new ArrayList<>();
         Phone phone1 = new Phone("86", "0571", "87654321", "001");
         Phone phone2 = new Phone("86", "0571", "87654322", "002");
         phones.add(phone1);

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/concurrent/CompletableFutureTaskTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/concurrent/CompletableFutureTaskTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 
 public class CompletableFutureTaskTest {
 
-    private static final ExecutorService executor = new ThreadPoolExecutor(0, 10, 60L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(), new NamedThreadFactory("DubboMonitorCreator", true));
+    private static final ExecutorService executor = new ThreadPoolExecutor(0, 10, 60L, TimeUnit.SECONDS, new SynchronousQueue<>(), new NamedThreadFactory("DubboMonitorCreator", true));
 
     @Test
     public void testCreate() throws InterruptedException {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
@@ -210,7 +210,7 @@ public class ExtensionLoaderTest {
     public void test_getSupportedExtensions() throws Exception {
         Set<String> exts = ExtensionLoader.getExtensionLoader(SimpleExt.class).getSupportedExtensions();
 
-        Set<String> expected = new HashSet<String>();
+        Set<String> expected = new HashSet<>();
         expected.add("impl1");
         expected.add("impl2");
         expected.add("impl3");
@@ -222,7 +222,7 @@ public class ExtensionLoaderTest {
     public void test_getSupportedExtensions_wrapperIsNotExt() throws Exception {
         Set<String> exts = ExtensionLoader.getExtensionLoader(WrappedExt.class).getSupportedExtensions();
 
-        Set<String> expected = new HashSet<String>();
+        Set<String> expected = new HashSet<>();
         expected.add("impl1");
         expected.add("impl2");
 

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoader_Adaptive_Test.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoader_Adaptive_Test.java
@@ -57,7 +57,7 @@ public class ExtensionLoader_Adaptive_Test {
         {
             SimpleExt ext = ExtensionLoader.getExtensionLoader(SimpleExt.class).getAdaptiveExtension();
 
-            Map<String, String> map = new HashMap<String, String>();
+            Map<String, String> map = new HashMap<>();
             URL url = new URL("p1", "1.2.3.4", 1010, "path1", map);
 
             String echo = ext.echo(url, "haha");
@@ -67,7 +67,7 @@ public class ExtensionLoader_Adaptive_Test {
         {
             SimpleExt ext = ExtensionLoader.getExtensionLoader(SimpleExt.class).getAdaptiveExtension();
 
-            Map<String, String> map = new HashMap<String, String>();
+            Map<String, String> map = new HashMap<>();
             map.put("simple.ext", "impl2");
             URL url = new URL("p1", "1.2.3.4", 1010, "path1", map);
 
@@ -80,7 +80,7 @@ public class ExtensionLoader_Adaptive_Test {
     public void test_getAdaptiveExtension_customizeAdaptiveKey() throws Exception {
         SimpleExt ext = ExtensionLoader.getExtensionLoader(SimpleExt.class).getAdaptiveExtension();
 
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put("key2", "impl2");
         URL url = new URL("p1", "1.2.3.4", 1010, "path1", map);
 
@@ -100,7 +100,7 @@ public class ExtensionLoader_Adaptive_Test {
             String echo = ext.echo(URL.valueOf("1.2.3.4:20880"), "s");
             assertEquals("Ext3Impl1-echo", echo); // default value
 
-            Map<String, String> map = new HashMap<String, String>();
+            Map<String, String> map = new HashMap<>();
             URL url = new URL("impl3", "1.2.3.4", 1010, "path1", map);
 
             echo = ext.echo(url, "s");
@@ -113,7 +113,7 @@ public class ExtensionLoader_Adaptive_Test {
 
         {
 
-            Map<String, String> map = new HashMap<String, String>();
+            Map<String, String> map = new HashMap<>();
             URL url = new URL(null, "1.2.3.4", 1010, "path1", map);
             String yell = ext.yell(url, "s");
             assertEquals("Ext3Impl1-yell", yell); // default value
@@ -165,7 +165,7 @@ public class ExtensionLoader_Adaptive_Test {
     public void test_getAdaptiveExtension_ExceptionWhenNotAdaptiveMethod() throws Exception {
         SimpleExt ext = ExtensionLoader.getExtensionLoader(SimpleExt.class).getAdaptiveExtension();
 
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         URL url = new URL("p1", "1.2.3.4", 1010, "path1", map);
 
         try {
@@ -194,7 +194,7 @@ public class ExtensionLoader_Adaptive_Test {
     public void test_urlHolder_getAdaptiveExtension() throws Exception {
         Ext2 ext = ExtensionLoader.getExtensionLoader(Ext2.class).getAdaptiveExtension();
 
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put("ext2", "impl1");
         URL url = new URL("p1", "1.2.3.4", 1010, "path1", map);
 
@@ -254,7 +254,7 @@ public class ExtensionLoader_Adaptive_Test {
     public void test_urlHolder_getAdaptiveExtension_ExceptionWhenNotAdativeMethod() throws Exception {
         Ext2 ext = ExtensionLoader.getExtensionLoader(Ext2.class).getAdaptiveExtension();
 
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         URL url = new URL("p1", "1.2.3.4", 1010, "path1", map);
 
         try {

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/json/JSONTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/json/JSONTest.java
@@ -53,7 +53,7 @@ public class JSONTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testMap() throws Exception {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put("aaa", "bbb");
 
         StringWriter writer = new StringWriter();
@@ -69,7 +69,7 @@ public class JSONTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testMapArray() throws Exception {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put("aaa", "bbb");
 
         StringWriter writer = new StringWriter();
@@ -86,7 +86,7 @@ public class JSONTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testLinkedMap() throws Exception {
-        LinkedHashMap<String, String> map = new LinkedHashMap<String, String>();
+        LinkedHashMap<String, String> map = new LinkedHashMap<>();
         map.put("aaa", "bbb");
 
         StringWriter writer = new StringWriter();

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/status/support/StatusUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/status/support/StatusUtilsTest.java
@@ -35,7 +35,7 @@ public class StatusUtilsTest {
         Status status1 = new Status(Status.Level.ERROR);
         Status status2 = new Status(Status.Level.WARN);
         Status status3 = new Status(Status.Level.OK);
-        Map<String, Status> statuses = new HashMap<String, Status>();
+        Map<String, Status> statuses = new HashMap<>();
         statuses.put("status1", status1);
         statuses.put("status2", status2);
         statuses.put("status3", status3);
@@ -50,7 +50,7 @@ public class StatusUtilsTest {
     public void testGetSummaryStatus2() throws Exception {
         Status status1 = new Status(Status.Level.WARN);
         Status status2 = new Status(Status.Level.OK);
-        Map<String, Status> statuses = new HashMap<String, Status>();
+        Map<String, Status> statuses = new HashMap<>();
         statuses.put("status1", status1);
         statuses.put("status2", status2);
         Status status = StatusUtils.getSummaryStatus(statuses);
@@ -62,7 +62,7 @@ public class StatusUtilsTest {
     @Test
     public void testGetSummaryStatus3() throws Exception {
         Status status1 = new Status(Status.Level.OK);
-        Map<String, Status> statuses = new HashMap<String, Status>();
+        Map<String, Status> statuses = new HashMap<>();
         statuses.put("status1", status1);
         Status status = StatusUtils.getSummaryStatus(statuses);
         assertThat(status.getLevel(), is(Status.Level.OK));

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalTest.java
@@ -58,11 +58,11 @@ public class InternalThreadLocalTest {
 
     @Test
     public void testRemoveAll() throws InterruptedException {
-        final InternalThreadLocal<Integer> internalThreadLocal = new InternalThreadLocal<Integer>();
+        final InternalThreadLocal<Integer> internalThreadLocal = new InternalThreadLocal<>();
         internalThreadLocal.set(1);
         Assertions.assertTrue(internalThreadLocal.get() == 1, "set failed");
 
-        final InternalThreadLocal<String> internalThreadLocalString = new InternalThreadLocal<String>();
+        final InternalThreadLocal<String> internalThreadLocalString = new InternalThreadLocal<>();
         internalThreadLocalString.set("value");
         Assertions.assertTrue("value".equals(internalThreadLocalString.get()), "set failed");
 
@@ -73,11 +73,11 @@ public class InternalThreadLocalTest {
 
     @Test
     public void testSize() throws InterruptedException {
-        final InternalThreadLocal<Integer> internalThreadLocal = new InternalThreadLocal<Integer>();
+        final InternalThreadLocal<Integer> internalThreadLocal = new InternalThreadLocal<>();
         internalThreadLocal.set(1);
         Assertions.assertTrue(InternalThreadLocal.size() == 1, "size method is wrong!");
 
-        final InternalThreadLocal<String> internalThreadLocalString = new InternalThreadLocal<String>();
+        final InternalThreadLocal<String> internalThreadLocalString = new InternalThreadLocal<>();
         internalThreadLocalString.set("value");
         Assertions.assertTrue(InternalThreadLocal.size() == 2, "size method is wrong!");
     }
@@ -85,7 +85,7 @@ public class InternalThreadLocalTest {
     @Test
     public void testSetAndGet() {
         final Integer testVal = 10;
-        final InternalThreadLocal<Integer> internalThreadLocal = new InternalThreadLocal<Integer>();
+        final InternalThreadLocal<Integer> internalThreadLocal = new InternalThreadLocal<>();
         internalThreadLocal.set(testVal);
         Assertions.assertTrue(
                 Objects.equals(testVal, internalThreadLocal.get()), "set is not equals get");
@@ -93,7 +93,7 @@ public class InternalThreadLocalTest {
 
     @Test
     public void testRemove() {
-        final InternalThreadLocal<Integer> internalThreadLocal = new InternalThreadLocal<Integer>();
+        final InternalThreadLocal<Integer> internalThreadLocal = new InternalThreadLocal<>();
         internalThreadLocal.set(1);
         Assertions.assertTrue(internalThreadLocal.get() == 1, "get method false!");
 
@@ -122,7 +122,7 @@ public class InternalThreadLocalTest {
     public void testMultiThreadSetAndGet() throws InterruptedException {
         final Integer testVal1 = 10;
         final Integer testVal2 = 20;
-        final InternalThreadLocal<Integer> internalThreadLocal = new InternalThreadLocal<Integer>();
+        final InternalThreadLocal<Integer> internalThreadLocal = new InternalThreadLocal<>();
         final CountDownLatch countDownLatch = new CountDownLatch(2);
         Thread t1 = new Thread(new Runnable() {
             @Override
@@ -160,7 +160,7 @@ public class InternalThreadLocalTest {
         final ThreadLocal<String>[] caches1 = new ThreadLocal[PERFORMANCE_THREAD_COUNT];
         final Thread mainThread = Thread.currentThread();
         for (int i = 0; i < PERFORMANCE_THREAD_COUNT; i++) {
-            caches1[i] = new ThreadLocal<String>();
+            caches1[i] = new ThreadLocal<>();
         }
         Thread t1 = new Thread(new Runnable() {
             @Override
@@ -195,7 +195,7 @@ public class InternalThreadLocalTest {
         final InternalThreadLocal<String>[] caches = new InternalThreadLocal[PERFORMANCE_THREAD_COUNT];
         final Thread mainThread = Thread.currentThread();
         for (int i = 0; i < PERFORMANCE_THREAD_COUNT; i++) {
-            caches[i] = new InternalThreadLocal<String>();
+            caches[i] = new InternalThreadLocal<>();
         }
         Thread t = new InternalThread(new Runnable() {
             @Override

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/eager/EagerThreadPoolExecutorTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/eager/EagerThreadPoolExecutorTest.java
@@ -63,7 +63,7 @@ public class EagerThreadPoolExecutorTest {
         long alive = 1000;
 
         //init queue and executor
-        TaskQueue<Runnable> taskQueue = new TaskQueue<Runnable>(queues);
+        TaskQueue<Runnable> taskQueue = new TaskQueue<>(queues);
         final EagerThreadPoolExecutor executor = new EagerThreadPoolExecutor(cores,
                 threads,
                 alive,

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/eager/TaskQueueTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadpool/support/eager/TaskQueueTest.java
@@ -33,14 +33,14 @@ public class TaskQueueTest {
     @Test
     public void testOffer1() throws Exception {
         Assertions.assertThrows(RejectedExecutionException.class, () -> {
-            TaskQueue<Runnable> queue = new TaskQueue<Runnable>(1);
+            TaskQueue<Runnable> queue = new TaskQueue<>(1);
             queue.offer(mock(Runnable.class));
         });
     }
 
     @Test
     public void testOffer2() throws Exception {
-        TaskQueue<Runnable> queue = new TaskQueue<Runnable>(1);
+        TaskQueue<Runnable> queue = new TaskQueue<>(1);
         EagerThreadPoolExecutor executor = mock(EagerThreadPoolExecutor.class);
         Mockito.when(executor.getPoolSize()).thenReturn(2);
         Mockito.when(executor.getSubmittedTaskCount()).thenReturn(1);
@@ -50,7 +50,7 @@ public class TaskQueueTest {
 
     @Test
     public void testOffer3() throws Exception {
-        TaskQueue<Runnable> queue = new TaskQueue<Runnable>(1);
+        TaskQueue<Runnable> queue = new TaskQueue<>(1);
         EagerThreadPoolExecutor executor = mock(EagerThreadPoolExecutor.class);
         Mockito.when(executor.getPoolSize()).thenReturn(2);
         Mockito.when(executor.getSubmittedTaskCount()).thenReturn(2);
@@ -61,7 +61,7 @@ public class TaskQueueTest {
 
     @Test
     public void testOffer4() throws Exception {
-        TaskQueue<Runnable> queue = new TaskQueue<Runnable>(1);
+        TaskQueue<Runnable> queue = new TaskQueue<>(1);
         EagerThreadPoolExecutor executor = mock(EagerThreadPoolExecutor.class);
         Mockito.when(executor.getPoolSize()).thenReturn(4);
         Mockito.when(executor.getSubmittedTaskCount()).thenReturn(4);
@@ -73,7 +73,7 @@ public class TaskQueueTest {
     @Test
     public void testRetryOffer1() throws Exception {
         Assertions.assertThrows(RejectedExecutionException.class, () -> {
-            TaskQueue<Runnable> queue = new TaskQueue<Runnable>(1);
+            TaskQueue<Runnable> queue = new TaskQueue<>(1);
             EagerThreadPoolExecutor executor = mock(EagerThreadPoolExecutor.class);
             Mockito.when(executor.isShutdown()).thenReturn(true);
             queue.setExecutor(executor);
@@ -84,7 +84,7 @@ public class TaskQueueTest {
 
     @Test
     public void testRetryOffer2() throws Exception {
-        TaskQueue<Runnable> queue = new TaskQueue<Runnable>(1);
+        TaskQueue<Runnable> queue = new TaskQueue<>(1);
         EagerThreadPoolExecutor executor = mock(EagerThreadPoolExecutor.class);
         Mockito.when(executor.isShutdown()).thenReturn(false);
         queue.setExecutor(executor);

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/CollectionUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/CollectionUtilsTest.java
@@ -44,12 +44,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class CollectionUtilsTest {
     @Test
     public void testSort() throws Exception {
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         list.add(100);
         list.add(10);
         list.add(20);
 
-        List<Integer> expected = new ArrayList<Integer>();
+        List<Integer> expected = new ArrayList<>();
         expected.add(10);
         expected.add(20);
         expected.add(100);
@@ -66,7 +66,7 @@ public class CollectionUtilsTest {
 
     @Test
     public void testSortSimpleName() throws Exception {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         list.add("aaa.z");
         list.add("b");
         list.add(null);
@@ -93,13 +93,13 @@ public class CollectionUtilsTest {
 
         assertTrue(CollectionUtils.splitAll(new HashMap<String, List<String>>(), "-").isEmpty());
 
-        Map<String, List<String>> input = new HashMap<String, List<String>>();
+        Map<String, List<String>> input = new HashMap<>();
         input.put("key1", Arrays.asList("1:a", "2:b", "3:c"));
         input.put("key2", Arrays.asList("1:a", "2:b"));
         input.put("key3", null);
         input.put("key4", new ArrayList<String>());
 
-        Map<String, Map<String, String>> expected = new HashMap<String, Map<String, String>>();
+        Map<String, Map<String, String>> expected = new HashMap<>();
         expected.put("key1", CollectionUtils.toStringMap("1", "a", "2", "b", "3", "c"));
         expected.put("key2", CollectionUtils.toStringMap("1", "a", "2", "b"));
         expected.put("key3", null);
@@ -113,13 +113,13 @@ public class CollectionUtilsTest {
         assertNull(CollectionUtils.joinAll(null, null));
         assertNull(CollectionUtils.joinAll(null, "-"));
 
-        Map<String, List<String>> expected = new HashMap<String, List<String>>();
+        Map<String, List<String>> expected = new HashMap<>();
         expected.put("key1", Arrays.asList("1:a", "2:b", "3:c"));
         expected.put("key2", Arrays.asList("1:a", "2:b"));
         expected.put("key3", null);
         expected.put("key4", new ArrayList<String>());
 
-        Map<String, Map<String, String>> input = new HashMap<String, Map<String, String>>();
+        Map<String, Map<String, String>> input = new HashMap<>();
         input.put("key1", CollectionUtils.toStringMap("1", "a", "2", "b", "3", "c"));
         input.put("key2", CollectionUtils.toStringMap("1", "a", "2", "b"));
         input.put("key3", null);
@@ -171,7 +171,7 @@ public class CollectionUtilsTest {
     public void testToMap1() throws Exception {
         assertTrue(CollectionUtils.toMap().isEmpty());
 
-        Map<String, Integer> expected = new HashMap<String, Integer>();
+        Map<String, Integer> expected = new HashMap<>();
         expected.put("a", 1);
         expected.put("b", 2);
         expected.put("c", 3);

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/CompatibleTypeUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/CompatibleTypeUtilsTest.java
@@ -136,11 +136,11 @@ public class CompatibleTypeUtilsTest {
         }
 
         {
-            List<String> list = new ArrayList<String>();
+            List<String> list = new ArrayList<>();
             list.add("a");
             list.add("b");
 
-            Set<String> set = new HashSet<String>();
+            Set<String> set = new HashSet<>();
             set.add("a");
             set.add("b");
 

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/HolderTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/HolderTest.java
@@ -25,7 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class HolderTest {
     @Test
     public void testSetAndGet() throws Exception {
-        Holder<String> holder = new Holder<String>();
+        Holder<String> holder = new Holder<>();
         String message = "hello";
         holder.set(message);
         assertThat(holder.get(), is(message));

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRUCacheTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRUCacheTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class LRUCacheTest {
     @Test
     public void testCache() throws Exception {
-        LRUCache<String, Integer> cache = new LRUCache<String, Integer>(3);
+        LRUCache<String, Integer> cache = new LRUCache<>(3);
         cache.put("one", 1);
         cache.put("two", 2);
         cache.put("three", 3);
@@ -53,7 +53,7 @@ public class LRUCacheTest {
 
     @Test
     public void testCapacity() throws Exception {
-        LRUCache<String, Integer> cache = new LRUCache<String, Integer>();
+        LRUCache<String, Integer> cache = new LRUCache<>();
         assertThat(cache.getMaxCapacity(), equalTo(1000));
         cache.setMaxCapacity(10);
         assertThat(cache.getMaxCapacity(), equalTo(10));

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ParametersTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/ParametersTest.java
@@ -27,7 +27,7 @@ public class ParametersTest {
     final String LoadBalance = "lcr";
 
     public void testMap2Parameters() throws Exception {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put("name", "org.apache.dubbo.rpc.service.GenericService");
         map.put("version", "1.0.15");
         map.put("lb", "lcr");

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PojoUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/PojoUtilsTest.java
@@ -60,7 +60,7 @@ public class PojoUtilsTest {
         bigPerson.setEmail("abc@123.com");
         bigPerson.setPenName("pname");
 
-        ArrayList<Phone> phones = new ArrayList<Phone>();
+        ArrayList<Phone> phones = new ArrayList<>();
         Phone phone1 = new Phone("86", "0571", "11223344", "001");
         Phone phone2 = new Phone("86", "0571", "11223344", "002");
         phones.add(phone1);
@@ -134,9 +134,9 @@ public class PojoUtilsTest {
 
     @Test
     public void test_Map_List_pojo() throws Exception {
-        Map<String, List<Object>> map = new HashMap<String, List<Object>>();
+        Map<String, List<Object>> map = new HashMap<>();
 
-        List<Object> list = new ArrayList<Object>();
+        List<Object> list = new ArrayList<>();
         list.add(new Person());
         list.add(new SerializablePerson());
 
@@ -224,7 +224,7 @@ public class PojoUtilsTest {
         person1.setName("person1");
         Person person2 = new Person();
         person2.setName("person2");
-        List<Person> list = new LinkedList<Person>();
+        List<Person> list = new LinkedList<>();
         list.add(person1);
         list.add(person2);
         Object o = PojoUtils.realize(PojoUtils.generalize(list), Person[].class);
@@ -309,7 +309,7 @@ public class PojoUtilsTest {
     @Test
     public void test_simpleCollection() throws Exception {
         Type gtype = getType("returnListPersonMethod");
-        List<Person> list = new ArrayList<Person>();
+        List<Person> list = new ArrayList<>();
         list.add(new Person());
         {
             Person person = new Person();
@@ -360,7 +360,7 @@ public class PojoUtilsTest {
 
     @Test
     public void test_Loop_Map() throws Exception {
-        Map<String, Object> map = new HashMap<String, Object>();
+        Map<String, Object> map = new HashMap<>();
 
         map.put("k", "v");
         map.put("m", map);
@@ -388,7 +388,7 @@ public class PojoUtilsTest {
         p.setChild(c);
         c.setParent(p);
 
-        Map<String, Object> map = new HashMap<String, Object>();
+        Map<String, Object> map = new HashMap<>();
         map.put("k", p);
 
         Object generalize = PojoUtils.generalize(map);
@@ -416,7 +416,7 @@ public class PojoUtilsTest {
         p.setChild(c);
         c.setParent(p);
 
-        List<Object> list = new ArrayList<Object>();
+        List<Object> list = new ArrayList<>();
         list.add(p);
 
         Object generalize = PojoUtils.generalize(list);
@@ -441,7 +441,7 @@ public class PojoUtilsTest {
         p.setAge(10);
         p.setName("jerry");
 
-        List<Object> list = new ArrayList<Object>();
+        List<Object> list = new ArrayList<>();
         list.add(p);
 
         Object generalize = PojoUtils.generalize(list);
@@ -575,7 +575,7 @@ public class PojoUtilsTest {
 
     @Test
     public void testRealize() throws Exception {
-        Map<String, String> map = new LinkedHashMap<String, String>();
+        Map<String, String> map = new LinkedHashMap<>();
         map.put("key", "value");
         Object obj = PojoUtils.generalize(map);
         assertTrue(obj instanceof LinkedHashMap);
@@ -588,7 +588,7 @@ public class PojoUtilsTest {
 
     @Test
     public void testRealizeLinkedList() throws Exception {
-        LinkedList<Person> input = new LinkedList<Person>();
+        LinkedList<Person> input = new LinkedList<>();
         Person person = new Person();
         person.setAge(37);
         input.add(person);
@@ -601,8 +601,8 @@ public class PojoUtilsTest {
 
     @Test
     public void testPojoList() throws Exception {
-        ListResult<Parent> result = new ListResult<Parent>();
-        List<Parent> list = new ArrayList<Parent>();
+        ListResult<Parent> result = new ListResult<>();
+        List<Parent> list = new ArrayList<>();
         Parent parent = new Parent();
         parent.setAge(Integer.MAX_VALUE);
         parent.setName("zhangsan");
@@ -623,13 +623,13 @@ public class PojoUtilsTest {
 
     @Test
     public void testListPojoListPojo() throws Exception {
-        InnerPojo<Parent> parentList = new InnerPojo<Parent>();
+        InnerPojo<Parent> parentList = new InnerPojo<>();
         Parent parent = new Parent();
         parent.setName("zhangsan");
         parent.setAge(Integer.MAX_VALUE);
         parentList.setList(Arrays.asList(parent));
 
-        ListResult<InnerPojo<Parent>> list = new ListResult<InnerPojo<Parent>>();
+        ListResult<InnerPojo<Parent>> list = new ListResult<>();
         list.setResult(Arrays.asList(parentList));
 
         Object generializeObject = PojoUtils.generalize(list);
@@ -766,8 +766,8 @@ public class PojoUtilsTest {
     }
 
     public static class TestData {
-        private Map<String, Child> children = new HashMap<String, Child>();
-        private List<Child> list = new ArrayList<Child>();
+        private Map<String, Child> children = new HashMap<>();
+        private List<Child> list = new ArrayList<>();
 
         public List<Child> getList() {
             return list;

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StackTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StackTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class StackTest {
     @Test
     public void testOps() throws Exception {
-        Stack<String> stack = new Stack<String>();
+        Stack<String> stack = new Stack<>();
         stack.push("one");
         assertThat(stack.get(0), equalTo("one"));
         assertThat(stack.peek(), equalTo("one"));
@@ -50,7 +50,7 @@ public class StackTest {
 
     @Test
     public void testClear() throws Exception {
-        Stack<String> stack = new Stack<String>();
+        Stack<String> stack = new Stack<>();
         stack.push("one");
         stack.push("two");
         assertThat(stack.isEmpty(), is(false));
@@ -61,7 +61,7 @@ public class StackTest {
     @Test
     public void testIllegalPop() throws Exception {
         Assertions.assertThrows(EmptyStackException.class, () -> {
-            Stack<String> stack = new Stack<String>();
+            Stack<String> stack = new Stack<>();
             stack.pop();
         });
     }
@@ -69,7 +69,7 @@ public class StackTest {
     @Test
     public void testIllegalPeek() throws Exception {
         Assertions.assertThrows(EmptyStackException.class, () -> {
-            Stack<String> stack = new Stack<String>();
+            Stack<String> stack = new Stack<>();
             stack.peek();
         });
     }
@@ -77,7 +77,7 @@ public class StackTest {
     @Test
     public void testIllegalGet() throws Exception {
         Assertions.assertThrows(IndexOutOfBoundsException.class, () -> {
-            Stack<String> stack = new Stack<String>();
+            Stack<String> stack = new Stack<>();
             stack.get(1);
         });
     }
@@ -85,7 +85,7 @@ public class StackTest {
     @Test
     public void testIllegalSet() throws Exception {
         Assertions.assertThrows(IndexOutOfBoundsException.class, () -> {
-            Stack<String> stack = new Stack<String>();
+            Stack<String> stack = new Stack<>();
             stack.set(1, "illegal");
         });
     }
@@ -93,7 +93,7 @@ public class StackTest {
     @Test
     public void testIllegalRemove() throws Exception {
         Assertions.assertThrows(IndexOutOfBoundsException.class, () -> {
-            Stack<String> stack = new Stack<String>();
+            Stack<String> stack = new Stack<>();
             stack.remove(1);
         });
     }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
@@ -192,7 +192,7 @@ public class StringUtilsTest {
 
     @Test
     public void testGetServiceKey() throws Exception {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put(Constants.GROUP_KEY, "dubbo");
         map.put(Constants.INTERFACE_KEY, "a.b.c.Foo");
         map.put(Constants.VERSION_KEY, "1.0.0");
@@ -201,7 +201,7 @@ public class StringUtilsTest {
 
     @Test
     public void testToQueryString() throws Exception {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put("key1", "value1");
         map.put("key2", "value2");
         String queryString = StringUtils.toQueryString(map);
@@ -247,7 +247,7 @@ public class StringUtilsTest {
 
     @Test
     public void testJoinCollectionString() throws Exception {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         assertEquals("", StringUtils.join(list, ","));
 
         list.add("v1");

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/UrlUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/UrlUtilsTest.java
@@ -77,7 +77,7 @@ public class UrlUtilsTest {
     @Test
     public void testParseFromParameter() {
         String address = "127.0.0.1";
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("username", "root");
         parameters.put("password", "alibaba");
         parameters.put("port", "10000");
@@ -102,7 +102,7 @@ public class UrlUtilsTest {
         String backupAddress1 = "192.168.0.2";
         String backupAddress2 = "192.168.0.3";
 
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("username", "root");
         parameters.put("password", "alibaba");
         parameters.put("port", "10000");
@@ -119,7 +119,7 @@ public class UrlUtilsTest {
     @Test
     public void testParseUrls() {
         String addresses = "192.168.0.1|192.168.0.2|192.168.0.3";
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("username", "root");
         parameters.put("password", "alibaba");
         parameters.put("port", "10000");
@@ -137,7 +137,7 @@ public class UrlUtilsTest {
     @Test
     public void testConvertRegister() {
         String key = "perf/dubbo.test.api.HelloService:1.0.0";
-        Map<String, Map<String, String>> register = new HashMap<String, Map<String, String>>();
+        Map<String, Map<String, String>> register = new HashMap<>();
         register.put(key, null);
         Map<String, Map<String, String>> newRegister = UrlUtils.convertRegister(register);
         assertEquals(register, newRegister);
@@ -146,12 +146,12 @@ public class UrlUtilsTest {
     @Test
     public void testConvertRegister2() {
         String key = "dubbo.test.api.HelloService";
-        Map<String, Map<String, String>> register = new HashMap<String, Map<String, String>>();
-        Map<String, String> service = new HashMap<String, String>();
+        Map<String, Map<String, String>> register = new HashMap<>();
+        Map<String, String> service = new HashMap<>();
         service.put("dubbo://127.0.0.1:20880/com.xxx.XxxService", "version=1.0.0&group=test&dubbo.version=2.0.0");
         register.put(key, service);
         Map<String, Map<String, String>> newRegister = UrlUtils.convertRegister(register);
-        Map<String, String> newService = new HashMap<String, String>();
+        Map<String, String> newService = new HashMap<>();
         newService.put("dubbo://127.0.0.1:20880/com.xxx.XxxService", "dubbo.version=2.0.0&group=test&version=1.0.0");
         assertEquals(newService, newRegister.get("test/dubbo.test.api.HelloService:1.0.0"));
     }
@@ -159,7 +159,7 @@ public class UrlUtilsTest {
     @Test
     public void testSubscribe() {
         String key = "perf/dubbo.test.api.HelloService:1.0.0";
-        Map<String, String> subscribe = new HashMap<String, String>();
+        Map<String, String> subscribe = new HashMap<>();
         subscribe.put(key, null);
         Map<String, String> newSubscribe = UrlUtils.convertSubscribe(subscribe);
         assertEquals(subscribe, newSubscribe);
@@ -168,7 +168,7 @@ public class UrlUtilsTest {
     @Test
     public void testSubscribe2() {
         String key = "dubbo.test.api.HelloService";
-        Map<String, String> subscribe = new HashMap<String, String>();
+        Map<String, String> subscribe = new HashMap<>();
         subscribe.put(key, "version=1.0.0&group=test&dubbo.version=2.0.0");
         Map<String, String> newSubscribe = UrlUtils.convertSubscribe(subscribe);
         assertEquals("dubbo.version=2.0.0&group=test&version=1.0.0", newSubscribe.get("test/dubbo.test.api.HelloService:1.0.0"));
@@ -177,12 +177,12 @@ public class UrlUtilsTest {
     @Test
     public void testRevertRegister() {
         String key = "perf/dubbo.test.api.HelloService:1.0.0";
-        Map<String, Map<String, String>> register = new HashMap<String, Map<String, String>>();
-        Map<String, String> service = new HashMap<String, String>();
+        Map<String, Map<String, String>> register = new HashMap<>();
+        Map<String, String> service = new HashMap<>();
         service.put("dubbo://127.0.0.1:20880/com.xxx.XxxService", null);
         register.put(key, service);
         Map<String, Map<String, String>> newRegister = UrlUtils.revertRegister(register);
-        Map<String, Map<String, String>> expectedRegister = new HashMap<String, Map<String, String>>();
+        Map<String, Map<String, String>> expectedRegister = new HashMap<>();
         service.put("dubbo://127.0.0.1:20880/com.xxx.XxxService", "group=perf&version=1.0.0");
         expectedRegister.put("dubbo.test.api.HelloService", service);
         assertEquals(expectedRegister, newRegister);
@@ -191,12 +191,12 @@ public class UrlUtilsTest {
     @Test
     public void testRevertRegister2() {
         String key = "dubbo.test.api.HelloService";
-        Map<String, Map<String, String>> register = new HashMap<String, Map<String, String>>();
-        Map<String, String> service = new HashMap<String, String>();
+        Map<String, Map<String, String>> register = new HashMap<>();
+        Map<String, String> service = new HashMap<>();
         service.put("dubbo://127.0.0.1:20880/com.xxx.XxxService", null);
         register.put(key, service);
         Map<String, Map<String, String>> newRegister = UrlUtils.revertRegister(register);
-        Map<String, Map<String, String>> expectedRegister = new HashMap<String, Map<String, String>>();
+        Map<String, Map<String, String>> expectedRegister = new HashMap<>();
         service.put("dubbo://127.0.0.1:20880/com.xxx.XxxService", null);
         expectedRegister.put("dubbo.test.api.HelloService", service);
         assertEquals(expectedRegister, newRegister);
@@ -205,10 +205,10 @@ public class UrlUtilsTest {
     @Test
     public void testRevertSubscribe() {
         String key = "perf/dubbo.test.api.HelloService:1.0.0";
-        Map<String, String> subscribe = new HashMap<String, String>();
+        Map<String, String> subscribe = new HashMap<>();
         subscribe.put(key, null);
         Map<String, String> newSubscribe = UrlUtils.revertSubscribe(subscribe);
-        Map<String, String> expectSubscribe = new HashMap<String, String>();
+        Map<String, String> expectSubscribe = new HashMap<>();
         expectSubscribe.put("dubbo.test.api.HelloService", "group=perf&version=1.0.0");
         assertEquals(expectSubscribe, newSubscribe);
     }
@@ -216,7 +216,7 @@ public class UrlUtilsTest {
     @Test
     public void testRevertSubscribe2() {
         String key = "dubbo.test.api.HelloService";
-        Map<String, String> subscribe = new HashMap<String, String>();
+        Map<String, String> subscribe = new HashMap<>();
         subscribe.put(key, null);
         Map<String, String> newSubscribe = UrlUtils.revertSubscribe(subscribe);
         assertEquals(subscribe, newSubscribe);
@@ -225,12 +225,12 @@ public class UrlUtilsTest {
     @Test
     public void testRevertNotify() {
         String key = "dubbo.test.api.HelloService";
-        Map<String, Map<String, String>> notify = new HashMap<String, Map<String, String>>();
-        Map<String, String> service = new HashMap<String, String>();
+        Map<String, Map<String, String>> notify = new HashMap<>();
+        Map<String, String> service = new HashMap<>();
         service.put("dubbo://127.0.0.1:20880/com.xxx.XxxService", "group=perf&version=1.0.0");
         notify.put(key, service);
         Map<String, Map<String, String>> newRegister = UrlUtils.revertNotify(notify);
-        Map<String, Map<String, String>> expectedRegister = new HashMap<String, Map<String, String>>();
+        Map<String, Map<String, String>> expectedRegister = new HashMap<>();
         service.put("dubbo://127.0.0.1:20880/com.xxx.XxxService", "group=perf&version=1.0.0");
         expectedRegister.put("perf/dubbo.test.api.HelloService:1.0.0", service);
         assertEquals(expectedRegister, newRegister);
@@ -239,12 +239,12 @@ public class UrlUtilsTest {
     @Test
     public void testRevertNotify2() {
         String key = "perf/dubbo.test.api.HelloService:1.0.0";
-        Map<String, Map<String, String>> notify = new HashMap<String, Map<String, String>>();
-        Map<String, String> service = new HashMap<String, String>();
+        Map<String, Map<String, String>> notify = new HashMap<>();
+        Map<String, String> service = new HashMap<>();
         service.put("dubbo://127.0.0.1:20880/com.xxx.XxxService", "group=perf&version=1.0.0");
         notify.put(key, service);
         Map<String, Map<String, String>> newRegister = UrlUtils.revertNotify(notify);
-        Map<String, Map<String, String>> expectedRegister = new HashMap<String, Map<String, String>>();
+        Map<String, Map<String, String>> expectedRegister = new HashMap<>();
         service.put("dubbo://127.0.0.1:20880/com.xxx.XxxService", "group=perf&version=1.0.0");
         expectedRegister.put("perf/dubbo.test.api.HelloService:1.0.0", service);
         assertEquals(expectedRegister, newRegister);
@@ -254,12 +254,12 @@ public class UrlUtilsTest {
     @Test
     public void testRevertForbid() {
         String service = "dubbo.test.api.HelloService";
-        List<String> forbid = new ArrayList<String>();
+        List<String> forbid = new ArrayList<>();
         forbid.add(service);
-        Set<URL> subscribed = new HashSet<URL>();
+        Set<URL> subscribed = new HashSet<>();
         subscribed.add(URL.valueOf("dubbo://127.0.0.1:20880/" + service + "?group=perf&version=1.0.0"));
         List<String> newForbid = UrlUtils.revertForbid(forbid, subscribed);
-        List<String> expectForbid = new ArrayList<String>();
+        List<String> expectForbid = new ArrayList<>();
         expectForbid.add("perf/" + service + ":1.0.0");
         assertEquals(expectForbid, newForbid);
     }
@@ -274,7 +274,7 @@ public class UrlUtilsTest {
     public void testRevertForbid3() {
         String service1 = "dubbo.test.api.HelloService:1.0.0";
         String service2 = "dubbo.test.api.HelloService:2.0.0";
-        List<String> forbid = new ArrayList<String>();
+        List<String> forbid = new ArrayList<>();
         forbid.add(service1);
         forbid.add(service2);
         List<String> newForbid = UrlUtils.revertForbid(forbid, null);

--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/cache/support/AbstractCacheFactory.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/cache/support/AbstractCacheFactory.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ConcurrentMap;
 @Deprecated
 public abstract class AbstractCacheFactory implements CacheFactory {
 
-    private final ConcurrentMap<String, Cache> caches = new ConcurrentHashMap<String, Cache>();
+    private final ConcurrentMap<String, Cache> caches = new ConcurrentHashMap<>();
 
     @Override
     public Cache getCache(URL url, Invocation invocation) {

--- a/dubbo-compatible/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/CompatibleReferenceAnnotationBeanPostProcessor.java
+++ b/dubbo-compatible/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/CompatibleReferenceAnnotationBeanPostProcessor.java
@@ -81,10 +81,10 @@ public class CompatibleReferenceAnnotationBeanPostProcessor extends Instantiatio
     private ClassLoader classLoader;
 
     private final ConcurrentMap<String, ReferenceInjectionMetadata> injectionMetadataCache =
-            new ConcurrentHashMap<String, ReferenceInjectionMetadata>(256);
+            new ConcurrentHashMap<>(256);
 
     private final ConcurrentMap<String, ReferenceBean<?>> referenceBeansCache =
-            new ConcurrentHashMap<String, ReferenceBean<?>>();
+            new ConcurrentHashMap<>();
 
     @Override
     public PropertyValues postProcessPropertyValues(
@@ -110,7 +110,7 @@ public class CompatibleReferenceAnnotationBeanPostProcessor extends Instantiatio
      */
     private List<ReferenceFieldElement> findFieldReferenceMetadata(final Class<?> beanClass) {
 
-        final List<ReferenceFieldElement> elements = new LinkedList<ReferenceFieldElement>();
+        final List<ReferenceFieldElement> elements = new LinkedList<>();
 
         ReflectionUtils.doWithFields(beanClass, new ReflectionUtils.FieldCallback() {
             @Override
@@ -145,7 +145,7 @@ public class CompatibleReferenceAnnotationBeanPostProcessor extends Instantiatio
      */
     private List<ReferenceMethodElement> findMethodReferenceMetadata(final Class<?> beanClass) {
 
-        final List<ReferenceMethodElement> elements = new LinkedList<ReferenceMethodElement>();
+        final List<ReferenceMethodElement> elements = new LinkedList<>();
 
         ReflectionUtils.doWithMethods(beanClass, new ReflectionUtils.MethodCallback() {
             @Override
@@ -293,7 +293,7 @@ public class CompatibleReferenceAnnotationBeanPostProcessor extends Instantiatio
         }
 
         private static <T> Collection<T> combine(Collection<? extends T>... elements) {
-            List<T> allElements = new ArrayList<T>();
+            List<T> allElements = new ArrayList<>();
             for (Collection<? extends T> e : elements) {
                 allElements.addAll(e);
             }
@@ -449,7 +449,7 @@ public class CompatibleReferenceAnnotationBeanPostProcessor extends Instantiatio
     public Map<InjectionMetadata.InjectedElement, ReferenceBean<?>> getInjectedFieldReferenceBeanMap() {
 
         Map<InjectionMetadata.InjectedElement, ReferenceBean<?>> injectedElementReferenceBeanMap =
-                new LinkedHashMap<InjectionMetadata.InjectedElement, ReferenceBean<?>>();
+                new LinkedHashMap<>();
 
         for (ReferenceInjectionMetadata metadata : injectionMetadataCache.values()) {
 
@@ -476,7 +476,7 @@ public class CompatibleReferenceAnnotationBeanPostProcessor extends Instantiatio
     public Map<InjectionMetadata.InjectedElement, ReferenceBean<?>> getInjectedMethodReferenceBeanMap() {
 
         Map<InjectionMetadata.InjectedElement, ReferenceBean<?>> injectedElementReferenceBeanMap =
-                new LinkedHashMap<InjectionMetadata.InjectedElement, ReferenceBean<?>>();
+                new LinkedHashMap<>();
 
         for (ReferenceInjectionMetadata metadata : injectionMetadataCache.values()) {
 

--- a/dubbo-compatible/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/CompatibleServiceAnnotationBeanPostProcessor.java
+++ b/dubbo-compatible/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/CompatibleServiceAnnotationBeanPostProcessor.java
@@ -221,7 +221,7 @@ public class CompatibleServiceAnnotationBeanPostProcessor implements BeanDefinit
 
         Set<BeanDefinition> beanDefinitions = scanner.findCandidateComponents(packageToScan);
 
-        Set<BeanDefinitionHolder> beanDefinitionHolders = new LinkedHashSet<BeanDefinitionHolder>(beanDefinitions.size());
+        Set<BeanDefinitionHolder> beanDefinitionHolders = new LinkedHashSet<>(beanDefinitions.size());
 
         for (BeanDefinition beanDefinition : beanDefinitions) {
 
@@ -370,7 +370,7 @@ public class CompatibleServiceAnnotationBeanPostProcessor implements BeanDefinit
     }
 
     private Set<String> resolvePackagesToScan(Set<String> packagesToScan) {
-        Set<String> resolvedPackagesToScan = new LinkedHashSet<String>(packagesToScan.size());
+        Set<String> resolvedPackagesToScan = new LinkedHashSet<>(packagesToScan.size());
         for (String packageToScan : packagesToScan) {
             if (StringUtils.hasText(packageToScan)) {
                 String resolvedPackageToScan = environment.resolvePlaceholders(packageToScan.trim());
@@ -460,7 +460,7 @@ public class CompatibleServiceAnnotationBeanPostProcessor implements BeanDefinit
 
     private ManagedList<RuntimeBeanReference> toRuntimeBeanReferences(String... beanNames) {
 
-        ManagedList<RuntimeBeanReference> runtimeBeanReferences = new ManagedList<RuntimeBeanReference>();
+        ManagedList<RuntimeBeanReference> runtimeBeanReferences = new ManagedList<>();
 
         if (!ObjectUtils.isEmpty(beanNames)) {
 

--- a/dubbo-compatible/src/main/java/org/apache/dubbo/config/spring/context/annotation/CompatibleDubboComponentScanRegistrar.java
+++ b/dubbo-compatible/src/main/java/org/apache/dubbo/config/spring/context/annotation/CompatibleDubboComponentScanRegistrar.java
@@ -96,7 +96,7 @@ public class CompatibleDubboComponentScanRegistrar implements ImportBeanDefiniti
         Class<?>[] basePackageClasses = attributes.getClassArray("basePackageClasses");
         String[] value = attributes.getStringArray("value");
         // Appends value array attributes
-        Set<String> packagesToScan = new LinkedHashSet<String>(Arrays.asList(value));
+        Set<String> packagesToScan = new LinkedHashSet<>(Arrays.asList(value));
         packagesToScan.addAll(Arrays.asList(basePackages));
         for (Class<?> basePackageClass : basePackageClasses) {
             packagesToScan.add(ClassUtils.getPackageName(basePackageClass));

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/cache/MyCache.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/cache/MyCache.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 public class MyCache implements Cache {
 
-    private Map<Object, Object> map = new HashMap<Object, Object>();
+    private Map<Object, Object> map = new HashMap<>();
 
     public MyCache(URL url) {
     }

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/config/ApplicationConfigTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/config/ApplicationConfigTest.java
@@ -45,7 +45,7 @@ public class ApplicationConfigTest {
         assertThat(application.getName(), equalTo("app"));
         application = new ApplicationConfig("app2");
         assertThat(application.getName(), equalTo("app2"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ApplicationConfig.appendParameters(parameters, application);
         assertThat(parameters, hasEntry(Constants.APPLICATION_KEY, "app2"));
     }
@@ -55,7 +55,7 @@ public class ApplicationConfigTest {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setVersion("1.0.0");
         assertThat(application.getVersion(), equalTo("1.0.0"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ApplicationConfig.appendParameters(parameters, application);
         assertThat(parameters, hasEntry("application.version", "1.0.0"));
     }
@@ -139,7 +139,7 @@ public class ApplicationConfigTest {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setDumpDirectory("/dump");
         assertThat(application.getDumpDirectory(), equalTo("/dump"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ApplicationConfig.appendParameters(parameters, application);
         assertThat(parameters, hasEntry(Constants.DUMP_DIRECTORY, "/dump"));
     }
@@ -149,7 +149,7 @@ public class ApplicationConfigTest {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setQosEnable(true);
         assertThat(application.getQosEnable(), is(true));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ApplicationConfig.appendParameters(parameters, application);
         assertThat(parameters, hasEntry(Constants.QOS_ENABLE, "true"));
     }
@@ -166,7 +166,7 @@ public class ApplicationConfigTest {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setQosAcceptForeignIp(true);
         assertThat(application.getQosAcceptForeignIp(), is(true));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ApplicationConfig.appendParameters(parameters, application);
         assertThat(parameters, hasEntry(Constants.ACCEPT_FOREIGN_IP, "true"));
     }
@@ -175,7 +175,7 @@ public class ApplicationConfigTest {
     public void testParameters() throws Exception {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setQosAcceptForeignIp(true);
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("k1", "v1");
         ApplicationConfig.appendParameters(parameters, application);
         assertThat(parameters, hasEntry("k1", "v1"));

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/config/ArgumentConfigTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/config/ArgumentConfigTest.java
@@ -57,7 +57,7 @@ public class ArgumentConfigTest {
         argument.setIndex(1);
         argument.setType("int");
         argument.setCallback(true);
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         AbstractServiceConfig.appendParameters(parameters, argument);
         assertThat(parameters, hasEntry("callback", "true"));
         assertThat(parameters.size(), is(1));

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
@@ -46,7 +46,7 @@ public class MethodConfigTest {
         MethodConfig method = new MethodConfig();
         method.setName("hello");
         assertThat(method.getName(), equalTo("hello"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MethodConfig.appendParameters(parameters, method);
         assertThat(parameters, not(hasKey("name")));
     }
@@ -118,10 +118,10 @@ public class MethodConfigTest {
         MethodConfig method = new MethodConfig();
         method.setOnreturn("on-return-object");
         assertThat(method.getOnreturn(), equalTo((Object) "on-return-object"));
-        Map<String, Object> attribute = new HashMap<String, Object>();
+        Map<String, Object> attribute = new HashMap<>();
         MethodConfig.appendAttributes(attribute, method);
         assertThat(attribute, hasEntry((Object) Constants.ON_RETURN_INSTANCE_KEY, (Object) "on-return-object"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MethodConfig.appendParameters(parameters, method);
         assertThat(parameters.size(), is(0));
     }
@@ -131,10 +131,10 @@ public class MethodConfigTest {
         MethodConfig method = new MethodConfig();
         method.setOnreturnMethod("on-return-method");
         assertThat(method.getOnreturnMethod(), equalTo("on-return-method"));
-        Map<String, Object> attribute = new HashMap<String, Object>();
+        Map<String, Object> attribute = new HashMap<>();
         MethodConfig.appendAttributes(attribute, method);
         assertThat(attribute, hasEntry((Object) Constants.ON_RETURN_METHOD_KEY, (Object) "on-return-method"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MethodConfig.appendParameters(parameters, method);
         assertThat(parameters.size(), is(0));
     }
@@ -144,10 +144,10 @@ public class MethodConfigTest {
         MethodConfig method = new MethodConfig();
         method.setOnthrow("on-throw-object");
         assertThat(method.getOnthrow(), equalTo((Object) "on-throw-object"));
-        Map<String, Object> attribute = new HashMap<String, Object>();
+        Map<String, Object> attribute = new HashMap<>();
         MethodConfig.appendAttributes(attribute, method);
         assertThat(attribute, hasEntry((Object) Constants.ON_THROW_INSTANCE_KEY, (Object) "on-throw-object"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MethodConfig.appendParameters(parameters, method);
         assertThat(parameters.size(), is(0));
     }
@@ -157,10 +157,10 @@ public class MethodConfigTest {
         MethodConfig method = new MethodConfig();
         method.setOnthrowMethod("on-throw-method");
         assertThat(method.getOnthrowMethod(), equalTo("on-throw-method"));
-        Map<String, Object> attribute = new HashMap<String, Object>();
+        Map<String, Object> attribute = new HashMap<>();
         MethodConfig.appendAttributes(attribute, method);
         assertThat(attribute, hasEntry((Object) Constants.ON_THROW_METHOD_KEY, (Object) "on-throw-method"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MethodConfig.appendParameters(parameters, method);
         assertThat(parameters.size(), is(0));
     }
@@ -170,10 +170,10 @@ public class MethodConfigTest {
         MethodConfig method = new MethodConfig();
         method.setOninvoke("on-invoke-object");
         assertThat(method.getOninvoke(), equalTo((Object) "on-invoke-object"));
-        Map<String, Object> attribute = new HashMap<String, Object>();
+        Map<String, Object> attribute = new HashMap<>();
         MethodConfig.appendAttributes(attribute, method);
         assertThat(attribute, hasEntry((Object) Constants.ON_INVOKE_INSTANCE_KEY, (Object) "on-invoke-object"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MethodConfig.appendParameters(parameters, method);
         assertThat(parameters.size(), is(0));
     }
@@ -183,10 +183,10 @@ public class MethodConfigTest {
         MethodConfig method = new MethodConfig();
         method.setOninvokeMethod("on-invoke-method");
         assertThat(method.getOninvokeMethod(), equalTo("on-invoke-method"));
-        Map<String, Object> attribute = new HashMap<String, Object>();
+        Map<String, Object> attribute = new HashMap<>();
         MethodConfig.appendAttributes(attribute, method);
         assertThat(attribute, hasEntry((Object) Constants.ON_INVOKE_METHOD_KEY, (Object) "on-invoke-method"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MethodConfig.appendParameters(parameters, method);
         assertThat(parameters.size(), is(0));
     }

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/config/ModuleConfigTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/config/ModuleConfigTest.java
@@ -40,7 +40,7 @@ public class ModuleConfigTest {
     public void testName1() throws Exception {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             ModuleConfig module = new ModuleConfig();
-            Map<String, String> parameters = new HashMap<String, String>();
+            Map<String, String> parameters = new HashMap<>();
             ModuleConfig.appendParameters(parameters, module);
         });
     }
@@ -51,7 +51,7 @@ public class ModuleConfigTest {
         module.setName("module-name");
         assertThat(module.getName(), equalTo("module-name"));
         assertThat(module.getId(), equalTo("module-name"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ModuleConfig.appendParameters(parameters, module);
         assertThat(parameters, hasEntry("module", "module-name"));
     }
@@ -62,7 +62,7 @@ public class ModuleConfigTest {
         module.setName("module-name");
         module.setVersion("1.0.0");
         assertThat(module.getVersion(), equalTo("1.0.0"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ModuleConfig.appendParameters(parameters, module);
         assertThat(parameters, hasEntry("module.version", "1.0.0"));
     }

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/config/ProtocolConfigTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/config/ProtocolConfigTest.java
@@ -36,7 +36,7 @@ public class ProtocolConfigTest {
     public void testName() throws Exception {
         ProtocolConfig protocol = new ProtocolConfig();
         protocol.setName("name");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProtocolConfig.appendParameters(parameters, protocol);
         assertThat(protocol.getName(), equalTo("name"));
         assertThat(protocol.getId(), equalTo("name"));
@@ -47,7 +47,7 @@ public class ProtocolConfigTest {
     public void testHost() throws Exception {
         ProtocolConfig protocol = new ProtocolConfig();
         protocol.setHost("host");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProtocolConfig.appendParameters(parameters, protocol);
         assertThat(protocol.getHost(), equalTo("host"));
         assertThat(parameters.isEmpty(), is(true));
@@ -57,7 +57,7 @@ public class ProtocolConfigTest {
     public void testPort() throws Exception {
         ProtocolConfig protocol = new ProtocolConfig();
         protocol.setPort(8080);
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProtocolConfig.appendParameters(parameters, protocol);
         assertThat(protocol.getPort(), equalTo(8080));
         assertThat(parameters.isEmpty(), is(true));
@@ -67,7 +67,7 @@ public class ProtocolConfigTest {
     public void testPath() throws Exception {
         ProtocolConfig protocol = new ProtocolConfig();
         protocol.setContextpath("context-path");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProtocolConfig.appendParameters(parameters, protocol);
         assertThat(protocol.getPath(), equalTo("context-path"));
         assertThat(protocol.getContextpath(), equalTo("context-path"));

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/config/ProviderConfigTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/config/ProviderConfigTest.java
@@ -43,7 +43,7 @@ public class ProviderConfigTest {
     public void testDefault() throws Exception {
         ProviderConfig provider = new ProviderConfig();
         provider.setDefault(true);
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProviderConfig.appendParameters(parameters, provider);
         assertThat(provider.isDefault(), is(true));
         assertThat(parameters, not(hasKey("default")));
@@ -53,7 +53,7 @@ public class ProviderConfigTest {
     public void testHost() throws Exception {
         ProviderConfig provider = new ProviderConfig();
         provider.setHost("demo-host");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProviderConfig.appendParameters(parameters, provider);
         assertThat(provider.getHost(), equalTo("demo-host"));
         assertThat(parameters, not(hasKey("host")));
@@ -63,7 +63,7 @@ public class ProviderConfigTest {
     public void testPort() throws Exception {
         ProviderConfig provider = new ProviderConfig();
         provider.setPort(8080);
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProviderConfig.appendParameters(parameters, provider);
         assertThat(provider.getPort(), is(8080));
         assertThat(parameters, not(hasKey("port")));
@@ -73,7 +73,7 @@ public class ProviderConfigTest {
     public void testPath() throws Exception {
         ProviderConfig provider = new ProviderConfig();
         provider.setPath("/path");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProviderConfig.appendParameters(parameters, provider);
         assertThat(provider.getPath(), equalTo("/path"));
         assertThat(provider.getContextpath(), equalTo("/path"));
@@ -84,7 +84,7 @@ public class ProviderConfigTest {
     public void testContextPath() throws Exception {
         ProviderConfig provider = new ProviderConfig();
         provider.setContextpath("/context-path");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProviderConfig.appendParameters(parameters, provider);
         assertThat(provider.getContextpath(), equalTo("/context-path"));
         assertThat(parameters, not(hasKey("/context-path")));
@@ -158,7 +158,7 @@ public class ProviderConfigTest {
     public void testPrompt() throws Exception {
         ProviderConfig provider = new ProviderConfig();
         provider.setPrompt("#");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProviderConfig.appendParameters(parameters, provider);
         assertThat(provider.getPrompt(), equalTo("#"));
         assertThat(parameters, hasEntry("prompt", "%23"));

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
@@ -55,14 +55,14 @@ public class ReferenceConfigTest {
         protocol.setName("dubbo");
 
         ServiceConfig<DemoService> demoService;
-        demoService = new ServiceConfig<DemoService>();
+        demoService = new ServiceConfig<>();
         demoService.setInterface(DemoService.class);
         demoService.setRef(new DemoServiceImpl());
         demoService.setApplication(application);
         demoService.setRegistry(registry);
         demoService.setProtocol(protocol);
 
-        ReferenceConfig<DemoService> rc = new ReferenceConfig<DemoService>();
+        ReferenceConfig<DemoService> rc = new ReferenceConfig<>();
         rc.setApplication(application);
         rc.setRegistry(registry);
         rc.setInterface(DemoService.class.getName());

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/config/RegistryConfigTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/config/RegistryConfigTest.java
@@ -46,7 +46,7 @@ public class RegistryConfigTest {
         RegistryConfig registry = new RegistryConfig();
         registry.setAddress("localhost");
         assertThat(registry.getAddress(), equalTo("localhost"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         RegistryConfig.appendParameters(parameters, registry);
         assertThat(parameters, not(hasKey("address")));
     }
@@ -162,7 +162,7 @@ public class RegistryConfigTest {
         RegistryConfig registry = new RegistryConfig();
         registry.setParameters(Collections.singletonMap("k1", "v1"));
         assertThat(registry.getParameters(), hasEntry("k1", "v1"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         RegistryConfig.appendParameters(parameters, registry);
         assertThat(parameters, hasEntry("k1", "v1"));
     }

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/filter/FilterTest.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/filter/FilterTest.java
@@ -37,7 +37,7 @@ public class FilterTest {
     @Test
     public void testInvokeException() {
         try {
-            Invoker<FilterTest> invoker = new MyInvoker<FilterTest>(null);
+            Invoker<FilterTest> invoker = new MyInvoker<>(null);
             Invocation invocation = new MockInvocation("aa");
             myFilter.invoke(invoker, invocation);
             fail();
@@ -48,7 +48,7 @@ public class FilterTest {
 
     @Test
     public void testDefault() {
-        Invoker<FilterTest> invoker = new MyInvoker<FilterTest>(null);
+        Invoker<FilterTest> invoker = new MyInvoker<>(null);
         Invocation invocation = new MockInvocation("bbb");
         Result res = myFilter.invoke(invoker, invocation);
         System.out.println(res);

--- a/dubbo-compatible/src/test/java/org/apache/dubbo/service/MockInvocation.java
+++ b/dubbo-compatible/src/test/java/org/apache/dubbo/service/MockInvocation.java
@@ -47,7 +47,7 @@ public class MockInvocation implements Invocation {
     }
 
     public Map<String, String> getAttachments() {
-        Map<String, String> attachments = new HashMap<String, String>();
+        Map<String, String> attachments = new HashMap<>();
         attachments.put(Constants.PATH_KEY, "dubbo");
         attachments.put(Constants.GROUP_KEY, "dubbo");
         attachments.put(Constants.VERSION_KEY, "1.0.0");

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractConfig.java
@@ -94,7 +94,7 @@ public abstract class AbstractConfig implements Serializable {
     /**
      * The legacy properties container
      */
-    private static final Map<String, String> legacyProperties = new HashMap<String, String>();
+    private static final Map<String, String> legacyProperties = new HashMap<>();
 
     /**
      * The suffix container

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -286,7 +286,7 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
      */
     protected List<URL> loadRegistries(boolean provider) {
         // check && override if necessary
-        List<URL> registryList = new ArrayList<URL>();
+        List<URL> registryList = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(registries)) {
             for (RegistryConfig config : registries) {
                 String address = config.getAddress();
@@ -294,7 +294,7 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
                     address = Constants.ANYHOST_VALUE;
                 }
                 if (!RegistryConfig.NO_AVAILABLE.equalsIgnoreCase(address)) {
-                    Map<String, String> map = new HashMap<String, String>();
+                    Map<String, String> map = new HashMap<>();
                     appendParameters(map, application);
                     appendParameters(map, config);
                     map.put("path", RegistryService.class.getName());
@@ -327,7 +327,7 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
      */
     protected URL loadMonitor(URL registryURL) {
         checkMonitor();
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put(Constants.INTERFACE_KEY, MonitorService.class.getName());
         appendRuntimeParameters(map);
         //set ip
@@ -375,7 +375,7 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
         if (StringUtils.isEmpty(address)) {
             return null;
         }
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         appendParameters(map, metadataReportConfig);
         return UrlUtils.parseURL(address, map);
     }
@@ -551,7 +551,7 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
         if (registries == null || registries.isEmpty()) {
             String address = ConfigUtils.getProperty("dubbo.registry.address");
             if (address != null && address.length() > 0) {
-                List<RegistryConfig> tmpRegistries = new ArrayList<RegistryConfig>();
+                List<RegistryConfig> tmpRegistries = new ArrayList<>();
                 String[] as = address.split("\\s*[|]+\\s*");
                 for (String a : as) {
                     RegistryConfig registryConfig = new RegistryConfig();
@@ -727,7 +727,7 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
     }
 
     public void setRegistry(RegistryConfig registry) {
-        List<RegistryConfig> registries = new ArrayList<RegistryConfig>(1);
+        List<RegistryConfig> registries = new ArrayList<>(1);
         registries.add(registry);
         setRegistries(registries);
     }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
@@ -207,7 +207,7 @@ public class ApplicationConfig extends AbstractConfig {
     }
 
     public void setRegistry(RegistryConfig registry) {
-        List<RegistryConfig> registries = new ArrayList<RegistryConfig>(1);
+        List<RegistryConfig> registries = new ArrayList<>(1);
         registries.add(registry);
         this.registries = registries;
     }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ModuleConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ModuleConfig.java
@@ -120,7 +120,7 @@ public class ModuleConfig extends AbstractConfig {
     }
 
     public void setRegistry(RegistryConfig registry) {
-        List<RegistryConfig> registries = new ArrayList<RegistryConfig>(1);
+        List<RegistryConfig> registries = new ArrayList<>(1);
         registries.add(registry);
         this.registries = registries;
     }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -96,7 +96,7 @@ public class ReferenceConfig<T> extends AbstractReferenceConfig {
     /**
      * The url of the reference service
      */
-    private final List<URL> urls = new ArrayList<URL>();
+    private final List<URL> urls = new ArrayList<>();
 
     /**
      * The interface name of the reference service
@@ -256,7 +256,7 @@ public class ReferenceConfig<T> extends AbstractReferenceConfig {
         initialized = true;
         checkStubAndLocal(interfaceClass);
         checkMock(interfaceClass);
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
 
         map.put(Constants.SIDE_KEY, Constants.CONSUMER_SIDE);
         appendRuntimeParameters(map);
@@ -281,7 +281,7 @@ public class ReferenceConfig<T> extends AbstractReferenceConfig {
         appendParameters(map, this);
         Map<String, Object> attributes = null;
         if (CollectionUtils.isNotEmpty(methods)) {
-            attributes = new HashMap<String, Object>();
+            attributes = new HashMap<>();
             for (MethodConfig methodConfig : methods) {
                 appendParameters(map, methodConfig, methodConfig.getName());
                 String retryKey = methodConfig.getName() + ".retry";
@@ -366,7 +366,7 @@ public class ReferenceConfig<T> extends AbstractReferenceConfig {
             if (urls.size() == 1) {
                 invoker = refprotocol.refer(interfaceClass, urls.get(0));
             } else {
-                List<Invoker<?>> invokers = new ArrayList<Invoker<?>>();
+                List<Invoker<?>> invokers = new ArrayList<>();
                 URL registryURL = null;
                 for (URL url : urls) {
                     invokers.add(refprotocol.refer(interfaceClass, url));

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -100,7 +100,7 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
     /**
      * A random port cache, the different protocols who has no port specified have different random port
      */
-    private static final Map<String, Integer> RANDOM_PORT_MAP = new HashMap<String, Integer>();
+    private static final Map<String, Integer> RANDOM_PORT_MAP = new HashMap<>();
 
     /**
      * A delayed exposure service timer
@@ -110,12 +110,12 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
     /**
      * The urls of the services exported
      */
-    private final List<URL> urls = new ArrayList<URL>();
+    private final List<URL> urls = new ArrayList<>();
 
     /**
      * The exported services
      */
-    private final List<Exporter<?>> exporters = new ArrayList<Exporter<?>>();
+    private final List<Exporter<?>> exporters = new ArrayList<>();
 
     /**
      * The interface name of the exported service
@@ -179,7 +179,7 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
         if (CollectionUtils.isEmpty(providers)) {
             return null;
         }
-        List<ProtocolConfig> protocols = new ArrayList<ProtocolConfig>(providers.size());
+        List<ProtocolConfig> protocols = new ArrayList<>(providers.size());
         for (ProviderConfig provider : providers) {
             protocols.add(convertProviderToProtocol(provider));
         }
@@ -191,7 +191,7 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
         if (CollectionUtils.isEmpty(protocols)) {
             return null;
         }
-        List<ProviderConfig> providers = new ArrayList<ProviderConfig>(protocols.size());
+        List<ProviderConfig> providers = new ArrayList<>(protocols.size());
         for (ProtocolConfig provider : protocols) {
             providers.add(convertProtocolToProvider(provider));
         }
@@ -410,7 +410,7 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
             name = Constants.DUBBO;
         }
 
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put(Constants.SIDE_KEY, Constants.PROVIDER_SIDE);
         appendRuntimeParameters(map);
         appendParameters(map, application);

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ReferenceConfigCache.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/utils/ReferenceConfigCache.java
@@ -62,10 +62,10 @@ public class ReferenceConfigCache {
             return ret.toString();
         }
     };
-    static final ConcurrentMap<String, ReferenceConfigCache> cacheHolder = new ConcurrentHashMap<String, ReferenceConfigCache>();
+    static final ConcurrentMap<String, ReferenceConfigCache> cacheHolder = new ConcurrentHashMap<>();
     private final String name;
     private final KeyGenerator generator;
-    ConcurrentMap<String, ReferenceConfig<?>> cache = new ConcurrentHashMap<String, ReferenceConfig<?>>();
+    ConcurrentMap<String, ReferenceConfig<?>> cache = new ConcurrentHashMap<>();
 
     private ReferenceConfigCache(String name, KeyGenerator generator) {
         this.name = name;
@@ -137,7 +137,7 @@ public class ReferenceConfigCache {
      * clear and destroy all {@link ReferenceConfig} in the cache.
      */
     public void destroyAll() {
-        Set<String> set = new HashSet<String>(cache.keySet());
+        Set<String> set = new HashSet<>(cache.keySet());
         for (String key : set) {
             destroyKey(key);
         }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractConfigTest.java
@@ -106,7 +106,7 @@ public class AbstractConfigTest {
 
     @Test
     public void testAppendParameters1() throws Exception {
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("default.num", "one");
         parameters.put("num", "ONE");
         AbstractConfig.appendParameters(parameters, new ParameterConfig(1, "hello/world", 30, "password"), "prefix");
@@ -122,21 +122,21 @@ public class AbstractConfigTest {
     @Test
     public void testAppendParameters2() throws Exception {
         Assertions.assertThrows(IllegalStateException.class, () -> {
-            Map<String, String> parameters = new HashMap<String, String>();
+            Map<String, String> parameters = new HashMap<>();
             AbstractConfig.appendParameters(parameters, new ParameterConfig());
         });
     }
 
     @Test
     public void testAppendParameters3() throws Exception {
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         AbstractConfig.appendParameters(parameters, null);
         assertTrue(parameters.isEmpty());
     }
 
     @Test
     public void testAppendParameters4() throws Exception {
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         AbstractConfig.appendParameters(parameters, new ParameterConfig(1, "hello/world", 30, "password"));
         Assertions.assertEquals("one", parameters.get("key.1"));
         Assertions.assertEquals("two", parameters.get("key.2"));
@@ -147,7 +147,7 @@ public class AbstractConfigTest {
 
     @Test
     public void testAppendAttributes1() throws Exception {
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         AbstractConfig.appendAttributes(parameters, new AttributeConfig('l', true, (byte) 0x01), "prefix");
         Assertions.assertEquals('l', parameters.get("prefix.let"));
         Assertions.assertEquals(true, parameters.get("prefix.activate"));
@@ -156,7 +156,7 @@ public class AbstractConfigTest {
 
     @Test
     public void testAppendAttributes2() throws Exception {
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         AbstractConfig.appendAttributes(parameters, new AttributeConfig('l', true, (byte) 0x01));
         Assertions.assertEquals('l', parameters.get("let"));
         Assertions.assertEquals(true, parameters.get("activate"));
@@ -685,7 +685,7 @@ public class AbstractConfigTest {
         }
 
         public Map getParameters() {
-            Map<String, String> map = new HashMap<String, String>();
+            Map<String, String> map = new HashMap<>();
             map.put("key.1", "one");
             map.put("key-2", "two");
             return map;

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractMethodConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractMethodConfigTest.java
@@ -114,7 +114,7 @@ public class AbstractMethodConfigTest {
     @Test
     public void testParameters() throws Exception {
         MethodConfig methodConfig = new MethodConfig();
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("key", "value");
         methodConfig.setParameters(parameters);
         assertThat(methodConfig.getParameters(), sameInstance(parameters));

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractReferenceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractReferenceConfigTest.java
@@ -51,7 +51,7 @@ public class AbstractReferenceConfigTest {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setGeneric(true);
         assertThat(referenceConfig.isGeneric(), is(true));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         AbstractInterfaceConfig.appendParameters(parameters, referenceConfig);
         // FIXME: not sure why AbstractReferenceConfig has both isGeneric and getGeneric
         assertThat(parameters, hasKey("generic"));
@@ -69,7 +69,7 @@ public class AbstractReferenceConfigTest {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setFilter("mockfilter");
         assertThat(referenceConfig.getFilter(), equalTo("mockfilter"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put(Constants.REFERENCE_FILTER_KEY, "prefilter");
         AbstractInterfaceConfig.appendParameters(parameters, referenceConfig);
         assertThat(parameters, hasValue("prefilter,mockfilter"));
@@ -80,7 +80,7 @@ public class AbstractReferenceConfigTest {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setListener("mockinvokerlistener");
         assertThat(referenceConfig.getListener(), equalTo("mockinvokerlistener"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put(Constants.INVOKER_LISTENER_KEY, "prelistener");
         AbstractInterfaceConfig.appendParameters(parameters, referenceConfig);
         assertThat(parameters, hasValue("prelistener,mockinvokerlistener"));
@@ -113,7 +113,7 @@ public class AbstractReferenceConfigTest {
     public void testStubevent() throws Exception {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setOnconnect("onConnect");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         AbstractInterfaceConfig.appendParameters(parameters, referenceConfig);
         assertThat(parameters, hasKey(Constants.STUB_EVENT_KEY));
     }
@@ -122,7 +122,7 @@ public class AbstractReferenceConfigTest {
     public void testReconnect() throws Exception {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setReconnect("reconnect");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         AbstractInterfaceConfig.appendParameters(parameters, referenceConfig);
         assertThat(referenceConfig.getReconnect(), equalTo("reconnect"));
         assertThat(parameters, hasKey(Constants.RECONNECT_KEY));
@@ -132,7 +132,7 @@ public class AbstractReferenceConfigTest {
     public void testSticky() throws Exception {
         ReferenceConfig referenceConfig = new ReferenceConfig();
         referenceConfig.setSticky(true);
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         AbstractInterfaceConfig.appendParameters(parameters, referenceConfig);
         assertThat(referenceConfig.getSticky(), is(true));
         assertThat(parameters, hasKey(Constants.CLUSTER_STICKY_KEY));

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractServiceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractServiceConfigTest.java
@@ -74,7 +74,7 @@ public class AbstractServiceConfigTest {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setDocument("http://dubbo.io");
         assertThat(serviceConfig.getDocument(), equalTo("http://dubbo.io"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         AbstractServiceConfig.appendParameters(parameters, serviceConfig);
         assertThat(parameters, hasEntry("document", "http%3A%2F%2Fdubbo.io"));
     }
@@ -137,7 +137,7 @@ public class AbstractServiceConfigTest {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setFilter("mockfilter");
         assertThat(serviceConfig.getFilter(), equalTo("mockfilter"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put(Constants.SERVICE_FILTER_KEY, "prefilter");
         AbstractServiceConfig.appendParameters(parameters, serviceConfig);
         assertThat(parameters, hasEntry(Constants.SERVICE_FILTER_KEY, "prefilter,mockfilter"));
@@ -148,7 +148,7 @@ public class AbstractServiceConfigTest {
         ServiceConfig serviceConfig = new ServiceConfig();
         serviceConfig.setListener("mockexporterlistener");
         assertThat(serviceConfig.getListener(), equalTo("mockexporterlistener"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put(Constants.EXPORTER_LISTENER_KEY, "prelistener");
         AbstractServiceConfig.appendParameters(parameters, serviceConfig);
         assertThat(parameters, hasEntry(Constants.EXPORTER_LISTENER_KEY, "prelistener,mockexporterlistener"));

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ApplicationConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ApplicationConfigTest.java
@@ -42,7 +42,7 @@ public class ApplicationConfigTest {
         assertThat(application.getName(), equalTo("app"));
         application = new ApplicationConfig("app2");
         assertThat(application.getName(), equalTo("app2"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ApplicationConfig.appendParameters(parameters, application);
         assertThat(parameters, hasEntry(Constants.APPLICATION_KEY, "app2"));
     }
@@ -52,7 +52,7 @@ public class ApplicationConfigTest {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setVersion("1.0.0");
         assertThat(application.getVersion(), equalTo("1.0.0"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ApplicationConfig.appendParameters(parameters, application);
         assertThat(parameters, hasEntry("application.version", "1.0.0"));
     }
@@ -136,7 +136,7 @@ public class ApplicationConfigTest {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setDumpDirectory("/dump");
         assertThat(application.getDumpDirectory(), equalTo("/dump"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ApplicationConfig.appendParameters(parameters, application);
         assertThat(parameters, hasEntry(Constants.DUMP_DIRECTORY, "/dump"));
     }
@@ -146,7 +146,7 @@ public class ApplicationConfigTest {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setQosEnable(true);
         assertThat(application.getQosEnable(), is(true));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ApplicationConfig.appendParameters(parameters, application);
         assertThat(parameters, hasEntry(Constants.QOS_ENABLE, "true"));
     }
@@ -163,7 +163,7 @@ public class ApplicationConfigTest {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setQosAcceptForeignIp(true);
         assertThat(application.getQosAcceptForeignIp(), is(true));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ApplicationConfig.appendParameters(parameters, application);
         assertThat(parameters, hasEntry(Constants.ACCEPT_FOREIGN_IP, "true"));
     }
@@ -172,7 +172,7 @@ public class ApplicationConfigTest {
     public void testParameters() throws Exception {
         ApplicationConfig application = new ApplicationConfig("app");
         application.setQosAcceptForeignIp(true);
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("k1", "v1");
         ApplicationConfig.appendParameters(parameters, application);
         assertThat(parameters, hasEntry("k1", "v1"));

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ArgumentConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ArgumentConfigTest.java
@@ -55,7 +55,7 @@ public class ArgumentConfigTest {
         argument.setIndex(1);
         argument.setType("int");
         argument.setCallback(true);
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         AbstractServiceConfig.appendParameters(parameters, argument);
         assertThat(parameters, hasEntry("callback", "true"));
         assertThat(parameters.size(), is(1));

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/MethodConfigTest.java
@@ -40,7 +40,7 @@ public class MethodConfigTest {
         MethodConfig method = new MethodConfig();
         method.setName("hello");
         assertThat(method.getName(), equalTo("hello"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MethodConfig.appendParameters(parameters, method);
         assertThat(parameters, not(hasKey("name")));
     }
@@ -101,10 +101,10 @@ public class MethodConfigTest {
         MethodConfig method = new MethodConfig();
         method.setOnreturn("on-return-object");
         assertThat(method.getOnreturn(), equalTo((Object) "on-return-object"));
-        Map<String, Object> attribute = new HashMap<String, Object>();
+        Map<String, Object> attribute = new HashMap<>();
         MethodConfig.appendAttributes(attribute, method);
         assertThat(attribute, hasEntry((Object) Constants.ON_RETURN_INSTANCE_KEY, (Object) "on-return-object"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MethodConfig.appendParameters(parameters, method);
         assertThat(parameters.size(), is(0));
     }
@@ -114,10 +114,10 @@ public class MethodConfigTest {
         MethodConfig method = new MethodConfig();
         method.setOnreturnMethod("on-return-method");
         assertThat(method.getOnreturnMethod(), equalTo("on-return-method"));
-        Map<String, Object> attribute = new HashMap<String, Object>();
+        Map<String, Object> attribute = new HashMap<>();
         MethodConfig.appendAttributes(attribute, method);
         assertThat(attribute, hasEntry((Object) Constants.ON_RETURN_METHOD_KEY, (Object) "on-return-method"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MethodConfig.appendParameters(parameters, method);
         assertThat(parameters.size(), is(0));
     }
@@ -127,10 +127,10 @@ public class MethodConfigTest {
         MethodConfig method = new MethodConfig();
         method.setOnthrow("on-throw-object");
         assertThat(method.getOnthrow(), equalTo((Object) "on-throw-object"));
-        Map<String, Object> attribute = new HashMap<String, Object>();
+        Map<String, Object> attribute = new HashMap<>();
         MethodConfig.appendAttributes(attribute, method);
         assertThat(attribute, hasEntry((Object) Constants.ON_THROW_INSTANCE_KEY, (Object) "on-throw-object"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MethodConfig.appendParameters(parameters, method);
         assertThat(parameters.size(), is(0));
     }
@@ -140,10 +140,10 @@ public class MethodConfigTest {
         MethodConfig method = new MethodConfig();
         method.setOnthrowMethod("on-throw-method");
         assertThat(method.getOnthrowMethod(), equalTo("on-throw-method"));
-        Map<String, Object> attribute = new HashMap<String, Object>();
+        Map<String, Object> attribute = new HashMap<>();
         MethodConfig.appendAttributes(attribute, method);
         assertThat(attribute, hasEntry((Object) Constants.ON_THROW_METHOD_KEY, (Object) "on-throw-method"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MethodConfig.appendParameters(parameters, method);
         assertThat(parameters.size(), is(0));
     }
@@ -153,10 +153,10 @@ public class MethodConfigTest {
         MethodConfig method = new MethodConfig();
         method.setOninvoke("on-invoke-object");
         assertThat(method.getOninvoke(), equalTo((Object) "on-invoke-object"));
-        Map<String, Object> attribute = new HashMap<String, Object>();
+        Map<String, Object> attribute = new HashMap<>();
         MethodConfig.appendAttributes(attribute, method);
         assertThat(attribute, hasEntry((Object) Constants.ON_INVOKE_INSTANCE_KEY, (Object) "on-invoke-object"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MethodConfig.appendParameters(parameters, method);
         assertThat(parameters.size(), is(0));
     }
@@ -166,10 +166,10 @@ public class MethodConfigTest {
         MethodConfig method = new MethodConfig();
         method.setOninvokeMethod("on-invoke-method");
         assertThat(method.getOninvokeMethod(), equalTo("on-invoke-method"));
-        Map<String, Object> attribute = new HashMap<String, Object>();
+        Map<String, Object> attribute = new HashMap<>();
         MethodConfig.appendAttributes(attribute, method);
         assertThat(attribute, hasEntry((Object) Constants.ON_INVOKE_METHOD_KEY, (Object) "on-invoke-method"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MethodConfig.appendParameters(parameters, method);
         assertThat(parameters.size(), is(0));
     }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ModuleConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ModuleConfigTest.java
@@ -37,7 +37,7 @@ public class ModuleConfigTest {
     public void testName1() {
         Assertions.assertThrows(IllegalStateException.class, () -> {
             ModuleConfig module = new ModuleConfig();
-            Map<String, String> parameters = new HashMap<String, String>();
+            Map<String, String> parameters = new HashMap<>();
             ModuleConfig.appendParameters(parameters, module);
         });
 
@@ -49,7 +49,7 @@ public class ModuleConfigTest {
         module.setName("module-name");
         assertThat(module.getName(), equalTo("module-name"));
         assertThat(module.getId(), equalTo("module-name"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ModuleConfig.appendParameters(parameters, module);
         assertThat(parameters, hasEntry("module", "module-name"));
     }
@@ -60,7 +60,7 @@ public class ModuleConfigTest {
         module.setName("module-name");
         module.setVersion("1.0.0");
         assertThat(module.getVersion(), equalTo("1.0.0"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ModuleConfig.appendParameters(parameters, module);
         assertThat(parameters, hasEntry("module.version", "1.0.0"));
     }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/MonitorConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/MonitorConfigTest.java
@@ -34,7 +34,7 @@ public class MonitorConfigTest {
         MonitorConfig monitor = new MonitorConfig();
         monitor.setAddress("monitor-addr");
         assertThat(monitor.getAddress(), equalTo("monitor-addr"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MonitorConfig.appendParameters(parameters, monitor);
         assertThat(parameters.isEmpty(), is(true));
     }
@@ -44,7 +44,7 @@ public class MonitorConfigTest {
         MonitorConfig monitor = new MonitorConfig();
         monitor.setProtocol("protocol");
         assertThat(monitor.getProtocol(), equalTo("protocol"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MonitorConfig.appendParameters(parameters, monitor);
         assertThat(parameters.isEmpty(), is(true));
     }
@@ -54,7 +54,7 @@ public class MonitorConfigTest {
         MonitorConfig monitor = new MonitorConfig();
         monitor.setUsername("user");
         assertThat(monitor.getUsername(), equalTo("user"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MonitorConfig.appendParameters(parameters, monitor);
         assertThat(parameters.isEmpty(), is(true));
     }
@@ -64,7 +64,7 @@ public class MonitorConfigTest {
         MonitorConfig monitor = new MonitorConfig();
         monitor.setPassword("secret");
         assertThat(monitor.getPassword(), equalTo("secret"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         MonitorConfig.appendParameters(parameters, monitor);
         assertThat(parameters.isEmpty(), is(true));
     }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ProtocolConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ProtocolConfigTest.java
@@ -48,7 +48,7 @@ public class ProtocolConfigTest {
     public void testName() throws Exception {
         ProtocolConfig protocol = new ProtocolConfig();
         protocol.setName("name");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProtocolConfig.appendParameters(parameters, protocol);
         assertThat(protocol.getName(), equalTo("name"));
         assertThat(protocol.getId(), equalTo("name"));
@@ -59,7 +59,7 @@ public class ProtocolConfigTest {
     public void testHost() throws Exception {
         ProtocolConfig protocol = new ProtocolConfig();
         protocol.setHost("host");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProtocolConfig.appendParameters(parameters, protocol);
         assertThat(protocol.getHost(), equalTo("host"));
         assertThat(parameters.isEmpty(), is(true));
@@ -69,7 +69,7 @@ public class ProtocolConfigTest {
     public void testPort() throws Exception {
         ProtocolConfig protocol = new ProtocolConfig();
         protocol.setPort(8080);
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProtocolConfig.appendParameters(parameters, protocol);
         assertThat(protocol.getPort(), equalTo(8080));
         assertThat(parameters.isEmpty(), is(true));
@@ -79,7 +79,7 @@ public class ProtocolConfigTest {
     public void testPath() throws Exception {
         ProtocolConfig protocol = new ProtocolConfig();
         protocol.setContextpath("context-path");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProtocolConfig.appendParameters(parameters, protocol);
         assertThat(protocol.getPath(), equalTo("context-path"));
         assertThat(protocol.getContextpath(), equalTo("context-path"));

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ProviderConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ProviderConfigTest.java
@@ -41,7 +41,7 @@ public class ProviderConfigTest {
     public void testDefault() throws Exception {
         ProviderConfig provider = new ProviderConfig();
         provider.setDefault(true);
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProviderConfig.appendParameters(parameters, provider);
         assertThat(provider.isDefault(), is(true));
         assertThat(parameters, not(hasKey("default")));
@@ -51,7 +51,7 @@ public class ProviderConfigTest {
     public void testHost() throws Exception {
         ProviderConfig provider = new ProviderConfig();
         provider.setHost("demo-host");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProviderConfig.appendParameters(parameters, provider);
         assertThat(provider.getHost(), equalTo("demo-host"));
         assertThat(parameters, not(hasKey("host")));
@@ -61,7 +61,7 @@ public class ProviderConfigTest {
     public void testPort() throws Exception {
         ProviderConfig provider = new ProviderConfig();
         provider.setPort(8080);
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProviderConfig.appendParameters(parameters, provider);
         assertThat(provider.getPort(), is(8080));
         assertThat(parameters, not(hasKey("port")));
@@ -71,7 +71,7 @@ public class ProviderConfigTest {
     public void testPath() throws Exception {
         ProviderConfig provider = new ProviderConfig();
         provider.setPath("/path");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProviderConfig.appendParameters(parameters, provider);
         assertThat(provider.getPath(), equalTo("/path"));
         assertThat(provider.getContextpath(), equalTo("/path"));
@@ -82,7 +82,7 @@ public class ProviderConfigTest {
     public void testContextPath() throws Exception {
         ProviderConfig provider = new ProviderConfig();
         provider.setContextpath("/context-path");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProviderConfig.appendParameters(parameters, provider);
         assertThat(provider.getContextpath(), equalTo("/context-path"));
         assertThat(parameters, not(hasKey("/context-path")));
@@ -169,7 +169,7 @@ public class ProviderConfigTest {
     public void testPrompt() throws Exception {
         ProviderConfig provider = new ProviderConfig();
         provider.setPrompt("#");
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         ProviderConfig.appendParameters(parameters, provider);
         assertThat(provider.getPrompt(), equalTo("#"));
         assertThat(parameters, hasEntry("prompt", "%23"));

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ReferenceConfigTest.java
@@ -50,14 +50,14 @@ public class ReferenceConfigTest {
         protocol.setName("mockprotocol");
 
         ServiceConfig<DemoService> demoService;
-        demoService = new ServiceConfig<DemoService>();
+        demoService = new ServiceConfig<>();
         demoService.setInterface(DemoService.class);
         demoService.setRef(new DemoServiceImpl());
         demoService.setApplication(application);
         demoService.setRegistry(registry);
         demoService.setProtocol(protocol);
 
-        ReferenceConfig<DemoService> rc = new ReferenceConfig<DemoService>();
+        ReferenceConfig<DemoService> rc = new ReferenceConfig<>();
         rc.setApplication(application);
         rc.setRegistry(registry);
         rc.setInterface(DemoService.class.getName());
@@ -87,7 +87,7 @@ public class ReferenceConfigTest {
         ProtocolConfig protocol = new ProtocolConfig();
         protocol.setName("mockprotocol");
 
-        ReferenceConfig<DemoService> rc = new ReferenceConfig<DemoService>();
+        ReferenceConfig<DemoService> rc = new ReferenceConfig<>();
         rc.setApplication(application);
         rc.setRegistry(registry);
         rc.setInterface(DemoService.class.getName());
@@ -103,7 +103,7 @@ public class ReferenceConfigTest {
         Assertions.assertFalse(success);
         Assertions.assertNull(demoService);
 
-        ServiceConfig<DemoService> sc = new ServiceConfig<DemoService>();
+        ServiceConfig<DemoService> sc = new ServiceConfig<>();
         sc.setInterface(DemoService.class);
         sc.setRef(new DemoServiceImpl());
         sc.setApplication(application);

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/RegistryConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/RegistryConfigTest.java
@@ -45,7 +45,7 @@ public class RegistryConfigTest {
         RegistryConfig registry = new RegistryConfig();
         registry.setAddress("localhost");
         assertThat(registry.getAddress(), equalTo("localhost"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         RegistryConfig.appendParameters(parameters, registry);
         assertThat(parameters, not(hasKey("address")));
     }
@@ -165,7 +165,7 @@ public class RegistryConfigTest {
         RegistryConfig registry = new RegistryConfig();
         registry.setParameters(Collections.singletonMap("k1", "v1"));
         assertThat(registry.getParameters(), hasEntry("k1", "v1"));
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         RegistryConfig.appendParameters(parameters, registry);
         assertThat(parameters, hasEntry("k1", "v1"));
     }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java
@@ -58,8 +58,8 @@ public class ServiceConfigTest {
     private Protocol protocolDelegate = Mockito.mock(Protocol.class);
     private Registry registryDelegate = Mockito.mock(Registry.class);
     private Exporter exporter = Mockito.mock(Exporter.class);
-    private ServiceConfig<DemoServiceImpl> service = new ServiceConfig<DemoServiceImpl>();
-    private ServiceConfig<DemoServiceImpl> service2 = new ServiceConfig<DemoServiceImpl>();
+    private ServiceConfig<DemoServiceImpl> service = new ServiceConfig<>();
+    private ServiceConfig<DemoServiceImpl> service2 = new ServiceConfig<>();
 
 
     @BeforeEach
@@ -159,11 +159,11 @@ public class ServiceConfigTest {
 
     @Test
     public void testInterfaceClass() throws Exception {
-        ServiceConfig<Greeting> service = new ServiceConfig<Greeting>();
+        ServiceConfig<Greeting> service = new ServiceConfig<>();
         service.setInterface(Greeting.class.getName());
         service.setRef(Mockito.mock(Greeting.class));
         assertThat(service.getInterfaceClass() == Greeting.class, is(true));
-        service = new ServiceConfig<Greeting>();
+        service = new ServiceConfig<>();
         service.setRef(Mockito.mock(Greeting.class, withSettings().extraInterfaces(GenericService.class)));
         assertThat(service.getInterfaceClass() == GenericService.class, is(true));
     }
@@ -171,14 +171,14 @@ public class ServiceConfigTest {
     @Test
     public void testInterface1() throws Exception {
         Assertions.assertThrows(IllegalStateException.class, () -> {
-            ServiceConfig<DemoService> service = new ServiceConfig<DemoService>();
+            ServiceConfig<DemoService> service = new ServiceConfig<>();
             service.setInterface(DemoServiceImpl.class);
         });
     }
 
     @Test
     public void testInterface2() throws Exception {
-        ServiceConfig<DemoService> service = new ServiceConfig<DemoService>();
+        ServiceConfig<DemoService> service = new ServiceConfig<>();
         service.setInterface(DemoService.class);
         assertThat(service.getInterface(), equalTo(DemoService.class.getName()));
     }
@@ -228,7 +228,7 @@ public class ServiceConfigTest {
 
     @Test
     public void testUniqueServiceName() throws Exception {
-        ServiceConfig<Greeting> service = new ServiceConfig<Greeting>();
+        ServiceConfig<Greeting> service = new ServiceConfig<>();
         service.setGroup("dubbo");
         service.setInterface(Greeting.class);
         service.setVersion("1.0.0");

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/cache/CacheTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/cache/CacheTest.java
@@ -61,7 +61,7 @@ public class CacheTest {
         ApplicationConfig applicationConfig = new ApplicationConfig("cache-test");
         RegistryConfig registryConfig = new RegistryConfig("N/A");
         ProtocolConfig protocolConfig = new ProtocolConfig("injvm");
-        ServiceConfig<CacheService> service = new ServiceConfig<CacheService>();
+        ServiceConfig<CacheService> service = new ServiceConfig<>();
         service.setApplication(applicationConfig);
         service.setRegistry(registryConfig);
         service.setProtocol(protocolConfig);
@@ -69,7 +69,7 @@ public class CacheTest {
         service.setRef(new CacheServiceImpl());
         service.export();
         try {
-            ReferenceConfig<CacheService> reference = new ReferenceConfig<CacheService>();
+            ReferenceConfig<CacheService> reference = new ReferenceConfig<>();
             reference.setApplication(applicationConfig);
             reference.setInterface(CacheService.class);
             reference.setUrl("injvm://127.0.0.1?scope=remote&cache=true");
@@ -128,7 +128,7 @@ public class CacheTest {
     public void testCacheProvider() throws Exception {
         CacheFactory cacheFactory = ExtensionLoader.getExtensionLoader(CacheFactory.class).getAdaptiveExtension();
 
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("findCache.cache", "threadlocal");
         URL url = new URL("dubbo", "127.0.0.1", 29582, "org.apache.dubbo.config.cache.CacheService", parameters);
 

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/mock/MockRegistry.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/mock/MockRegistry.java
@@ -80,7 +80,7 @@ public class MockRegistry implements Registry {
     @Override
     public void subscribe(URL url, NotifyListener listener) {
         this.subscribedUrl = url;
-        List<URL> urls = new ArrayList<URL>();
+        List<URL> urls = new ArrayList<>();
 
         urls.add(url.setProtocol("mockprotocol")
                 .removeParameter(Constants.CATEGORY_KEY)

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/url/InvokerSideConfigUrlTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/url/InvokerSideConfigUrlTest.java
@@ -177,7 +177,7 @@ public class InvokerSideConfigUrlTest extends UrlTestBase {
         regConfForReference = new RegistryConfig();
         methodConfForReference = new MethodConfig();
 
-        refConf = new ReferenceConfig<DemoService>();
+        refConf = new ReferenceConfig<>();
         consumerConf = new ConsumerConfig();
 
         methodConfForReference.setName("sayName");

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/url/UrlTestBase.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/url/UrlTestBase.java
@@ -146,7 +146,7 @@ public class UrlTestBase {
         protoConfForProvider = new ProtocolConfig("mockprotocol");
         protoConfForService = new ProtocolConfig("mockprotocol");
         methodConfForService = new MethodConfig();
-        servConf = new ServiceConfig<DemoService>();
+        servConf = new ServiceConfig<>();
 
 //        provConf.setApplication(appConfForProvider);
         servConf.setApplication(application);

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ServiceBean.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/ServiceBean.java
@@ -123,7 +123,7 @@ public class ServiceBean<T> extends ServiceConfig<T> implements InitializingBean
                 Map<String, ProtocolConfig> protocolConfigMap = applicationContext == null ? null : BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, ProtocolConfig.class, false, false);
                 if (CollectionUtils.isEmptyMap(protocolConfigMap)
                         && providerConfigMap.size() > 1) { // backward compatibility
-                    List<ProviderConfig> providerConfigs = new ArrayList<ProviderConfig>();
+                    List<ProviderConfig> providerConfigs = new ArrayList<>();
                     for (ProviderConfig config : providerConfigMap.values()) {
                         if (config.isDefault() != null && config.isDefault()) {
                             providerConfigs.add(config);
@@ -266,7 +266,7 @@ public class ServiceBean<T> extends ServiceConfig<T> implements InitializingBean
                 && (getProvider() == null || CollectionUtils.isEmpty(getProvider().getProtocols()))) {
             Map<String, ProtocolConfig> protocolConfigMap = applicationContext == null ? null : BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, ProtocolConfig.class, false, false);
             if (protocolConfigMap != null && protocolConfigMap.size() > 0) {
-                List<ProtocolConfig> protocolConfigs = new ArrayList<ProtocolConfig>();
+                List<ProtocolConfig> protocolConfigs = new ArrayList<>();
                 if (StringUtils.isNotEmpty(getProtocolIds())) {
                     Arrays.stream(Constants.COMMA_SPLIT_PATTERN.split(getProtocolIds()))
                             .forEach(id -> {

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/AnnotationInjectedBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/AnnotationInjectedBeanPostProcessor.java
@@ -80,9 +80,9 @@ public abstract class AnnotationInjectedBeanPostProcessor<A extends Annotation> 
     private final Class<A> annotationType;
 
     private final ConcurrentMap<String, AnnotationInjectedBeanPostProcessor.AnnotatedInjectionMetadata> injectionMetadataCache =
-            new ConcurrentHashMap<String, AnnotationInjectedBeanPostProcessor.AnnotatedInjectionMetadata>(CACHE_SIZE);
+            new ConcurrentHashMap<>(CACHE_SIZE);
 
-    private final ConcurrentMap<String, Object> injectedObjectsCache = new ConcurrentHashMap<String, Object>(CACHE_SIZE);
+    private final ConcurrentMap<String, Object> injectedObjectsCache = new ConcurrentHashMap<>(CACHE_SIZE);
 
     private ConfigurableListableBeanFactory beanFactory;
 
@@ -97,7 +97,7 @@ public abstract class AnnotationInjectedBeanPostProcessor<A extends Annotation> 
     }
 
     private static <T> Collection<T> combine(Collection<? extends T>... elements) {
-        List<T> allElements = new ArrayList<T>();
+        List<T> allElements = new ArrayList<>();
         for (Collection<? extends T> e : elements) {
             allElements.addAll(e);
         }
@@ -145,7 +145,7 @@ public abstract class AnnotationInjectedBeanPostProcessor<A extends Annotation> 
      */
     private List<AnnotationInjectedBeanPostProcessor.AnnotatedFieldElement> findFieldAnnotationMetadata(final Class<?> beanClass) {
 
-        final List<AnnotationInjectedBeanPostProcessor.AnnotatedFieldElement> elements = new LinkedList<AnnotationInjectedBeanPostProcessor.AnnotatedFieldElement>();
+        final List<AnnotationInjectedBeanPostProcessor.AnnotatedFieldElement> elements = new LinkedList<>();
 
         ReflectionUtils.doWithFields(beanClass, new ReflectionUtils.FieldCallback() {
             @Override
@@ -180,7 +180,7 @@ public abstract class AnnotationInjectedBeanPostProcessor<A extends Annotation> 
      */
     private List<AnnotationInjectedBeanPostProcessor.AnnotatedMethodElement> findAnnotatedMethodMetadata(final Class<?> beanClass) {
 
-        final List<AnnotationInjectedBeanPostProcessor.AnnotatedMethodElement> elements = new LinkedList<AnnotationInjectedBeanPostProcessor.AnnotatedMethodElement>();
+        final List<AnnotationInjectedBeanPostProcessor.AnnotatedMethodElement> elements = new LinkedList<>();
 
         ReflectionUtils.doWithMethods(beanClass, new ReflectionUtils.MethodCallback() {
             @Override
@@ -396,7 +396,7 @@ public abstract class AnnotationInjectedBeanPostProcessor<A extends Annotation> 
     protected Map<InjectionMetadata.InjectedElement, Object> getInjectedFieldObjectsMap() {
 
         Map<InjectionMetadata.InjectedElement, Object> injectedElementBeanMap =
-                new LinkedHashMap<InjectionMetadata.InjectedElement, Object>();
+                new LinkedHashMap<>();
 
         for (AnnotationInjectedBeanPostProcessor.AnnotatedInjectionMetadata metadata : injectionMetadataCache.values()) {
 
@@ -422,7 +422,7 @@ public abstract class AnnotationInjectedBeanPostProcessor<A extends Annotation> 
     protected Map<InjectionMetadata.InjectedElement, Object> getInjectedMethodObjectsMap() {
 
         Map<InjectionMetadata.InjectedElement, Object> injectedElementBeanMap =
-                new LinkedHashMap<InjectionMetadata.InjectedElement, Object>();
+                new LinkedHashMap<>();
 
         for (AnnotationInjectedBeanPostProcessor.AnnotatedInjectionMetadata metadata : injectionMetadataCache.values()) {
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceAnnotationBeanPostProcessor.java
@@ -60,16 +60,16 @@ public class ReferenceAnnotationBeanPostProcessor extends AnnotationInjectedBean
     private static final int CACHE_SIZE = Integer.getInteger(BEAN_NAME + ".cache.size", 32);
 
     private final ConcurrentMap<String, ReferenceBean<?>> referenceBeanCache =
-            new ConcurrentHashMap<String, ReferenceBean<?>>(CACHE_SIZE);
+            new ConcurrentHashMap<>(CACHE_SIZE);
 
     private final ConcurrentHashMap<String, ReferenceBeanInvocationHandler> localReferenceBeanInvocationHandlerCache =
-            new ConcurrentHashMap<String, ReferenceBeanInvocationHandler>(CACHE_SIZE);
+            new ConcurrentHashMap<>(CACHE_SIZE);
 
     private final ConcurrentMap<InjectionMetadata.InjectedElement, ReferenceBean<?>> injectedFieldReferenceBeanCache =
-            new ConcurrentHashMap<InjectionMetadata.InjectedElement, ReferenceBean<?>>(CACHE_SIZE);
+            new ConcurrentHashMap<>(CACHE_SIZE);
 
     private final ConcurrentMap<InjectionMetadata.InjectedElement, ReferenceBean<?>> injectedMethodReferenceBeanCache =
-            new ConcurrentHashMap<InjectionMetadata.InjectedElement, ReferenceBean<?>>(CACHE_SIZE);
+            new ConcurrentHashMap<>(CACHE_SIZE);
 
     private ApplicationContext applicationContext;
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceAnnotationBeanPostProcessor.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/beans/factory/annotation/ServiceAnnotationBeanPostProcessor.java
@@ -218,7 +218,7 @@ public class ServiceAnnotationBeanPostProcessor implements BeanDefinitionRegistr
 
         Set<BeanDefinition> beanDefinitions = scanner.findCandidateComponents(packageToScan);
 
-        Set<BeanDefinitionHolder> beanDefinitionHolders = new LinkedHashSet<BeanDefinitionHolder>(beanDefinitions.size());
+        Set<BeanDefinitionHolder> beanDefinitionHolders = new LinkedHashSet<>(beanDefinitions.size());
 
         for (BeanDefinition beanDefinition : beanDefinitions) {
 
@@ -350,7 +350,7 @@ public class ServiceAnnotationBeanPostProcessor implements BeanDefinitionRegistr
     }
 
     private Set<String> resolvePackagesToScan(Set<String> packagesToScan) {
-        Set<String> resolvedPackagesToScan = new LinkedHashSet<String>(packagesToScan.size());
+        Set<String> resolvedPackagesToScan = new LinkedHashSet<>(packagesToScan.size());
         for (String packageToScan : packagesToScan) {
             if (StringUtils.hasText(packageToScan)) {
                 String resolvedPackageToScan = environment.resolvePlaceholders(packageToScan.trim());
@@ -441,7 +441,7 @@ public class ServiceAnnotationBeanPostProcessor implements BeanDefinitionRegistr
 
     private ManagedList<RuntimeBeanReference> toRuntimeBeanReferences(String... beanNames) {
 
-        ManagedList<RuntimeBeanReference> runtimeBeanReferences = new ManagedList<RuntimeBeanReference>();
+        ManagedList<RuntimeBeanReference> runtimeBeanReferences = new ManagedList<>();
 
         if (!ObjectUtils.isEmpty(beanNames)) {
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/annotation/DubboComponentScanRegistrar.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/annotation/DubboComponentScanRegistrar.java
@@ -99,7 +99,7 @@ public class DubboComponentScanRegistrar implements ImportBeanDefinitionRegistra
         Class<?>[] basePackageClasses = attributes.getClassArray("basePackageClasses");
         String[] value = attributes.getStringArray("value");
         // Appends value array attributes
-        Set<String> packagesToScan = new LinkedHashSet<String>(Arrays.asList(value));
+        Set<String> packagesToScan = new LinkedHashSet<>(Arrays.asList(value));
         packagesToScan.addAll(Arrays.asList(basePackages));
         for (Class<?> basePackageClass : basePackageClasses) {
             packagesToScan.add(ClassUtils.getPackageName(basePackageClass));

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/annotation/DubboConfigBindingRegistrar.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/context/annotation/DubboConfigBindingRegistrar.java
@@ -160,7 +160,7 @@ public class DubboConfigBindingRegistrar implements ImportBeanDefinitionRegistra
 
     private Set<String> resolveMultipleBeanNames(Map<String, Object> properties) {
 
-        Set<String> beanNames = new LinkedHashSet<String>();
+        Set<String> beanNames = new LinkedHashSet<>();
 
         for (String propertyName : properties.keySet()) {
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/extension/SpringExtensionFactory.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/extension/SpringExtensionFactory.java
@@ -40,7 +40,7 @@ import java.util.Set;
 public class SpringExtensionFactory implements ExtensionFactory {
     private static final Logger logger = LoggerFactory.getLogger(SpringExtensionFactory.class);
 
-    private static final Set<ApplicationContext> contexts = new ConcurrentHashSet<ApplicationContext>();
+    private static final Set<ApplicationContext> contexts = new ConcurrentHashSet<>();
     private static final ApplicationListener shutdownHookListener = new ShutdownHookListener();
 
     public static void addApplicationContext(ApplicationContext context) {

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/schema/DubboBeanDefinitionParser.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/schema/DubboBeanDefinitionParser.java
@@ -125,7 +125,7 @@ public class DubboBeanDefinitionParser implements BeanDefinitionParser {
         } else if (ConsumerConfig.class.equals(beanClass)) {
             parseNested(element, parserContext, ReferenceBean.class, false, "reference", "consumer", id, beanDefinition);
         }
-        Set<String> props = new HashSet<String>();
+        Set<String> props = new HashSet<>();
         ManagedMap parameters = null;
         for (Method setter : beanClass.getMethods()) {
             String name = setter.getName();

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/AnnotationUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/AnnotationUtils.java
@@ -136,7 +136,7 @@ public class AnnotationUtils {
             return Collections.emptyMap();
         }
 
-        Map<ElementType, List<A>> annotationsMap = new LinkedHashMap<ElementType, List<A>>();
+        Map<ElementType, List<A>> annotationsMap = new LinkedHashMap<>();
 
         Target target = annotationClass.getAnnotation(Target.class);
 
@@ -145,7 +145,7 @@ public class AnnotationUtils {
 
         for (ElementType elementType : elementTypes) {
 
-            List<A> annotationsList = new LinkedList<A>();
+            List<A> annotationsList = new LinkedList<>();
 
             switch (elementType) {
 
@@ -237,11 +237,11 @@ public class AnnotationUtils {
     public static Map<String, Object> getAttributes(Annotation annotation, PropertyResolver propertyResolver,
                                                     boolean ignoreDefaultValue, String... ignoreAttributeNames) {
 
-        Set<String> ignoreAttributeNamesSet = new HashSet<String>(arrayToList(ignoreAttributeNames));
+        Set<String> ignoreAttributeNamesSet = new HashSet<>(arrayToList(ignoreAttributeNames));
 
         Map<String, Object> attributes = getAnnotationAttributes(annotation);
 
-        Map<String, Object> actualAttributes = new LinkedHashMap<String, Object>();
+        Map<String, Object> actualAttributes = new LinkedHashMap<>();
 
         for (Map.Entry<String, Object> entry : attributes.entrySet()) {
 

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/BeanFactoryUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/BeanFactoryUtils.java
@@ -106,7 +106,7 @@ public class BeanFactoryUtils {
 
         String[] allBeanNames = beanNamesForTypeIncludingAncestors(beanFactory, beanType);
 
-        List<T> beans = new ArrayList<T>(beanNames.length);
+        List<T> beans = new ArrayList<>(beanNames.length);
 
         for (String beanName : beanNames) {
             if (containsElement(allBeanNames, beanName)) {

--- a/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/PropertySourcesUtils.java
+++ b/dubbo-config/dubbo-config-spring/src/main/java/org/apache/dubbo/config/spring/util/PropertySourcesUtils.java
@@ -72,7 +72,7 @@ public abstract class PropertySourcesUtils {
      */
     public static Map<String, Object> getSubProperties(ConfigurableEnvironment environment, String prefix) {
 
-        Map<String, Object> subProperties = new LinkedHashMap<String, Object>();
+        Map<String, Object> subProperties = new LinkedHashMap<>();
 
         MutablePropertySources propertySources = environment.getPropertySources();
 

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/AbstractRegistryService.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/AbstractRegistryService.java
@@ -42,19 +42,19 @@ public abstract class AbstractRegistryService implements RegistryService {
 
     // registered services
     // Map<serviceName, Map<url, queryString>>
-    private final ConcurrentMap<String, List<URL>> registered = new ConcurrentHashMap<String, List<URL>>();
+    private final ConcurrentMap<String, List<URL>> registered = new ConcurrentHashMap<>();
 
     // subscribed services
     // Map<serviceName, queryString>
-    private final ConcurrentMap<String, Map<String, String>> subscribed = new ConcurrentHashMap<String, Map<String, String>>();
+    private final ConcurrentMap<String, Map<String, String>> subscribed = new ConcurrentHashMap<>();
 
     // notified services
     // Map<serviceName, Map<url, queryString>>
-    private final ConcurrentMap<String, List<URL>> notified = new ConcurrentHashMap<String, List<URL>>();
+    private final ConcurrentMap<String, List<URL>> notified = new ConcurrentHashMap<>();
 
     // notification listeners for the subscribed services
     // Map<serviceName, List<notificationListener>>
-    private final ConcurrentMap<String, List<NotifyListener>> notifyListeners = new ConcurrentHashMap<String, List<NotifyListener>>();
+    private final ConcurrentMap<String, List<NotifyListener>> notifyListeners = new ConcurrentHashMap<>();
 
     @Override
     public void register(URL url) {

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/ConfigTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/ConfigTest.java
@@ -115,7 +115,7 @@ public class ConfigTest {
 
         providerContext.refresh();
 
-        ReferenceConfig<HelloService> reference = new ReferenceConfig<HelloService>();
+        ReferenceConfig<HelloService> reference = new ReferenceConfig<>();
         reference.setApplication(new ApplicationConfig("consumer"));
         reference.setRegistry(new RegistryConfig(RegistryConfig.NO_AVAILABLE));
         reference.setInterface(HelloService.class);
@@ -145,7 +145,7 @@ public class ConfigTest {
     }
 
     private DemoService refer(String url) {
-        ReferenceConfig<DemoService> reference = new ReferenceConfig<DemoService>();
+        ReferenceConfig<DemoService> reference = new ReferenceConfig<>();
         reference.setApplication(new ApplicationConfig("consumer"));
         reference.setRegistry(new RegistryConfig(RegistryConfig.NO_AVAILABLE));
         reference.setInterface(DemoService.class);
@@ -155,7 +155,7 @@ public class ConfigTest {
 
     @Test
     public void testToString() {
-        ReferenceConfig<DemoService> reference = new ReferenceConfig<DemoService>();
+        ReferenceConfig<DemoService> reference = new ReferenceConfig<>();
         reference.setApplication(new ApplicationConfig("consumer"));
         reference.setRegistry(new RegistryConfig(RegistryConfig.NO_AVAILABLE));
         reference.setInterface(DemoService.class);
@@ -169,7 +169,7 @@ public class ConfigTest {
 
     @Test
     public void testForks() {
-        ReferenceConfig<DemoService> reference = new ReferenceConfig<DemoService>();
+        ReferenceConfig<DemoService> reference = new ReferenceConfig<>();
         reference.setApplication(new ApplicationConfig("consumer"));
         reference.setRegistry(new RegistryConfig(RegistryConfig.NO_AVAILABLE));
         reference.setInterface(DemoService.class);
@@ -357,7 +357,7 @@ public class ConfigTest {
     public void testAppendFilter() throws Exception {
         ProviderConfig provider = new ProviderConfig();
         provider.setFilter("classloader,monitor");
-        ServiceConfig<DemoService> service = new ServiceConfig<DemoService>();
+        ServiceConfig<DemoService> service = new ServiceConfig<>();
         service.setFilter("accesslog,trace");
         service.setProvider(provider);
         service.setProtocol(new ProtocolConfig("dubbo", 20880));
@@ -374,7 +374,7 @@ public class ConfigTest {
 
             ConsumerConfig consumer = new ConsumerConfig();
             consumer.setFilter("classloader,monitor");
-            ReferenceConfig<DemoService> reference = new ReferenceConfig<DemoService>();
+            ReferenceConfig<DemoService> reference = new ReferenceConfig<>();
             reference.setFilter("accesslog,trace");
             reference.setConsumer(consumer);
             reference.setApplication(new ApplicationConfig("consumer"));
@@ -556,7 +556,7 @@ public class ConfigTest {
         protocol.setName("dubbo");
         protocol.setPort(13123);
 
-        ServiceConfig<DemoService> service = new ServiceConfig<DemoService>();
+        ServiceConfig<DemoService> service = new ServiceConfig<>();
         service.setInterface(DemoService.class);
         service.setRef(new DemoServiceImpl());
         service.setApplication(application);
@@ -570,7 +570,7 @@ public class ConfigTest {
             assertEquals("world", url.getParameter("owner"));
             assertEquals(13123, url.getPort());
 
-            ReferenceConfig<DemoService> reference = new ReferenceConfig<DemoService>();
+            ReferenceConfig<DemoService> reference = new ReferenceConfig<>();
             reference.setApplication(new ApplicationConfig("consumer"));
             reference.setRegistry(new RegistryConfig(RegistryConfig.NO_AVAILABLE));
             reference.setInterface(DemoService.class);
@@ -687,7 +687,7 @@ public class ConfigTest {
         System.setProperty("dubbo.reference.retries", "5");
 
         try {
-            ServiceConfig<DemoService> service = new ServiceConfig<DemoService>();
+            ServiceConfig<DemoService> service = new ServiceConfig<>();
             service.setInterface(DemoService.class);
             service.setRef(new DemoServiceImpl());
             service.setRegistry(new RegistryConfig(RegistryConfig.NO_AVAILABLE));
@@ -695,7 +695,7 @@ public class ConfigTest {
             service.setProtocol(protocolConfig);
             service.export();
 
-            ReferenceConfig<DemoService> reference = new ReferenceConfig<DemoService>();
+            ReferenceConfig<DemoService> reference = new ReferenceConfig<>();
             reference.setInterface(DemoService.class);
             reference.setInjvm(true);
             reference.setRetries(2);
@@ -714,7 +714,7 @@ public class ConfigTest {
         System.setProperty("dubbo.protocol.name", "dubbo");
         System.setProperty("dubbo.protocol.port", "20834");
         try {
-            ServiceConfig<DemoService> serviceConfig = new ServiceConfig<DemoService>();
+            ServiceConfig<DemoService> serviceConfig = new ServiceConfig<>();
             serviceConfig.setInterface(DemoService.class);
             serviceConfig.setRef(new DemoServiceImpl());
             serviceConfig.export();
@@ -754,7 +754,7 @@ public class ConfigTest {
             protocol.setName("rmi");
             protocol.setPort(1099);
 
-            ServiceConfig<DemoService> service = new ServiceConfig<DemoService>();
+            ServiceConfig<DemoService> service = new ServiceConfig<>();
             service.setInterface(DemoService.class);
             service.setRef(new DemoServiceImpl());
             service.setApplication(application);
@@ -796,7 +796,7 @@ public class ConfigTest {
             ProtocolConfig protocol = new ProtocolConfig();
             protocol.setName("rmi");
 
-            ServiceConfig<DemoService> service = new ServiceConfig<DemoService>();
+            ServiceConfig<DemoService> service = new ServiceConfig<>();
             service.setInterface(DemoService.class);
             service.setRef(new DemoServiceImpl());
             service.setApplication(application);
@@ -836,7 +836,7 @@ public class ConfigTest {
 
     @Test
     public void testPath() throws Exception {
-        ServiceConfig<DemoService> service = new ServiceConfig<DemoService>();
+        ServiceConfig<DemoService> service = new ServiceConfig<>();
         service.setPath("a/b$c");
         try {
             service.setPath("a?b");
@@ -888,7 +888,7 @@ public class ConfigTest {
 
             ProtocolConfig protocol = new ProtocolConfig();
 
-            service = new ServiceConfig<DemoService>();
+            service = new ServiceConfig<>();
             service.setInterface(DemoService.class);
             service.setRef(new DemoServiceImpl());
             service.setApplication(application);
@@ -922,14 +922,14 @@ public class ConfigTest {
         protocol.setName("dubbo");
         protocol.setPort(-1);
 
-        demoService = new ServiceConfig<DemoService>();
+        demoService = new ServiceConfig<>();
         demoService.setInterface(DemoService.class);
         demoService.setRef(new DemoServiceImpl());
         demoService.setApplication(application);
         demoService.setRegistry(registry);
         demoService.setProtocol(protocol);
 
-        helloService = new ServiceConfig<HelloService>();
+        helloService = new ServiceConfig<>();
         helloService.setInterface(HelloService.class);
         helloService.setRef(new HelloServiceImpl());
         helloService.setApplication(application);
@@ -954,7 +954,7 @@ public class ConfigTest {
         RegistryConfig rc = new RegistryConfig();
         rc.setAddress(RegistryConfig.NO_AVAILABLE);
 
-        ServiceConfig<GenericService> sc = new ServiceConfig<GenericService>();
+        ServiceConfig<GenericService> sc = new ServiceConfig<>();
         sc.setApplication(ac);
         sc.setRegistry(rc);
         sc.setInterface(DemoService.class.getName());
@@ -965,7 +965,7 @@ public class ConfigTest {
             }
         });
 
-        ReferenceConfig<DemoService> ref = new ReferenceConfig<DemoService>();
+        ReferenceConfig<DemoService> ref = new ReferenceConfig<>();
         ref.setApplication(ac);
         ref.setRegistry(rc);
         ref.setInterface(DemoService.class.getName());
@@ -984,7 +984,7 @@ public class ConfigTest {
 
     @Test
     public void testGenericServiceConfig() throws Exception {
-        ServiceConfig<GenericService> service = new ServiceConfig<GenericService>();
+        ServiceConfig<GenericService> service = new ServiceConfig<>();
         service.setApplication(new ApplicationConfig("test"));
         service.setRegistry(new RegistryConfig("mock://localhost"));
         service.setInterface(DemoService.class.getName());

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/SimpleRegistryService.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/SimpleRegistryService.java
@@ -37,8 +37,8 @@ import java.util.concurrent.ConcurrentMap;
 public class SimpleRegistryService extends AbstractRegistryService {
 
     private final static Logger logger = LoggerFactory.getLogger(SimpleRegistryService.class);
-    private final ConcurrentMap<String, ConcurrentMap<String, URL>> remoteRegistered = new ConcurrentHashMap<String, ConcurrentMap<String, URL>>();
-    private final ConcurrentMap<String, ConcurrentMap<String, NotifyListener>> remoteListeners = new ConcurrentHashMap<String, ConcurrentMap<String, NotifyListener>>();
+    private final ConcurrentMap<String, ConcurrentMap<String, URL>> remoteRegistered = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ConcurrentMap<String, NotifyListener>> remoteListeners = new ConcurrentHashMap<>();
     private List<String> registries;
 
     @Override

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/AnnotationPropertyValuesAdapterTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/AnnotationPropertyValuesAdapterTest.java
@@ -126,7 +126,7 @@ public class AnnotationPropertyValuesAdapterTest {
         Assert.assertEquals("default,default", referenceBean.getFilter());
         Assert.assertEquals("default,default", referenceBean.getListener());
 
-        Map<String, String> data = new LinkedHashMap<String, String>();
+        Map<String, String> data = new LinkedHashMap<>();
         data.put("key1", "value1");
 
         Assert.assertEquals(data, referenceBean.getParameters());

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceBeanBuilderTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/annotation/ReferenceBeanBuilderTest.java
@@ -110,7 +110,7 @@ public class ReferenceBeanBuilderTest {
         Assert.assertEquals("deprecated", referenceBean.getListener());
 
         // parameters
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("n1", "v1");
         parameters.put("n2", "v2");
         parameters.put("n3", "v3");

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/config/YamlPropertySourceFactory.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/beans/factory/config/YamlPropertySourceFactory.java
@@ -63,7 +63,7 @@ public class YamlPropertySourceFactory extends YamlProcessor implements Property
     }
 
     public Map<String, Object> process() {
-        final Map<String, Object> result = new LinkedHashMap<String, Object>();
+        final Map<String, Object> result = new LinkedHashMap<>();
         process(new MatchCallback() {
             @Override
             public void process(Properties properties, Map<String, Object> map) {

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/registry/MockRegistry.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/registry/MockRegistry.java
@@ -27,9 +27,9 @@ public class MockRegistry implements Registry {
 
     private URL url;
 
-    private List<URL> registered = new ArrayList<URL>();
+    private List<URL> registered = new ArrayList<>();
 
-    private List<URL> subscribered = new ArrayList<URL>();
+    private List<URL> subscribered = new ArrayList<>();
 
     public MockRegistry(URL url) {
         if (url == null) {

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/registry/MockRegistryFactory.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/registry/MockRegistryFactory.java
@@ -26,7 +26,7 @@ import java.util.Map;
 
 public class MockRegistryFactory implements RegistryFactory {
 
-    private static final Map<URL, Registry> registries = new HashMap<URL, Registry>();
+    private static final Map<URL, Registry> registries = new HashMap<>();
 
     public static Collection<Registry> getCachedRegistry() {
         return registries.values();

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/status/DataSourceStatusCheckerTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/status/DataSourceStatusCheckerTest.java
@@ -69,7 +69,7 @@ public class DataSourceStatusCheckerTest {
 
     @Test
     public void testWithoutDatasource() {
-        Map<String, DataSource> map = new HashMap<String, DataSource>();
+        Map<String, DataSource> map = new HashMap<>();
         given(applicationContext.getBeansOfType(eq(DataSource.class), anyBoolean(), anyBoolean())).willReturn(map);
 
         Status status = dataSourceStatusChecker.check();
@@ -79,7 +79,7 @@ public class DataSourceStatusCheckerTest {
 
     @Test
     public void testWithDatasourceHasNextResult() throws SQLException {
-        Map<String, DataSource> map = new HashMap<String, DataSource>();
+        Map<String, DataSource> map = new HashMap<>();
         DataSource dataSource = mock(DataSource.class);
         Connection connection = mock(Connection.class, Answers.RETURNS_DEEP_STUBS);
         given(dataSource.getConnection()).willReturn(connection);
@@ -94,7 +94,7 @@ public class DataSourceStatusCheckerTest {
 
     @Test
     public void testWithDatasourceNotHasNextResult() throws SQLException {
-        Map<String, DataSource> map = new HashMap<String, DataSource>();
+        Map<String, DataSource> map = new HashMap<>();
         DataSource dataSource = mock(DataSource.class);
         Connection connection = mock(Connection.class, Answers.RETURNS_DEEP_STUBS);
         given(dataSource.getConnection()).willReturn(connection);

--- a/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/util/PropertySourcesUtilsTest.java
+++ b/dubbo-config/dubbo-config-spring/src/test/java/org/apache/dubbo/config/spring/util/PropertySourcesUtilsTest.java
@@ -38,8 +38,8 @@ public class PropertySourcesUtilsTest {
 
         MutablePropertySources propertySources = new MutablePropertySources();
 
-        Map<String, Object> source = new HashMap<String, Object>();
-        Map<String, Object> source2 = new HashMap<String, Object>();
+        Map<String, Object> source = new HashMap<>();
+        Map<String, Object> source2 = new HashMap<>();
 
         MapPropertySource propertySource = new MapPropertySource("propertySource", source);
         MapPropertySource propertySource2 = new MapPropertySource("propertySource2", source2);
@@ -58,7 +58,7 @@ public class PropertySourcesUtilsTest {
         source2.put("user.name", "mercyblitz");
         source2.put("user.age", "32");
 
-        Map<String, Object> expected = new HashMap<String, Object>();
+        Map<String, Object> expected = new HashMap<>();
         expected.put("name", "Mercy");
         expected.put("age", "31");
 

--- a/dubbo-container/dubbo-container-api/src/main/java/org/apache/dubbo/container/Main.java
+++ b/dubbo-container/dubbo-container-api/src/main/java/org/apache/dubbo/container/Main.java
@@ -55,7 +55,7 @@ public class Main {
                 args = Constants.COMMA_SPLIT_PATTERN.split(config);
             }
 
-            final List<Container> containers = new ArrayList<Container>();
+            final List<Container> containers = new ArrayList<>();
             for (int i = 0; i < args.length; i++) {
                 containers.add(loader.getExtension(args[i]));
             }

--- a/dubbo-container/dubbo-container-logback/src/main/java/org/apache/dubbo/container/logback/LogbackContainer.java
+++ b/dubbo-container/dubbo-container-logback/src/main/java/org/apache/dubbo/container/logback/LogbackContainer.java
@@ -74,14 +74,14 @@ public class LogbackContainer implements Container {
         rootLogger.detachAndStopAllAppenders();
 
         // appender
-        RollingFileAppender<ILoggingEvent> fileAppender = new RollingFileAppender<ILoggingEvent>();
+        RollingFileAppender<ILoggingEvent> fileAppender = new RollingFileAppender<>();
         fileAppender.setContext(loggerContext);
         fileAppender.setName("application");
         fileAppender.setFile(file);
         fileAppender.setAppend(true);
 
         // policy
-        TimeBasedRollingPolicy<ILoggingEvent> policy = new TimeBasedRollingPolicy<ILoggingEvent>();
+        TimeBasedRollingPolicy<ILoggingEvent> policy = new TimeBasedRollingPolicy<>();
         policy.setContext(loggerContext);
         policy.setMaxHistory(maxHistory);
         policy.setFileNamePattern(file + ".%d{yyyy-MM-dd}");

--- a/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/support/AbstractCacheFactory.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/support/AbstractCacheFactory.java
@@ -41,7 +41,7 @@ public abstract class AbstractCacheFactory implements CacheFactory {
     /**
      * This is used to store factory level-1 cached data.
      */
-    private final ConcurrentMap<String, Cache> caches = new ConcurrentHashMap<String, Cache>();
+    private final ConcurrentMap<String, Cache> caches = new ConcurrentHashMap<>();
 
     /**
      *  Takes URL and invocation instance and return cache instance for a given url.

--- a/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/support/expiring/ExpiringCache.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/support/expiring/ExpiringCache.java
@@ -48,7 +48,7 @@ public class ExpiringCache implements Cache {
         final int secondsToLive = url.getParameter("cache.seconds", 180);
         // Cache check interval (second)
         final int intervalSeconds = url.getParameter("cache.interval", 4);
-        ExpiringMap<Object, Object> expiringMap = new ExpiringMap<Object, Object>(secondsToLive, intervalSeconds);
+        ExpiringMap<Object, Object> expiringMap = new ExpiringMap<>(secondsToLive, intervalSeconds);
         expiringMap.getExpireThread().startExpiryIfNotStarted();
         this.store = expiringMap;
     }

--- a/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/support/expiring/ExpiringMap.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/support/expiring/ExpiringMap.java
@@ -148,7 +148,7 @@ public class ExpiringMap<K, V> implements Map<K, V> {
 
     @Override
     public Collection<V> values() {
-        List<V> list = new ArrayList<V>();
+        List<V> list = new ArrayList<>();
         Set<Entry<K, ExpiryObject>> delegatedSet = delegateMap.entrySet();
         for (Entry<K, ExpiryObject> entry : delegatedSet) {
             ExpiryObject value = entry.getValue();

--- a/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/support/lru/LruCache.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/support/lru/LruCache.java
@@ -54,7 +54,7 @@ public class LruCache implements Cache {
      */
     public LruCache(URL url) {
         final int max = url.getParameter("cache.size", 1000);
-        this.store = new LRUCache<Object, Object>(max);
+        this.store = new LRUCache<>(max);
     }
 
     /**

--- a/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/support/threadlocal/ThreadLocalCache.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/support/threadlocal/ThreadLocalCache.java
@@ -54,7 +54,7 @@ public class ThreadLocalCache implements Cache {
         this.store = new ThreadLocal<Map<Object, Object>>() {
             @Override
             protected Map<Object, Object> initialValue() {
-                return new HashMap<Object, Object>();
+                return new HashMap<>();
             }
         };
     }

--- a/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/AbstractValidation.java
+++ b/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/AbstractValidation.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentMap;
  */
 public abstract class AbstractValidation implements Validation {
 
-    private final ConcurrentMap<String, Validator> validators = new ConcurrentHashMap<String, Validator>();
+    private final ConcurrentMap<String, Validator> validators = new ConcurrentHashMap<>();
 
     @Override
     public Validator getValidator(URL url) {

--- a/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidator.java
+++ b/dubbo-filter/dubbo-filter-validation/src/main/java/org/apache/dubbo/validation/support/jvalidation/JValidator.java
@@ -94,7 +94,7 @@ public class JValidator implements Validator {
             factory = Validation.buildDefaultValidatorFactory();
         }
         this.validator = factory.getValidator();
-        this.methodClassMap = new ConcurrentHashMap<String, Class>();
+        this.methodClassMap = new ConcurrentHashMap<>();
     }
 
     private static boolean isPrimitives(Class<?> cls) {
@@ -243,12 +243,12 @@ public class JValidator implements Validator {
 
     @Override
     public void validate(String methodName, Class<?>[] parameterTypes, Object[] arguments) throws Exception {
-        List<Class<?>> groups = new ArrayList<Class<?>>();
+        List<Class<?>> groups = new ArrayList<>();
         Class<?> methodClass = methodClass(methodName);
         if (methodClass != null) {
             groups.add(methodClass);
         }
-        Set<ConstraintViolation<?>> violations = new HashSet<ConstraintViolation<?>>();
+        Set<ConstraintViolation<?>> violations = new HashSet<>();
         Method method = clazz.getMethod(methodName, parameterTypes);
         Class<?>[] methodClasses = null;
         if (method.isAnnotationPresent(MethodValidated.class)){

--- a/dubbo-metadata-report/dubbo-metadata-definition/src/main/java/org/apache/dubbo/metadata/definition/model/MethodDefinition.java
+++ b/dubbo-metadata-report/dubbo-metadata-definition/src/main/java/org/apache/dubbo/metadata/definition/model/MethodDefinition.java
@@ -37,7 +37,7 @@ public class MethodDefinition {
 
     public List<TypeDefinition> getParameters() {
         if (parameters == null) {
-            parameters = new ArrayList<TypeDefinition>();
+            parameters = new ArrayList<>();
         }
         return parameters;
     }

--- a/dubbo-metadata-report/dubbo-metadata-definition/src/main/java/org/apache/dubbo/metadata/definition/model/ServiceDefinition.java
+++ b/dubbo-metadata-report/dubbo-metadata-definition/src/main/java/org/apache/dubbo/metadata/definition/model/ServiceDefinition.java
@@ -40,14 +40,14 @@ public class ServiceDefinition {
 
     public List<MethodDefinition> getMethods() {
         if (methods == null) {
-            methods = new ArrayList<MethodDefinition>();
+            methods = new ArrayList<>();
         }
         return methods;
     }
 
     public List<TypeDefinition> getTypes() {
         if (types == null) {
-            types = new ArrayList<TypeDefinition>();
+            types = new ArrayList<>();
         }
         return types;
     }

--- a/dubbo-metadata-report/dubbo-metadata-definition/src/main/java/org/apache/dubbo/metadata/definition/model/TypeDefinition.java
+++ b/dubbo-metadata-report/dubbo-metadata-definition/src/main/java/org/apache/dubbo/metadata/definition/model/TypeDefinition.java
@@ -48,7 +48,7 @@ public class TypeDefinition {
 
     public List<String> getEnums() {
         if (enums == null) {
-            enums = new ArrayList<String>();
+            enums = new ArrayList<>();
         }
         return enums;
     }
@@ -59,14 +59,14 @@ public class TypeDefinition {
 
     public List<TypeDefinition> getItems() {
         if (items == null) {
-            items = new ArrayList<TypeDefinition>();
+            items = new ArrayList<>();
         }
         return items;
     }
 
     public Map<String, TypeDefinition> getProperties() {
         if (properties == null) {
-            properties = new HashMap<String, TypeDefinition>();
+            properties = new HashMap<>();
         }
         return properties;
     }

--- a/dubbo-metadata-report/dubbo-metadata-definition/src/main/java/org/apache/dubbo/metadata/definition/util/ClassUtils.java
+++ b/dubbo-metadata-report/dubbo-metadata-definition/src/main/java/org/apache/dubbo/metadata/definition/util/ClassUtils.java
@@ -64,7 +64,7 @@ public final class ClassUtils {
      * @return field list
      */
     public static List<Field> getNonStaticFields(final Class<?> clazz) {
-        List<Field> result = new ArrayList<Field>();
+        List<Field> result = new ArrayList<>();
         Class<?> target = clazz;
         while (target != null) {
             if (JaketConfigurationUtils.isExcludedType(target)) {
@@ -94,7 +94,7 @@ public final class ClassUtils {
      * @return methods list
      */
     public static List<Method> getPublicNonStaticMethods(final Class<?> clazz) {
-        List<Method> result = new ArrayList<Method>();
+        List<Method> result = new ArrayList<>();
 
         Method[] methods = clazz.getMethods();
         for (Method method : methods) {

--- a/dubbo-metadata-report/dubbo-metadata-report-api/src/main/java/org/apache/dubbo/metadata/support/AbstractMetadataReport.java
+++ b/dubbo-metadata-report/dubbo-metadata-report-api/src/main/java/org/apache/dubbo/metadata/support/AbstractMetadataReport.java
@@ -65,10 +65,10 @@ public abstract class AbstractMetadataReport implements MetadataReport {
     // Local disk cache, where the special key value.registies records the list of registry centers, and the others are the list of notified service providers
     final Properties properties = new Properties();
     private final ExecutorService reportCacheExecutor = Executors.newFixedThreadPool(1, new NamedThreadFactory("DubboSaveMetadataReport", true));
-    final Map<MetadataIdentifier, Object> allMetadataReports = new ConcurrentHashMap<MetadataIdentifier, Object>(4);
+    final Map<MetadataIdentifier, Object> allMetadataReports = new ConcurrentHashMap<>(4);
 
     private final AtomicLong lastCacheChanged = new AtomicLong();
-    final Map<MetadataIdentifier, Object> failedReports = new ConcurrentHashMap<MetadataIdentifier, Object>(4);
+    final Map<MetadataIdentifier, Object> failedReports = new ConcurrentHashMap<>(4);
     private URL reportURL;
     boolean syncReport;
     // Local disk cache file

--- a/dubbo-metadata-report/dubbo-metadata-report-api/src/main/java/org/apache/dubbo/metadata/support/AbstractMetadataReportFactory.java
+++ b/dubbo-metadata-report/dubbo-metadata-report-api/src/main/java/org/apache/dubbo/metadata/support/AbstractMetadataReportFactory.java
@@ -33,7 +33,7 @@ public abstract class AbstractMetadataReportFactory implements MetadataReportFac
     private static final ReentrantLock LOCK = new ReentrantLock();
 
     // Registry Collection Map<RegistryAddress, Registry>
-    private static final Map<String, MetadataReport> SERVICE_STORE_MAP = new ConcurrentHashMap<String, MetadataReport>();
+    private static final Map<String, MetadataReport> SERVICE_STORE_MAP = new ConcurrentHashMap<>();
 
     @Override
     public MetadataReport getMetadataReport(URL url) {

--- a/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/MetricName.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/main/java/org/apache/dubbo/metrics/MetricName.java
@@ -144,7 +144,7 @@ public class MetricName implements Comparable<MetricName> {
      * @return A newly created metric name with the specified tags associated with it.
      */
     public MetricName tag(Map<String, String> add) {
-        final Map<String, String> tags = new HashMap<String, String>(add);
+        final Map<String, String> tags = new HashMap<>(add);
         tags.putAll(this.tags);
         return new MetricName(key, tags, level);
     }
@@ -167,7 +167,7 @@ public class MetricName implements Comparable<MetricName> {
             throw new IllegalArgumentException("Argument count must be even");
         }
 
-        final Map<String, String> add = new HashMap<String, String>();
+        final Map<String, String> add = new HashMap<>();
 
         for (int i = 0; i < pairs.length; i += 2) {
             add.put(pairs[i], pairs[i+1]);
@@ -185,7 +185,7 @@ public class MetricName implements Comparable<MetricName> {
      **/
     public static MetricName join(MetricName... parts) {
         final StringBuilder nameBuilder = new StringBuilder();
-        final Map<String, String> tags = new HashMap<String, String>();
+        final Map<String, String> tags = new HashMap<>();
 
         boolean first = true;
         MetricName firstName = null;
@@ -382,7 +382,7 @@ public class MetricName implements Comparable<MetricName> {
     }
 
     private Iterable<String> uniqueSortedKeys(Map<String, String> left, Map<String, String> right) {
-        final Set<String> set = new TreeSet<String>(left.keySet());
+        final Set<String> set = new TreeSet<>(left.keySet());
         set.addAll(right.keySet());
         return set;
     }

--- a/dubbo-metrics/dubbo-metrics-api/src/test/java/org/apache/dubbo/metrics/MetricNameTest.java
+++ b/dubbo-metrics/dubbo-metrics-api/src/test/java/org/apache/dubbo/metrics/MetricNameTest.java
@@ -74,7 +74,7 @@ public class MetricNameTest {
 
     @Test
     public void testAddTagsVarious() {
-        final Map<String, String> refTags = new HashMap<String, String>();
+        final Map<String, String> refTags = new HashMap<>();
         refTags.put("foo", "bar");
         final MetricName test = MetricName.EMPTY.tag("foo", "bar");
         final MetricName test2 = MetricName.EMPTY.tag(refTags);
@@ -88,7 +88,7 @@ public class MetricNameTest {
 
     @Test
     public void testTaggedMoreArguments() {
-        final Map<String, String> refTags = new HashMap<String, String>();
+        final Map<String, String> refTags = new HashMap<>();
         refTags.put("foo", "bar");
         refTags.put("baz", "biz");
         Assertions.assertEquals(MetricName.EMPTY.tag("foo", "bar", "baz", "biz").getTags(), refTags);

--- a/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/support/AbstractMonitorFactory.java
+++ b/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/support/AbstractMonitorFactory.java
@@ -52,14 +52,14 @@ public abstract class AbstractMonitorFactory implements MonitorFactory {
     /**
      * The monitor centers Map<RegistryAddress, Registry>
      */
-    private static final Map<String, Monitor> MONITORS = new ConcurrentHashMap<String, Monitor>();
+    private static final Map<String, Monitor> MONITORS = new ConcurrentHashMap<>();
 
-    private static final Map<String, CompletableFuture<Monitor>> FUTURES = new ConcurrentHashMap<String, CompletableFuture<Monitor>>();
+    private static final Map<String, CompletableFuture<Monitor>> FUTURES = new ConcurrentHashMap<>();
 
     /**
      * The monitor create executor
      */
-    private static final ExecutorService executor = new ThreadPoolExecutor(0, 10, 60L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(), new NamedThreadFactory("DubboMonitorCreator", true));
+    private static final ExecutorService executor = new ThreadPoolExecutor(0, 10, 60L, TimeUnit.SECONDS, new SynchronousQueue<>(), new NamedThreadFactory("DubboMonitorCreator", true));
 
     public static Collection<Monitor> getMonitors() {
         return Collections.unmodifiableCollection(MONITORS.values());

--- a/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/support/MonitorFilter.java
+++ b/dubbo-monitor/dubbo-monitor-api/src/main/java/org/apache/dubbo/monitor/support/MonitorFilter.java
@@ -48,7 +48,7 @@ public class MonitorFilter implements Filter {
     /**
      * The Concurrent counter
      */
-    private final ConcurrentMap<String, AtomicInteger> concurrents = new ConcurrentHashMap<String, AtomicInteger>();
+    private final ConcurrentMap<String, AtomicInteger> concurrents = new ConcurrentHashMap<>();
 
     /**
      * The MonitorFactory

--- a/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/DubboMonitor.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/DubboMonitor.java
@@ -67,7 +67,7 @@ public class DubboMonitor implements Monitor {
      */
     private final long monitorInterval;
 
-    private final ConcurrentMap<Statistics, AtomicReference<long[]>> statisticsMap = new ConcurrentHashMap<Statistics, AtomicReference<long[]>>();
+    private final ConcurrentMap<Statistics, AtomicReference<long[]>> statisticsMap = new ConcurrentHashMap<>();
 
     public DubboMonitor(Invoker<MonitorService> monitorInvoker, MonitorService monitorService) {
         this.monitorInvoker = monitorInvoker;

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/decoder/HttpCommandDecoder.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/decoder/HttpCommandDecoder.java
@@ -46,7 +46,7 @@ public class HttpCommandDecoder {
                         commandContext = CommandContextFactory.newInstance(name);
                         commandContext.setHttp(true);
                     } else {
-                        List<String> valueList = new ArrayList<String>();
+                        List<String> valueList = new ArrayList<>();
                         for (List<String> values : queryStringDecoder.parameters().values()) {
                             valueList.addAll(values);
                         }
@@ -54,7 +54,7 @@ public class HttpCommandDecoder {
                     }
                 } else if (request.getMethod() == HttpMethod.POST) {
                     HttpPostRequestDecoder httpPostRequestDecoder = new HttpPostRequestDecoder(request);
-                    List<String> valueList = new ArrayList<String>();
+                    List<String> valueList = new ArrayList<>();
                     for (InterfaceHttpData interfaceHttpData : httpPostRequestDecoder.getBodyHttpDatas()) {
                         if (interfaceHttpData.getHttpDataType() == InterfaceHttpData.HttpDataType.Attribute) {
                             Attribute attribute = (Attribute) interfaceHttpData;

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/util/CommandHelper.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/command/util/CommandHelper.java
@@ -39,7 +39,7 @@ public class CommandHelper {
 
     public static List<Class<?>> getAllCommandClass(){
         final Set<String> commandList = ExtensionLoader.getExtensionLoader(BaseCommand.class).getSupportedExtensions();
-        final List<Class<?>> classes = new ArrayList<Class<?>>();
+        final List<Class<?>> classes = new ArrayList<>();
 
         for (String commandName : commandList) {
             BaseCommand command = ExtensionLoader.getExtensionLoader(BaseCommand.class).getExtension(commandName);

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/textui/TLadder.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/textui/TLadder.java
@@ -35,7 +35,7 @@ public class TLadder implements TComponent {
     // indent length
     private static final int INDENT_STEP = 2;
 
-    private final List<String> items = new ArrayList<String>();
+    private final List<String> items = new ArrayList<>();
 
 
     @Override

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/textui/TTable.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/textui/TTable.java
@@ -323,7 +323,7 @@ public class TTable implements TComponent {
         private final Align align;
 
         // data rows
-        private final List<String> rows = new ArrayList<String>();
+        private final List<String> rows = new ArrayList<>();
 
         public ColumnDefine(int width, boolean isAutoResize, Align align) {
             this.width = width;

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/textui/TTree.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/textui/TTree.java
@@ -195,7 +195,7 @@ public class TTree implements TComponent {
         /**
          * child nodes
          */
-        final List<Node> children = new ArrayList<Node>();
+        final List<Node> children = new ArrayList<>();
 
         /**
          * begin timestamp

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryDirectory.java
@@ -283,7 +283,7 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
 
     private List<Invoker<T>> toMergeInvokerList(List<Invoker<T>> invokers) {
         List<Invoker<T>> mergedInvokers = new ArrayList<>();
-        Map<String, List<Invoker<T>>> groupMap = new HashMap<String, List<Invoker<T>>>();
+        Map<String, List<Invoker<T>>> groupMap = new HashMap<>();
         for (Invoker<T> invoker : invokers) {
             String group = invoker.getUrl().getParameter(Constants.GROUP_KEY, "");
             groupMap.computeIfAbsent(group, k -> new ArrayList<>());
@@ -343,11 +343,11 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
      * @return invokers
      */
     private Map<String, Invoker<T>> toInvokers(List<URL> urls) {
-        Map<String, Invoker<T>> newUrlInvokerMap = new HashMap<String, Invoker<T>>();
+        Map<String, Invoker<T>> newUrlInvokerMap = new HashMap<>();
         if (urls == null || urls.isEmpty()) {
             return newUrlInvokerMap;
         }
-        Set<String> keys = new HashSet<String>();
+        Set<String> keys = new HashSet<>();
         String queryProtocols = this.queryMap.get(Constants.PROTOCOL_KEY);
         for (URL providerUrl : urls) {
             // If protocol is configured at the reference side, only the matching protocol is selected
@@ -393,7 +393,7 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
                         enabled = url.getParameter(Constants.ENABLED_KEY, true);
                     }
                     if (enabled) {
-                        invoker = new InvokerDelegate<T>(protocol.refer(serviceType, url), url, providerUrl);
+                        invoker = new InvokerDelegate<>(protocol.refer(serviceType, url), url, providerUrl);
                     }
                 } catch (Throwable t) {
                     logger.error("Failed to refer invoker for interface:" + serviceType + ",url:(" + url + ")" + t.getMessage(), t);
@@ -505,7 +505,7 @@ public class RegistryDirectory<T> extends AbstractDirectory<T> implements Notify
             for (Map.Entry<String, Invoker<T>> entry : oldUrlInvokerMap.entrySet()) {
                 if (!newInvokers.contains(entry.getValue())) {
                     if (deleted == null) {
-                        deleted = new ArrayList<String>();
+                        deleted = new ArrayList<>();
                     }
                     deleted.add(entry.getKey());
                 }

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/integration/RegistryProtocol.java
@@ -218,8 +218,8 @@ public class RegistryProtocol implements Protocol {
                 exporter = (ExporterChangeableWrapper<T>) bounds.get(key);
                 if (exporter == null) {
 
-                    final Invoker<?> invokerDelegete = new InvokerDelegate<T>(originInvoker, providerUrl);
-                    exporter = new ExporterChangeableWrapper<T>((Exporter<T>) protocol.export(invokerDelegete), originInvoker);
+                    final Invoker<?> invokerDelegete = new InvokerDelegate<>(originInvoker, providerUrl);
+                    exporter = new ExporterChangeableWrapper<>((Exporter<T>) protocol.export(invokerDelegete), originInvoker);
                     bounds.put(key, exporter);
                 }
             }
@@ -262,7 +262,7 @@ public class RegistryProtocol implements Protocol {
         if (exporter == null) {
             logger.warn(new IllegalStateException("error state, exporter should not be null"));
         } else {
-            final Invoker<T> invokerDelegate = new InvokerDelegate<T>(originInvoker, newInvokerUrl);
+            final Invoker<T> invokerDelegate = new InvokerDelegate<>(originInvoker, newInvokerUrl);
             exporter.setExporter(protocol.export(invokerDelegate));
         }
         return exporter;
@@ -365,11 +365,11 @@ public class RegistryProtocol implements Protocol {
     }
 
     private <T> Invoker<T> doRefer(Cluster cluster, Registry registry, Class<T> type, URL url) {
-        RegistryDirectory<T> directory = new RegistryDirectory<T>(type, url);
+        RegistryDirectory<T> directory = new RegistryDirectory<>(type, url);
         directory.setRegistry(registry);
         directory.setProtocol(protocol);
         // all attributes of REFER_KEY
-        Map<String, String> parameters = new HashMap<String, String>(directory.getUrl().getParameters());
+        Map<String, String> parameters = new HashMap<>(directory.getUrl().getParameters());
         URL subscribeUrl = new URL(CONSUMER_PROTOCOL, parameters.remove(REGISTER_IP_KEY), 0, type.getName(), parameters);
         if (!ANY_VALUE.equals(url.getServiceInterface()) && url.getParameter(REGISTER_KEY, true)) {
             directory.setRegisteredConsumerUrl(getRegisteredConsumerUrl(subscribeUrl, url));
@@ -405,7 +405,7 @@ public class RegistryProtocol implements Protocol {
 
     @Override
     public void destroy() {
-        List<Exporter<?>> exporters = new ArrayList<Exporter<?>>(bounds.values());
+        List<Exporter<?>> exporters = new ArrayList<>(bounds.values());
         for (Exporter<?> exporter : exporters) {
             exporter.unexport();
         }
@@ -536,7 +536,7 @@ public class RegistryProtocol implements Protocol {
         }
 
         private List<URL> getMatchedUrls(List<URL> configuratorUrls, URL currentSubscribe) {
-            List<URL> result = new ArrayList<URL>();
+            List<URL> result = new ArrayList<>();
             for (URL url : configuratorUrls) {
                 URL overrideUrl = url;
                 // Compatible with the old version

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/AbstractRegistry.java
@@ -389,8 +389,7 @@ public abstract class AbstractRegistry implements Registry {
         if (logger.isInfoEnabled()) {
             logger.info("Notify urls for subscribe url " + url + ", urls: " + urls);
         }
-        // keep every provider's category.
-        Map<String, List<URL>> result = new HashMap<>();
+        Map<String, List<URL>> result = new HashMap<String, List<URL>>();
         for (URL u : urls) {
             if (UrlUtils.isMatch(url, u)) {
                 String category = u.getParameter(Constants.CATEGORY_KEY, Constants.DEFAULT_CATEGORY);

--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/FailbackRegistry.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/FailbackRegistry.java
@@ -44,15 +44,15 @@ public abstract class FailbackRegistry extends AbstractRegistry {
 
     /*  retry task map */
 
-    private final ConcurrentMap<URL, FailedRegisteredTask> failedRegistered = new ConcurrentHashMap<URL, FailedRegisteredTask>();
+    private final ConcurrentMap<URL, FailedRegisteredTask> failedRegistered = new ConcurrentHashMap<>();
 
-    private final ConcurrentMap<URL, FailedUnregisteredTask> failedUnregistered = new ConcurrentHashMap<URL, FailedUnregisteredTask>();
+    private final ConcurrentMap<URL, FailedUnregisteredTask> failedUnregistered = new ConcurrentHashMap<>();
 
-    private final ConcurrentMap<Holder, FailedSubscribedTask> failedSubscribed = new ConcurrentHashMap<Holder, FailedSubscribedTask>();
+    private final ConcurrentMap<Holder, FailedSubscribedTask> failedSubscribed = new ConcurrentHashMap<>();
 
-    private final ConcurrentMap<Holder, FailedUnsubscribedTask> failedUnsubscribed = new ConcurrentHashMap<Holder, FailedUnsubscribedTask>();
+    private final ConcurrentMap<Holder, FailedUnsubscribedTask> failedUnsubscribed = new ConcurrentHashMap<>();
 
-    private final ConcurrentMap<Holder, FailedNotifiedTask> failedNotified = new ConcurrentHashMap<Holder, FailedNotifiedTask>();
+    private final ConcurrentMap<Holder, FailedNotifiedTask> failedNotified = new ConcurrentHashMap<>();
 
     /**
      * The time in milliseconds the retryExecutor will wait
@@ -367,7 +367,7 @@ public abstract class FailbackRegistry extends AbstractRegistry {
     @Override
     protected void recover() throws Exception {
         // register
-        Set<URL> recoverRegistered = new HashSet<URL>(getRegistered());
+        Set<URL> recoverRegistered = new HashSet<>(getRegistered());
         if (!recoverRegistered.isEmpty()) {
             if (logger.isInfoEnabled()) {
                 logger.info("Recover register url " + recoverRegistered);
@@ -377,7 +377,7 @@ public abstract class FailbackRegistry extends AbstractRegistry {
             }
         }
         // subscribe
-        Map<URL, Set<NotifyListener>> recoverSubscribed = new HashMap<URL, Set<NotifyListener>>(getSubscribed());
+        Map<URL, Set<NotifyListener>> recoverSubscribed = new HashMap<>(getSubscribed());
         if (!recoverSubscribed.isEmpty()) {
             if (logger.isInfoEnabled()) {
                 logger.info("Recover subscribe url " + recoverSubscribed.keySet());

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/PerformanceUtils.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/PerformanceUtils.java
@@ -56,7 +56,7 @@ public class PerformanceUtils {
     }
 
     public static List<String> getEnvironment() {
-        List<String> environment = new ArrayList<String>();
+        List<String> environment = new ArrayList<>();
         environment.add("OS: " + System.getProperty("os.name") + " " + System.getProperty("os.version") + " " + System.getProperty("os.arch", ""));
         environment.add("CPU: " + Runtime.getRuntime().availableProcessors() + " cores");
         environment.add("JVM: " + System.getProperty("java.vm.name") + " " + System.getProperty("java.runtime.version"));

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/AbstractRegistryTest.java
@@ -151,7 +151,7 @@ public class AbstractRegistryTest {
     @Test
     public void testSubscribeAndUnsubscribe() throws Exception {
         //test subscribe
-        final AtomicReference<Boolean> notified = new AtomicReference<Boolean>(false);
+        final AtomicReference<Boolean> notified = new AtomicReference<>(false);
         NotifyListener listener = urls -> notified.set(Boolean.TRUE);
         URL url = new URL("dubbo", "192.168.0.1", 2200);
         abstractRegistry.subscribe(url, listener);
@@ -166,7 +166,7 @@ public class AbstractRegistryTest {
     @Test
     public void testSubscribeIfUrlNull() throws Exception {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            final AtomicReference<Boolean> notified = new AtomicReference<Boolean>(false);
+            final AtomicReference<Boolean> notified = new AtomicReference<>(false);
             NotifyListener listener = urls -> notified.set(Boolean.TRUE);
             URL url = new URL("dubbo", "192.168.0.1", 2200);
             abstractRegistry.subscribe(null, listener);
@@ -177,7 +177,7 @@ public class AbstractRegistryTest {
     @Test
     public void testSubscribeIfListenerNull() throws Exception {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            final AtomicReference<Boolean> notified = new AtomicReference<Boolean>(false);
+            final AtomicReference<Boolean> notified = new AtomicReference<>(false);
             NotifyListener listener = urls -> notified.set(Boolean.TRUE);
             URL url = new URL("dubbo", "192.168.0.1", 2200);
             abstractRegistry.subscribe(url, null);
@@ -188,7 +188,7 @@ public class AbstractRegistryTest {
     @Test
     public void testUnsubscribeIfUrlNull() throws Exception {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            final AtomicReference<Boolean> notified = new AtomicReference<Boolean>(false);
+            final AtomicReference<Boolean> notified = new AtomicReference<>(false);
             NotifyListener listener = urls -> notified.set(Boolean.TRUE);
             abstractRegistry.unsubscribe(null, listener);
             Assertions.fail("unsubscribe url == null");
@@ -198,7 +198,7 @@ public class AbstractRegistryTest {
     @Test
     public void testUnsubscribeIfNotifyNull() throws Exception {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            final AtomicReference<Boolean> notified = new AtomicReference<Boolean>(false);
+            final AtomicReference<Boolean> notified = new AtomicReference<>(false);
             URL url = new URL("dubbo", "192.168.0.1", 2200);
             abstractRegistry.unsubscribe(url, null);
             Assertions.fail("unsubscribe listener == null");
@@ -307,7 +307,7 @@ public class AbstractRegistryTest {
      */
     @Test
     public void testNotify() throws Exception {
-        final AtomicReference<Boolean> notified = new AtomicReference<Boolean>(false);
+        final AtomicReference<Boolean> notified = new AtomicReference<>(false);
         NotifyListener listner1 = urls -> notified.set(Boolean.TRUE);
         URL url1 = new URL("dubbo", "192.168.0.1", 2200, parametersConsumer);
         abstractRegistry.subscribe(url1, listner1);
@@ -333,7 +333,7 @@ public class AbstractRegistryTest {
      */
     @Test
     public void testNotifyList() throws Exception {
-        final AtomicReference<Boolean> notified = new AtomicReference<Boolean>(false);
+        final AtomicReference<Boolean> notified = new AtomicReference<>(false);
         NotifyListener listner1 = urls -> notified.set(Boolean.TRUE);
         URL url1 = new URL("dubbo", "192.168.0.1", 2200, parametersConsumer);
         abstractRegistry.subscribe(url1, listner1);
@@ -357,7 +357,7 @@ public class AbstractRegistryTest {
     @Test
     public void testNotifyIfURLNull() throws Exception {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            final AtomicReference<Boolean> notified = new AtomicReference<Boolean>(false);
+            final AtomicReference<Boolean> notified = new AtomicReference<>(false);
             NotifyListener listner1 = urls -> notified.set(Boolean.TRUE);
             URL url1 = new URL("dubbo", "192.168.0.1", 2200, parametersConsumer);
             abstractRegistry.subscribe(url1, listner1);
@@ -379,7 +379,7 @@ public class AbstractRegistryTest {
     @Test
     public void testNotifyIfNotifyNull() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            final AtomicReference<Boolean> notified = new AtomicReference<Boolean>(false);
+            final AtomicReference<Boolean> notified = new AtomicReference<>(false);
             NotifyListener listner1 = urls -> notified.set(Boolean.TRUE);
             URL url1 = new URL("dubbo", "192.168.0.1", 2200, parametersConsumer);
             abstractRegistry.subscribe(url1, listner1);

--- a/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/FailbackRegistryTest.java
+++ b/dubbo-registry/dubbo-registry-api/src/test/java/org/apache/dubbo/registry/support/FailbackRegistryTest.java
@@ -59,7 +59,7 @@ public class FailbackRegistryTest {
     @Test
     public void testDoRetry() throws Exception {
 
-        final AtomicReference<Boolean> notified = new AtomicReference<Boolean>(false);
+        final AtomicReference<Boolean> notified = new AtomicReference<>(false);
 
         // the latest latch just for 3. Because retry method has been removed.
         final CountDownLatch latch = new CountDownLatch(2);
@@ -119,7 +119,7 @@ public class FailbackRegistryTest {
     @Test
     public void testDoRetry_register() throws Exception {
 
-        final AtomicReference<Boolean> notified = new AtomicReference<Boolean>(false);
+        final AtomicReference<Boolean> notified = new AtomicReference<>(false);
         final CountDownLatch latch = new CountDownLatch(1);//All of them are called 4 times. A successful attempt to lose 1. subscribe will not be done
 
         NotifyListener listner = new NotifyListener() {
@@ -184,7 +184,7 @@ public class FailbackRegistryTest {
     @Test
     public void testRecover() throws Exception {
         CountDownLatch countDownLatch = new CountDownLatch(4);
-        final AtomicReference<Boolean> notified = new AtomicReference<Boolean>(false);
+        final AtomicReference<Boolean> notified = new AtomicReference<>(false);
         NotifyListener listener = new NotifyListener() {
             @Override
             public void notify(List<URL> urls) {

--- a/dubbo-registry/dubbo-registry-default/src/test/java/org/apache/dubbo/registry/dubbo/AbstractRegistryService.java
+++ b/dubbo-registry/dubbo-registry-default/src/test/java/org/apache/dubbo/registry/dubbo/AbstractRegistryService.java
@@ -41,19 +41,19 @@ public abstract class AbstractRegistryService implements RegistryService {
 
     // Registered services
     // Map<serviceName, Map<url, queryString>>
-    private final ConcurrentMap<String, List<URL>> registered = new ConcurrentHashMap<String, List<URL>>();
+    private final ConcurrentMap<String, List<URL>> registered = new ConcurrentHashMap<>();
 
     // Subscribed services
     // Map<serviceName, queryString>
-    private final ConcurrentMap<String, Map<String, String>> subscribed = new ConcurrentHashMap<String, Map<String, String>>();
+    private final ConcurrentMap<String, Map<String, String>> subscribed = new ConcurrentHashMap<>();
 
     // Notified services
     // Map<serviceName, Map<url, queryString>>
-    private final ConcurrentMap<String, List<URL>> notified = new ConcurrentHashMap<String, List<URL>>();
+    private final ConcurrentMap<String, List<URL>> notified = new ConcurrentHashMap<>();
 
     // Listeners list for subscribed services
     // Map<serviceName, List<notificationListener>>
-    private final ConcurrentMap<String, List<NotifyListener>> notifyListeners = new ConcurrentHashMap<String, List<NotifyListener>>();
+    private final ConcurrentMap<String, List<NotifyListener>> notifyListeners = new ConcurrentHashMap<>();
 
     @Override
     public void register(URL url) {

--- a/dubbo-registry/dubbo-registry-default/src/test/java/org/apache/dubbo/registry/dubbo/RegistryDirectoryTest.java
+++ b/dubbo-registry/dubbo-registry-default/src/test/java/org/apache/dubbo/registry/dubbo/RegistryDirectoryTest.java
@@ -152,7 +152,7 @@ public class RegistryDirectoryTest {
     @Test
     public void testNotified_WithError() {
         RegistryDirectory registryDirectory = getRegistryDirectory();
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         // ignore error log
         URL badurl = URL.valueOf("notsupported://127.0.0.1/" + service);
         serviceUrls.add(badurl);
@@ -166,7 +166,7 @@ public class RegistryDirectoryTest {
 
     @Test
     public void testNotified_WithDuplicateUrls() {
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         // ignore error log
         serviceUrls.add(SERVICEURL);
         serviceUrls.add(SERVICEURL);
@@ -180,7 +180,7 @@ public class RegistryDirectoryTest {
     // forbid
     private void testforbid(RegistryDirectory registryDirectory) {
         invocation = new RpcInvocation();
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         serviceUrls.add(new URL(Constants.EMPTY_PROTOCOL, Constants.ANYHOST_VALUE, 0, service, Constants.CATEGORY_KEY, Constants.PROVIDERS_CATEGORY));
         registryDirectory.notify(serviceUrls);
         Assertions.assertEquals(false,
@@ -198,7 +198,7 @@ public class RegistryDirectoryTest {
     public void test_NotifiedDubbo1() {
         URL errorPathUrl = URL.valueOf("notsupport:/" + "xxx" + "?refer=" + URL.encode("interface=" + service));
         RegistryDirectory registryDirectory = getRegistryDirectory(errorPathUrl);
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         URL Dubbo1URL = URL.valueOf("dubbo://127.0.0.1:9098?lazy=true");
         serviceUrls.add(Dubbo1URL.addParameter("methods", "getXXX"));
         registryDirectory.notify(serviceUrls);
@@ -217,7 +217,7 @@ public class RegistryDirectoryTest {
 
     // notify one invoker
     private void test_Notified_only_routers(RegistryDirectory registryDirectory) {
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         serviceUrls.add(URL.valueOf("empty://127.0.0.1/?category=routers"));
         registryDirectory.notify(serviceUrls);
     }
@@ -225,7 +225,7 @@ public class RegistryDirectoryTest {
     // notify one invoker
     private void test_Notified1invokers(RegistryDirectory registryDirectory) {
 
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         serviceUrls.add(SERVICEURL.addParameter("methods", "getXXX1").addParameter(Constants.APPLICATION_KEY, "mockApplicationName"));// .addParameter("refer.autodestroy", "true")
         registryDirectory.notify(serviceUrls);
         Assertions.assertEquals(true, registryDirectory.isAvailable());
@@ -250,7 +250,7 @@ public class RegistryDirectoryTest {
 
     // 2 invokers===================================
     private void test_Notified2invokers(RegistryDirectory registryDirectory) {
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         serviceUrls.add(SERVICEURL.addParameter("methods", "getXXX1"));
         serviceUrls.add(SERVICEURL2.addParameter("methods", "getXXX1,getXXX2"));
         serviceUrls.add(SERVICEURL2.addParameter("methods", "getXXX1,getXXX2"));
@@ -274,7 +274,7 @@ public class RegistryDirectoryTest {
 
     // 3 invoker notifications===================================
     private void test_Notified3invokers(RegistryDirectory registryDirectory) {
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         serviceUrls.add(SERVICEURL.addParameter("methods", "getXXX1"));
         serviceUrls.add(SERVICEURL2.addParameter("methods", "getXXX1,getXXX2"));
         serviceUrls.add(SERVICEURL3.addParameter("methods", "getXXX1,getXXX2,getXXX3"));
@@ -317,7 +317,7 @@ public class RegistryDirectoryTest {
                 regurl);
         registryDirectory2.setProtocol(protocol);
 
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         // The parameters of the inspection registry need to be cleared
         {
             serviceUrls.clear();
@@ -403,7 +403,7 @@ public class RegistryDirectoryTest {
     public void testDestroy() {
         RegistryDirectory registryDirectory = getRegistryDirectory();
 
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         serviceUrls.add(SERVICEURL.addParameter("methods", "getXXX1"));
         serviceUrls.add(SERVICEURL2.addParameter("methods", "getXXX1,getXXX2"));
         serviceUrls.add(SERVICEURL3.addParameter("methods", "getXXX1,getXXX2,getXXX3"));
@@ -456,7 +456,7 @@ public class RegistryDirectoryTest {
 
         RegistryDirectory registryDirectory = getRegistryDirectory();
 
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         URL serviceURL = SERVICEURL_DUBBO_NOPATH.addParameter("methods", "getXXX1,getXXX2,getXXX3");
         serviceUrls.add(serviceURL);
 
@@ -485,7 +485,7 @@ public class RegistryDirectoryTest {
     @Test
     public void testParmeterRoute() {
         RegistryDirectory registryDirectory = getRegistryDirectory();
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         serviceUrls.add(SERVICEURL.addParameter("methods", "getXXX1.napoli"));
         serviceUrls.add(SERVICEURL2.addParameter("methods", "getXXX1.MORGAN,getXXX2"));
         serviceUrls.add(SERVICEURL3.addParameter("methods", "getXXX1.morgan,getXXX2,getXXX3"));
@@ -509,7 +509,7 @@ public class RegistryDirectoryTest {
         RegistryDirectory registryDirectory = getRegistryDirectory();
         List invokers = null;
 
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         registryDirectory.notify(serviceUrls);
 
         RpcInvocation inv = new RpcInvocation();
@@ -543,7 +543,7 @@ public class RegistryDirectoryTest {
         URL routerurl = URL.valueOf(Constants.ROUTE_PROTOCOL + "://127.0.0.1:9096/");
         URL routerurl2 = URL.valueOf(Constants.ROUTE_PROTOCOL + "://127.0.0.1:9097/");
 
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         // without ROUTER_KEY, the first router should not be created.
         serviceUrls.add(routerurl.addParameter(Constants.CATEGORY_KEY, Constants.ROUTERS_CATEGORY).addParameter(Constants.TYPE_KEY, "javascript").addParameter(Constants.ROUTER_KEY,
                 "notsupported").addParameter(Constants.RULE_KEY,
@@ -578,14 +578,14 @@ public class RegistryDirectoryTest {
     @Test
     public void testNotifyoverrideUrls_beforeInvoker() {
         RegistryDirectory registryDirectory = getRegistryDirectory();
-        List<URL> overrideUrls = new ArrayList<URL>();
+        List<URL> overrideUrls = new ArrayList<>();
         overrideUrls.add(URL.valueOf("override://0.0.0.0?timeout=1&connections=5"));
         registryDirectory.notify(overrideUrls);
         //The registry is initially pushed to override only, and the dirctory state should be false because there is no invoker.
         Assertions.assertEquals(false, registryDirectory.isAvailable());
 
         //After pushing two provider, the directory state is restored to true
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         serviceUrls.add(SERVICEURL.addParameter("timeout", "1000"));
         serviceUrls.add(SERVICEURL2.addParameter("timeout", "1000").addParameter("connections", "10"));
 
@@ -612,14 +612,14 @@ public class RegistryDirectoryTest {
         RegistryDirectory registryDirectory = getRegistryDirectory();
 
         //After pushing two provider, the directory state is restored to true
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         serviceUrls.add(SERVICEURL.addParameter("timeout", "1000"));
         serviceUrls.add(SERVICEURL2.addParameter("timeout", "1000").addParameter("connections", "10"));
 
         registryDirectory.notify(serviceUrls);
         Assertions.assertEquals(true, registryDirectory.isAvailable());
 
-        List<URL> overrideUrls = new ArrayList<URL>();
+        List<URL> overrideUrls = new ArrayList<>();
         overrideUrls.add(URL.valueOf("override://0.0.0.0?timeout=1&connections=5"));
         registryDirectory.notify(overrideUrls);
 
@@ -642,7 +642,7 @@ public class RegistryDirectoryTest {
     public void testNotifyoverrideUrls_withInvoker() {
         RegistryDirectory registryDirectory = getRegistryDirectory();
 
-        List<URL> durls = new ArrayList<URL>();
+        List<URL> durls = new ArrayList<>();
         durls.add(SERVICEURL.addParameter("timeout", "1000"));
         durls.add(SERVICEURL2.addParameter("timeout", "1000").addParameter("connections", "10"));
         durls.add(URL.valueOf("override://0.0.0.0?timeout=1&connections=5"));
@@ -671,7 +671,7 @@ public class RegistryDirectoryTest {
         RegistryDirectory registryDirectory = getRegistryDirectory();
         invocation = new RpcInvocation();
 
-        List<URL> durls = new ArrayList<URL>();
+        List<URL> durls = new ArrayList<>();
         durls.add(SERVICEURL.addParameter("timeout", "1"));//One is the same, one is different
         durls.add(SERVICEURL2.addParameter("timeout", "1").addParameter("connections", "5"));
         registryDirectory.notify(durls);
@@ -680,7 +680,7 @@ public class RegistryDirectoryTest {
         Invoker<?> a1Invoker = invokers.get(0);
         Invoker<?> b1Invoker = invokers.get(1);
 
-        durls = new ArrayList<URL>();
+        durls = new ArrayList<>();
         durls.add(URL.valueOf("override://0.0.0.0?timeout=1&connections=5"));
         registryDirectory.notify(durls);
         Assertions.assertEquals(true, registryDirectory.isAvailable());
@@ -705,12 +705,12 @@ public class RegistryDirectoryTest {
         RegistryDirectory registryDirectory = getRegistryDirectory();
         invocation = new RpcInvocation();
 
-        List<URL> durls = new ArrayList<URL>();
+        List<URL> durls = new ArrayList<>();
         durls.add(SERVICEURL.setHost("10.20.30.140").addParameter("timeout", "1").addParameter(Constants.SIDE_KEY, Constants.CONSUMER_SIDE));//One is the same, one is different
         durls.add(SERVICEURL2.setHost("10.20.30.141").addParameter("timeout", "2").addParameter(Constants.SIDE_KEY, Constants.CONSUMER_SIDE));
         registryDirectory.notify(durls);
 
-        durls = new ArrayList<URL>();
+        durls = new ArrayList<>();
         durls.add(URL.valueOf("override://0.0.0.0?timeout=3"));
         durls.add(URL.valueOf("override://10.20.30.141:9092?timeout=4"));
         registryDirectory.notify(durls);
@@ -731,15 +731,15 @@ public class RegistryDirectoryTest {
         RegistryDirectory registryDirectory = getRegistryDirectory();
         invocation = new RpcInvocation();
 
-        List<URL> durls = new ArrayList<URL>();
+        List<URL> durls = new ArrayList<>();
         durls.add(SERVICEURL.setHost("10.20.30.140").addParameter("timeout", "1"));
         registryDirectory.notify(durls);
 
-        durls = new ArrayList<URL>();
+        durls = new ArrayList<>();
         durls.add(URL.valueOf("override://0.0.0.0?timeout=1000"));
         registryDirectory.notify(durls);
 
-        durls = new ArrayList<URL>();
+        durls = new ArrayList<>();
         durls.add(URL.valueOf("override://0.0.0.0?timeout=3"));
         durls.add(URL.valueOf("override://0.0.0.0"));
         registryDirectory.notify(durls);
@@ -759,13 +759,13 @@ public class RegistryDirectoryTest {
         RegistryDirectory registryDirectory = getRegistryDirectory();
         invocation = new RpcInvocation();
 
-        List<URL> durls = new ArrayList<URL>();
+        List<URL> durls = new ArrayList<>();
         durls.add(SERVICEURL.setHost("10.20.30.140").addParameter("timeout", "1"));
         registryDirectory.notify(durls);
         Assertions.assertEquals(null, registryDirectory.getUrl().getParameter("mock"));
 
         //override
-        durls = new ArrayList<URL>();
+        durls = new ArrayList<>();
         durls.add(URL.valueOf("override://0.0.0.0?timeout=1000&mock=fail"));
         registryDirectory.notify(durls);
         List<Invoker<?>> invokers = registryDirectory.list(invocation);
@@ -774,7 +774,7 @@ public class RegistryDirectoryTest {
         Assertions.assertEquals("fail", registryDirectory.getUrl().getParameter("mock"));
 
         //override clean
-        durls = new ArrayList<URL>();
+        durls = new ArrayList<>();
         durls.add(URL.valueOf("override://0.0.0.0/dubbo.test.api.HelloService"));
         registryDirectory.notify(durls);
         invokers = registryDirectory.list(invocation);
@@ -794,11 +794,11 @@ public class RegistryDirectoryTest {
         RegistryDirectory registryDirectory = getRegistryDirectory();
         invocation = new RpcInvocation();
 
-        List<URL> durls = new ArrayList<URL>();
+        List<URL> durls = new ArrayList<>();
         durls.add(SERVICEURL.setHost("10.20.30.140").addParameter("timeout", "1"));
         registryDirectory.notify(durls);
 
-        durls = new ArrayList<URL>();
+        durls = new ArrayList<>();
         durls.add(URL.valueOf("override://0.0.0.0?timeout=3"));
         durls.add(URL.valueOf("override://0.0.0.0"));
         durls.add(URL.valueOf("override://10.20.30.140:9091?timeout=4"));
@@ -818,12 +818,12 @@ public class RegistryDirectoryTest {
         RegistryDirectory registryDirectory = getRegistryDirectory();
         invocation = new RpcInvocation();
 
-        List<URL> durls = new ArrayList<URL>();
+        List<URL> durls = new ArrayList<>();
         durls.add(SERVICEURL.setHost("10.20.30.140"));
         durls.add(SERVICEURL.setHost("10.20.30.141"));
         registryDirectory.notify(durls);
 
-        durls = new ArrayList<URL>();
+        durls = new ArrayList<>();
         durls.add(URL.valueOf("override://0.0.0.0?" + Constants.ENABLED_KEY + "=false"));
         registryDirectory.notify(durls);
 
@@ -841,12 +841,12 @@ public class RegistryDirectoryTest {
         RegistryDirectory registryDirectory = getRegistryDirectory();
         invocation = new RpcInvocation();
 
-        List<URL> durls = new ArrayList<URL>();
+        List<URL> durls = new ArrayList<>();
         durls.add(SERVICEURL.setHost("10.20.30.140"));
         durls.add(SERVICEURL.setHost("10.20.30.141"));
         registryDirectory.notify(durls);
 
-        durls = new ArrayList<URL>();
+        durls = new ArrayList<>();
         durls.add(URL.valueOf("override://10.20.30.140:9091?" + Constants.DISABLED_KEY + "=true"));
         registryDirectory.notify(durls);
 
@@ -854,7 +854,7 @@ public class RegistryDirectoryTest {
         Assertions.assertEquals(1, invokers.size());
         Assertions.assertEquals("10.20.30.141", invokers.get(0).getUrl().getHost());
 
-        durls = new ArrayList<URL>();
+        durls = new ArrayList<>();
         durls.add(URL.valueOf("empty://0.0.0.0?" + Constants.DISABLED_KEY + "=true&" + Constants.CATEGORY_KEY + "=" + Constants.CONFIGURATORS_CATEGORY));
         registryDirectory.notify(durls);
         List<Invoker<?>> invokers2 = registryDirectory.list(invocation);
@@ -870,7 +870,7 @@ public class RegistryDirectoryTest {
         RegistryDirectory registryDirectory = getRegistryDirectory();
         invocation = new RpcInvocation();
 
-        List<URL> durls = new ArrayList<URL>();
+        List<URL> durls = new ArrayList<>();
         durls.add(SERVICEURL.setHost("10.20.30.140"));
         durls.add(SERVICEURL.setHost("10.20.30.141"));
         registryDirectory.notify(durls);
@@ -878,14 +878,14 @@ public class RegistryDirectoryTest {
         List<Invoker<?>> invokers = registryDirectory.list(invocation);
         Assertions.assertEquals(2, invokers.size());
 
-        durls = new ArrayList<URL>();
+        durls = new ArrayList<>();
         durls.add(SERVICEURL.setHost("10.20.30.140"));
         registryDirectory.notify(durls);
         List<Invoker<?>> invokers2 = registryDirectory.list(invocation);
         Assertions.assertEquals(1, invokers2.size());
         Assertions.assertEquals("10.20.30.140", invokers2.get(0).getUrl().getHost());
 
-        durls = new ArrayList<URL>();
+        durls = new ArrayList<>();
         durls.add(URL.valueOf("empty://0.0.0.0?" + Constants.DISABLED_KEY + "=true&" + Constants.CATEGORY_KEY + "=" + Constants.CONFIGURATORS_CATEGORY));
         registryDirectory.notify(durls);
         List<Invoker<?>> invokers3 = registryDirectory.list(invocation);
@@ -902,7 +902,7 @@ public class RegistryDirectoryTest {
         invocation = new RpcInvocation();
 
         // Initially disable
-        List<URL> durls = new ArrayList<URL>();
+        List<URL> durls = new ArrayList<>();
         durls.add(SERVICEURL.setHost("10.20.30.140").addParameter(Constants.ENABLED_KEY, "false"));
         durls.add(SERVICEURL.setHost("10.20.30.141"));
         registryDirectory.notify(durls);
@@ -912,7 +912,7 @@ public class RegistryDirectoryTest {
         Assertions.assertEquals("10.20.30.141", invokers.get(0).getUrl().getHost());
 
         //Enabled by override rule
-        durls = new ArrayList<URL>();
+        durls = new ArrayList<>();
         durls.add(URL.valueOf("override://10.20.30.140:9091?" + Constants.DISABLED_KEY + "=false"));
         registryDirectory.notify(durls);
         List<Invoker<?>> invokers2 = registryDirectory.list(invocation);
@@ -929,7 +929,7 @@ public class RegistryDirectoryTest {
                 "script"); // FIX
         // BAD
 
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         // without ROUTER_KEY, the first router should not be created.
         serviceUrls.add(routerurl);
         registryDirectory.notify(serviceUrls);
@@ -951,7 +951,7 @@ public class RegistryDirectoryTest {
     public void testNotify_MockProviderOnly() {
         RegistryDirectory registryDirectory = getRegistryDirectory();
 
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         serviceUrls.add(SERVICEURL.addParameter("methods", "getXXX1"));
         serviceUrls.add(SERVICEURL2.addParameter("methods", "getXXX1,getXXX2"));
         serviceUrls.add(SERVICEURL.setProtocol(Constants.MOCK_PROTOCOL));
@@ -976,7 +976,7 @@ public class RegistryDirectoryTest {
     public void test_Notified_acceptProtocol0() {
         URL errorPathUrl = URL.valueOf("notsupport:/xxx?refer=" + URL.encode("interface=" + service));
         RegistryDirectory registryDirectory = getRegistryDirectory(errorPathUrl);
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         URL dubbo1URL = URL.valueOf("dubbo://127.0.0.1:9098?lazy=true&methods=getXXX");
         URL dubbo2URL = URL.valueOf("injvm://127.0.0.1:9099?lazy=true&methods=getXXX");
         serviceUrls.add(dubbo1URL);
@@ -995,7 +995,7 @@ public class RegistryDirectoryTest {
         URL errorPathUrl = URL.valueOf("notsupport:/xxx");
         errorPathUrl = errorPathUrl.addParameterAndEncoded(Constants.REFER_KEY, "interface=" + service + "&protocol=dubbo");
         RegistryDirectory registryDirectory = getRegistryDirectory(errorPathUrl);
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         URL dubbo1URL = URL.valueOf("dubbo://127.0.0.1:9098?lazy=true&methods=getXXX");
         URL dubbo2URL = URL.valueOf("injvm://127.0.0.1:9098?lazy=true&methods=getXXX");
         serviceUrls.add(dubbo1URL);
@@ -1014,7 +1014,7 @@ public class RegistryDirectoryTest {
         URL errorPathUrl = URL.valueOf("notsupport:/xxx");
         errorPathUrl = errorPathUrl.addParameterAndEncoded(Constants.REFER_KEY, "interface=" + service + "&protocol=dubbo,injvm");
         RegistryDirectory registryDirectory = getRegistryDirectory(errorPathUrl);
-        List<URL> serviceUrls = new ArrayList<URL>();
+        List<URL> serviceUrls = new ArrayList<>();
         URL dubbo1URL = URL.valueOf("dubbo://127.0.0.1:9098?lazy=true&methods=getXXX");
         URL dubbo2URL = URL.valueOf("injvm://127.0.0.1:9099?lazy=true&methods=getXXX");
         serviceUrls.add(dubbo1URL);

--- a/dubbo-registry/dubbo-registry-default/src/test/java/org/apache/dubbo/registry/dubbo/RegistryProtocolTest.java
+++ b/dubbo-registry/dubbo-registry-default/src/test/java/org/apache/dubbo/registry/dubbo/RegistryProtocolTest.java
@@ -102,11 +102,11 @@ public class RegistryProtocolTest {
     @Test
     public void testNotifyOverride() throws Exception {
         URL newRegistryUrl = registryUrl.addParameter(Constants.EXPORT_KEY, serviceUrl);
-        Invoker<RegistryProtocolTest> invoker = new MockInvoker<RegistryProtocolTest>(RegistryProtocolTest.class, newRegistryUrl);
+        Invoker<RegistryProtocolTest> invoker = new MockInvoker<>(RegistryProtocolTest.class, newRegistryUrl);
         Exporter<?> exporter = protocol.export(invoker);
         RegistryProtocol rprotocol = RegistryProtocol.getRegistryProtocol();
         NotifyListener listener = getListener(rprotocol);
-        List<URL> urls = new ArrayList<URL>();
+        List<URL> urls = new ArrayList<>();
         urls.add(URL.valueOf("override://0.0.0.0/?timeout=1000"));
         urls.add(URL.valueOf("override://0.0.0.0/" + service + "?timeout=100"));
         urls.add(URL.valueOf("override://0.0.0.0/" + service + "?x=y"));
@@ -132,11 +132,11 @@ public class RegistryProtocolTest {
     @Test
     public void testNotifyOverride_notmatch() throws Exception {
         URL newRegistryUrl = registryUrl.addParameter(Constants.EXPORT_KEY, serviceUrl);
-        Invoker<RegistryProtocolTest> invoker = new MockInvoker<RegistryProtocolTest>(RegistryProtocolTest.class, newRegistryUrl);
+        Invoker<RegistryProtocolTest> invoker = new MockInvoker<>(RegistryProtocolTest.class, newRegistryUrl);
         Exporter<?> exporter = protocol.export(invoker);
         RegistryProtocol rprotocol = RegistryProtocol.getRegistryProtocol();
         NotifyListener listener = getListener(rprotocol);
-        List<URL> urls = new ArrayList<URL>();
+        List<URL> urls = new ArrayList<>();
         urls.add(URL.valueOf("override://0.0.0.0/org.apache.dubbo.registry.protocol.HackService?timeout=100"));
         listener.notify(urls);
         assertEquals(true, exporter.getInvoker().isAvailable());
@@ -151,7 +151,7 @@ public class RegistryProtocolTest {
     @Test
     public void testDestoryRegistry() {
         URL newRegistryUrl = registryUrl.addParameter(Constants.EXPORT_KEY, serviceUrl);
-        Invoker<RegistryProtocolTest> invoker = new MockInvoker<RegistryProtocolTest>(RegistryProtocolTest.class, newRegistryUrl);
+        Invoker<RegistryProtocolTest> invoker = new MockInvoker<>(RegistryProtocolTest.class, newRegistryUrl);
         Exporter<?> exporter = protocol.export(invoker);
         destroyRegistryProtocol();
         try {

--- a/dubbo-registry/dubbo-registry-default/src/test/java/org/apache/dubbo/registry/dubbo/SimpleRegistryService.java
+++ b/dubbo-registry/dubbo-registry-default/src/test/java/org/apache/dubbo/registry/dubbo/SimpleRegistryService.java
@@ -37,8 +37,8 @@ import java.util.concurrent.ConcurrentMap;
 public class SimpleRegistryService extends AbstractRegistryService {
 
     private final static Logger logger = LoggerFactory.getLogger(SimpleRegistryService.class);
-    private final ConcurrentMap<String, ConcurrentMap<String, URL>> remoteRegistered = new ConcurrentHashMap<String, ConcurrentMap<String, URL>>();
-    private final ConcurrentMap<String, ConcurrentMap<String, NotifyListener>> remoteListeners = new ConcurrentHashMap<String, ConcurrentMap<String, NotifyListener>>();
+    private final ConcurrentMap<String, ConcurrentMap<String, URL>> remoteRegistered = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ConcurrentMap<String, NotifyListener>> remoteListeners = new ConcurrentHashMap<>();
     private List<String> registries;
 
     @Override

--- a/dubbo-registry/dubbo-registry-multicast/src/main/java/org/apache/dubbo/registry/multicast/MulticastRegistry.java
+++ b/dubbo-registry/dubbo-registry-multicast/src/main/java/org/apache/dubbo/registry/multicast/MulticastRegistry.java
@@ -65,7 +65,7 @@ public class MulticastRegistry extends FailbackRegistry {
 
     private final int multicastPort;
 
-    private final ConcurrentMap<URL, Set<URL>> received = new ConcurrentHashMap<URL, Set<URL>>();
+    private final ConcurrentMap<URL, Set<URL>> received = new ConcurrentHashMap<>();
 
     private final ScheduledExecutorService cleanExecutor = Executors.newScheduledThreadPool(1, new NamedThreadFactory("DubboMulticastRegistryCleanTimer", true));
 
@@ -347,7 +347,7 @@ public class MulticastRegistry extends FailbackRegistry {
                 }
                 if (urls == null || urls.isEmpty()) {
                     if (urls == null) {
-                        urls = new ConcurrentHashSet<URL>();
+                        urls = new ConcurrentHashSet<>();
                     }
                     URL empty = url.setProtocol(Constants.EMPTY_PROTOCOL);
                     urls.add(empty);
@@ -366,7 +366,7 @@ public class MulticastRegistry extends FailbackRegistry {
     }
 
     private List<URL> toList(Set<URL> urls) {
-        List<URL> list = new ArrayList<URL>();
+        List<URL> list = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(urls)) {
             for (URL url : urls) {
                 list.add(url);

--- a/dubbo-registry/dubbo-registry-redis/src/main/java/org/apache/dubbo/registry/redis/RedisRegistry.java
+++ b/dubbo-registry/dubbo-registry-redis/src/main/java/org/apache/dubbo/registry/redis/RedisRegistry.java
@@ -73,7 +73,7 @@ public class RedisRegistry extends FailbackRegistry {
 
     private final Map<String, JedisPool> jedisPools = new ConcurrentHashMap<>();
 
-    private final ConcurrentMap<String, Notifier> notifiers = new ConcurrentHashMap<String, Notifier>();
+    private final ConcurrentMap<String, Notifier> notifiers = new ConcurrentHashMap<>();
 
     private final int reconnectPeriod;
 
@@ -123,7 +123,7 @@ public class RedisRegistry extends FailbackRegistry {
         }
         replicate = "replicate".equals(cluster);
 
-        List<String> addresses = new ArrayList<String>();
+        List<String> addresses = new ArrayList<>();
         addresses.add(url.getAddress());
         String[] backups = url.getParameter(Constants.BACKUP_KEY, new String[0]);
         if (ArrayUtils.isNotEmpty(backups)) {

--- a/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/ZookeeperRegistry.java
+++ b/dubbo-registry/dubbo-registry-zookeeper/src/main/java/org/apache/dubbo/registry/zookeeper/ZookeeperRegistry.java
@@ -53,7 +53,7 @@ public class ZookeeperRegistry extends FailbackRegistry {
 
     private final Set<String> anyServices = new ConcurrentHashSet<>();
 
-    private final ConcurrentMap<URL, ConcurrentMap<NotifyListener, ChildListener>> zkListeners = new ConcurrentHashMap<URL, ConcurrentMap<NotifyListener, ChildListener>>();
+    private final ConcurrentMap<URL, ConcurrentMap<NotifyListener, ChildListener>> zkListeners = new ConcurrentHashMap<>();
 
     private final ZookeeperClient zkClient;
 

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/ReplierDispatcher.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/ReplierDispatcher.java
@@ -29,7 +29,7 @@ public class ReplierDispatcher implements Replier<Object> {
 
     private final Replier<?> defaultReplier;
 
-    private final Map<Class<?>, Replier<?>> repliers = new ConcurrentHashMap<Class<?>, Replier<?>>();
+    private final Map<Class<?>, Replier<?>> repliers = new ConcurrentHashMap<>();
 
     public ReplierDispatcher() {
         this(null, null);

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeServer.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/header/HeaderExchangeServer.java
@@ -159,7 +159,7 @@ public class HeaderExchangeServer implements ExchangeServer {
 
     @Override
     public Collection<ExchangeChannel> getExchangeChannels() {
-        Collection<ExchangeChannel> exchangeChannels = new ArrayList<ExchangeChannel>();
+        Collection<ExchangeChannel> exchangeChannels = new ArrayList<>();
         Collection<Channel> channels = server.getChannels();
         if (CollectionUtils.isNotEmpty(channels)) {
             for (Channel channel : channels) {

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/codec/TelnetCodec.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/codec/TelnetCodec.java
@@ -277,7 +277,7 @@ public class TelnetCodec extends TransportCodec {
         String result = toString(message, getCharset(channel));
         if (result.trim().length() > 0) {
             if (history == null) {
-                history = new LinkedList<String>();
+                history = new LinkedList<>();
                 channel.setAttribute(HISTORY_LIST_KEY, history);
             }
             if (history.isEmpty()) {

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/support/command/HelpTelnetHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/support/command/HelpTelnetHandler.java
@@ -53,12 +53,12 @@ public class HelpTelnetHandler implements TelnetHandler {
             buf.append(help.detail().replace("\r\n", "    \r\n").replace("\n", "    \n"));
             return buf.toString();
         } else {
-            List<List<String>> table = new ArrayList<List<String>>();
+            List<List<String>> table = new ArrayList<>();
             List<TelnetHandler> handlers = extensionLoader.getActivateExtension(channel.getUrl(), "telnet");
             if (CollectionUtils.isNotEmpty(handlers)) {
                 for (TelnetHandler handler : handlers) {
                     Help help = handler.getClass().getAnnotation(Help.class);
-                    List<String> row = new ArrayList<String>();
+                    List<String> row = new ArrayList<>();
                     String parameter = " " + extensionLoader.getExtensionName(handler) + " " + (help != null ? help.parameter().replace("\r\n", " ").replace("\n", " ") : "");
                     row.add(parameter.length() > 55 ? parameter.substring(0, 55) + "..." : parameter);
                     String summary = help != null ? help.summary().replace("\r\n", " ").replace("\n", " ") : "";

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/support/command/StatusTelnetHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/telnet/support/command/StatusTelnetHandler.java
@@ -47,8 +47,8 @@ public class StatusTelnetHandler implements TelnetHandler {
         if (message.equals("-l")) {
             List<StatusChecker> checkers = extensionLoader.getActivateExtension(channel.getUrl(), "status");
             String[] header = new String[]{"resource", "status", "message"};
-            List<List<String>> table = new ArrayList<List<String>>();
-            Map<String, Status> statuses = new HashMap<String, Status>();
+            List<List<String>> table = new ArrayList<>();
+            Map<String, Status> statuses = new HashMap<>();
             if (CollectionUtils.isNotEmpty(checkers)) {
                 for (StatusChecker checker : checkers) {
                     String name = extensionLoader.getExtensionName(checker);
@@ -60,7 +60,7 @@ public class StatusTelnetHandler implements TelnetHandler {
                     }
                     statuses.put(name, stat);
                     if (stat.getLevel() != null && stat.getLevel() != Status.Level.UNKNOWN) {
-                        List<String> row = new ArrayList<String>();
+                        List<String> row = new ArrayList<>();
                         row.add(name);
                         row.add(String.valueOf(stat.getLevel()));
                         row.add(stat.getMessage() == null ? "" : stat.getMessage());
@@ -69,7 +69,7 @@ public class StatusTelnetHandler implements TelnetHandler {
                 }
             }
             Status stat = StatusUtils.getSummaryStatus(statuses);
-            List<String> row = new ArrayList<String>();
+            List<String> row = new ArrayList<>();
             row.add("summary");
             row.add(String.valueOf(stat.getLevel()));
             row.add(stat.getMessage());
@@ -79,7 +79,7 @@ public class StatusTelnetHandler implements TelnetHandler {
             return "Unsupported parameter " + message + " for status.";
         }
         String status = channel.getUrl().getParameter("status");
-        Map<String, Status> statuses = new HashMap<String, Status>();
+        Map<String, Status> statuses = new HashMap<>();
         if (CollectionUtils.isNotEmptyMap(statuses)) {
             String[] ss = Constants.COMMA_SPLIT_PATTERN.split(status);
             for (String s : ss) {

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/ChannelHandlerDispatcher.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/ChannelHandlerDispatcher.java
@@ -33,7 +33,7 @@ public class ChannelHandlerDispatcher implements ChannelHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(ChannelHandlerDispatcher.class);
 
-    private final Collection<ChannelHandler> channelHandlers = new CopyOnWriteArraySet<ChannelHandler>();
+    private final Collection<ChannelHandler> channelHandlers = new CopyOnWriteArraySet<>();
 
     public ChannelHandlerDispatcher() {
     }

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/CodecSupport.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/transport/CodecSupport.java
@@ -34,8 +34,8 @@ import java.util.Set;
 public class CodecSupport {
 
     private static final Logger logger = LoggerFactory.getLogger(CodecSupport.class);
-    private static Map<Byte, Serialization> ID_SERIALIZATION_MAP = new HashMap<Byte, Serialization>();
-    private static Map<Byte, String> ID_SERIALIZATIONNAME_MAP = new HashMap<Byte, String>();
+    private static Map<Byte, Serialization> ID_SERIALIZATION_MAP = new HashMap<>();
+    private static Map<Byte, String> ID_SERIALIZATIONNAME_MAP = new HashMap<>();
 
     static {
         Set<String> supportedExtensions = ExtensionLoader.getExtensionLoader(Serialization.class).getSupportedExtensions();

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/PerformanceClientFixedTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/PerformanceClientFixedTest.java
@@ -53,7 +53,7 @@ public class PerformanceClientFixedTest  {
 
         //int idx = server.indexOf(':');
         Random rd = new Random(connectionCount);
-        ArrayList<ExchangeClient> arrays = new ArrayList<ExchangeClient>();
+        ArrayList<ExchangeClient> arrays = new ArrayList<>();
         String oneKBlock = null;
         String messageBlock = null;
         int s = 0;

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/PerformanceServerTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/PerformanceServerTest.java
@@ -84,7 +84,7 @@ public class PerformanceServerTest  {
                     return CompletableFuture.completedFuture(PerformanceUtils.getEnvironment());
                 }
                 if ("scene".equals(request)) {
-                    List<String> scene = new ArrayList<String>();
+                    List<String> scene = new ArrayList<>();
                     scene.add("Transporter: " + transporter);
                     scene.add("Service Threads: " + threads);
                     return CompletableFuture.completedFuture(scene);

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/PerformanceUtils.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/PerformanceUtils.java
@@ -55,7 +55,7 @@ public class PerformanceUtils {
     }
 
     public static List<String> getEnvironment() {
-        List<String> environment = new ArrayList<String>();
+        List<String> environment = new ArrayList<>();
         environment.add("OS: " + System.getProperty("os.name") + " " + System.getProperty("os.version") + " " + System.getProperty("os.arch", ""));
         environment.add("CPU: " + Runtime.getRuntime().availableProcessors() + " cores");
         environment.add("JVM: " + System.getProperty("java.vm.name") + " " + System.getProperty("java.runtime.version"));

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/codec/AbstractMockChannel.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/codec/AbstractMockChannel.java
@@ -36,7 +36,7 @@ public class AbstractMockChannel implements Channel {
     private ChannelHandler handler;
     private boolean isClosed;
     private volatile boolean closing;
-    private Map<String, Object> attributes = new HashMap<String, Object>(1);
+    private Map<String, Object> attributes = new HashMap<>(1);
     private volatile Object receivedMessage = null;
 
     public AbstractMockChannel() {

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/codec/ExchangeCodecTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/codec/ExchangeCodecTest.java
@@ -110,7 +110,7 @@ public class ExchangeCodecTest extends TelnetCodecTest {
 
     @Test
     public void test_Decode_Error_MagicNum() throws IOException {
-        HashMap<byte[], Object> inputBytes = new HashMap<byte[], Object>();
+        HashMap<byte[], Object> inputBytes = new HashMap<>();
         inputBytes.put(new byte[]{0}, TelnetCodec.DecodeResult.NEED_MORE_INPUT);
         inputBytes.put(new byte[]{MAGIC_HIGH, 0}, TelnetCodec.DecodeResult.NEED_MORE_INPUT);
         inputBytes.put(new byte[]{0, MAGIC_LOW}, TelnetCodec.DecodeResult.NEED_MORE_INPUT);

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/codec/TelnetCodecTest.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/codec/TelnetCodecTest.java
@@ -229,7 +229,7 @@ public class TelnetCodecTest {
 
     @Test
     public void testDecode_WithExitByte() throws IOException {
-        HashMap<byte[], Boolean> exitbytes = new HashMap<byte[], Boolean>();
+        HashMap<byte[], Boolean> exitbytes = new HashMap<>();
         exitbytes.put(new byte[]{3}, true); /* Windows Ctrl+C */
         exitbytes.put(new byte[]{1, 3}, false); //must equal the bytes
         exitbytes.put(new byte[]{-1, -12, -1, -3, 6}, true); /* Linux Ctrl+C */

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/MockChannel.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/exchange/support/header/MockChannel.java
@@ -31,11 +31,11 @@ import java.util.Map;
 
 public class MockChannel implements Channel {
 
-    private Map<String, Object> attributes = new HashMap<String, Object>();
+    private Map<String, Object> attributes = new HashMap<>();
 
     private volatile boolean closed = false;
     private volatile boolean closing = false;
-    private List<Object> sentObjects = new ArrayList<Object>();
+    private List<Object> sentObjects = new ArrayList<>();
 
     @Override
     public InetSocketAddress getRemoteAddress() {

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/handler/MockedChannel.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/handler/MockedChannel.java
@@ -30,7 +30,7 @@ public class MockedChannel implements Channel {
     private volatile boolean closing = false;
     private URL url;
     private ChannelHandler handler;
-    private Map<String, Object> map = new HashMap<String, Object>();
+    private Map<String, Object> map = new HashMap<>();
 
     public MockedChannel() {
         super();

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/handler/MockedChannelHandler.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/handler/MockedChannelHandler.java
@@ -25,8 +25,8 @@ import java.util.Collections;
 import java.util.Set;
 
 public class MockedChannelHandler implements ChannelHandler {
-    //    ConcurrentMap<String, Channel> channels = new ConcurrentHashMap<String, Channel>();
-    ConcurrentHashSet<Channel> channels = new ConcurrentHashSet<Channel>();
+    //    ConcurrentMap<String, Channel> channels = new ConcurrentHashMap<>();
+    ConcurrentHashSet<Channel> channels = new ConcurrentHashSet<>();
 
     @Override
     public void connected(Channel channel) throws RemotingException {

--- a/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/transport/codec/DeprecatedTelnetCodec.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/test/java/org/apache/dubbo/remoting/transport/codec/DeprecatedTelnetCodec.java
@@ -309,7 +309,7 @@ public class DeprecatedTelnetCodec implements Codec {
         String result = toString(message, getCharset(channel));
         if (result != null && result.trim().length() > 0) {
             if (history == null) {
-                history = new LinkedList<String>();
+                history = new LinkedList<>();
                 channel.setAttribute(HISTORY_LIST_KEY, history);
             }
             if (history.size() == 0) {

--- a/dubbo-remoting/dubbo-remoting-grizzly/src/main/java/org/apache/dubbo/remoting/transport/grizzly/GrizzlyServer.java
+++ b/dubbo-remoting/dubbo-remoting-grizzly/src/main/java/org/apache/dubbo/remoting/transport/grizzly/GrizzlyServer.java
@@ -46,7 +46,7 @@ public class GrizzlyServer extends AbstractServer {
 
     private static final Logger logger = LoggerFactory.getLogger(GrizzlyServer.class);
 
-    private final Map<String, Channel> channels = new ConcurrentHashMap<String, Channel>(); // <ip:port, channel>
+    private final Map<String, Channel> channels = new ConcurrentHashMap<>(); // <ip:port, channel>
 
     private TCPNIOTransport transport;
 

--- a/dubbo-remoting/dubbo-remoting-http/src/main/java/org/apache/dubbo/remoting/http/servlet/DispatcherServlet.java
+++ b/dubbo-remoting/dubbo-remoting-http/src/main/java/org/apache/dubbo/remoting/http/servlet/DispatcherServlet.java
@@ -32,7 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class DispatcherServlet extends HttpServlet {
 
     private static final long serialVersionUID = 5766349180380479888L;
-    private static final Map<Integer, HttpHandler> handlers = new ConcurrentHashMap<Integer, HttpHandler>();
+    private static final Map<Integer, HttpHandler> handlers = new ConcurrentHashMap<>();
     private static DispatcherServlet INSTANCE;
 
     public DispatcherServlet() {

--- a/dubbo-remoting/dubbo-remoting-http/src/main/java/org/apache/dubbo/remoting/http/servlet/ServletManager.java
+++ b/dubbo-remoting/dubbo-remoting-http/src/main/java/org/apache/dubbo/remoting/http/servlet/ServletManager.java
@@ -30,7 +30,7 @@ public class ServletManager {
 
     private static final ServletManager instance = new ServletManager();
 
-    private final Map<Integer, ServletContext> contextMap = new ConcurrentHashMap<Integer, ServletContext>();
+    private final Map<Integer, ServletContext> contextMap = new ConcurrentHashMap<>();
 
     public static ServletManager getInstance() {
         return instance;

--- a/dubbo-remoting/dubbo-remoting-mina/src/main/java/org/apache/dubbo/remoting/transport/mina/MinaClient.java
+++ b/dubbo-remoting/dubbo-remoting-mina/src/main/java/org/apache/dubbo/remoting/transport/mina/MinaClient.java
@@ -51,7 +51,7 @@ public class MinaClient extends AbstractClient {
 
     private static final Logger logger = LoggerFactory.getLogger(MinaClient.class);
 
-    private static final Map<String, SocketConnector> connectors = new ConcurrentHashMap<String, SocketConnector>();
+    private static final Map<String, SocketConnector> connectors = new ConcurrentHashMap<>();
 
     private String connectorKey;
 
@@ -90,7 +90,7 @@ public class MinaClient extends AbstractClient {
     protected void doConnect() throws Throwable {
         ConnectFuture future = connector.connect(getConnectAddress(), new MinaHandler(getUrl(), this));
         long start = System.currentTimeMillis();
-        final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> exception = new AtomicReference<>();
         final CountDownLatch finish = new CountDownLatch(1); // resolve future.awaitUninterruptibly() dead lock
         future.addListener(new IoFutureListener() {
             @Override

--- a/dubbo-remoting/dubbo-remoting-mina/src/main/java/org/apache/dubbo/remoting/transport/mina/MinaServer.java
+++ b/dubbo-remoting/dubbo-remoting-mina/src/main/java/org/apache/dubbo/remoting/transport/mina/MinaServer.java
@@ -82,7 +82,7 @@ public class MinaServer extends AbstractServer {
     @Override
     public Collection<Channel> getChannels() {
         Set<IoSession> sessions = acceptor.getManagedSessions(getBindAddress());
-        Collection<Channel> channels = new HashSet<Channel>();
+        Collection<Channel> channels = new HashSet<>();
         for (IoSession session : sessions) {
             if (session.isConnected()) {
                 channels.add(MinaChannel.getOrAddChannel(session, getUrl(), this));

--- a/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyChannel.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyChannel.java
@@ -38,11 +38,11 @@ final class NettyChannel extends AbstractChannel {
 
     private static final Logger logger = LoggerFactory.getLogger(NettyChannel.class);
 
-    private static final ConcurrentMap<org.jboss.netty.channel.Channel, NettyChannel> channelMap = new ConcurrentHashMap<org.jboss.netty.channel.Channel, NettyChannel>();
+    private static final ConcurrentMap<org.jboss.netty.channel.Channel, NettyChannel> channelMap = new ConcurrentHashMap<>();
 
     private final org.jboss.netty.channel.Channel channel;
 
-    private final Map<String, Object> attributes = new ConcurrentHashMap<String, Object>();
+    private final Map<String, Object> attributes = new ConcurrentHashMap<>();
 
     private NettyChannel(org.jboss.netty.channel.Channel channel, URL url, ChannelHandler handler) {
         super(url, handler);

--- a/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyHandler.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @Sharable
 public class NettyHandler extends SimpleChannelHandler {
 
-    private final Map<String, Channel> channels = new ConcurrentHashMap<String, Channel>(); // <ip:port, channel>
+    private final Map<String, Channel> channels = new ConcurrentHashMap<>(); // <ip:port, channel>
 
     private final URL url;
 

--- a/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyServer.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/main/java/org/apache/dubbo/remoting/transport/netty/NettyServer.java
@@ -138,7 +138,7 @@ public class NettyServer extends AbstractServer implements Server {
 
     @Override
     public Collection<Channel> getChannels() {
-        Collection<Channel> chs = new HashSet<Channel>();
+        Collection<Channel> chs = new HashSet<>();
         for (Channel channel : this.channels.values()) {
             if (channel.isConnected()) {
                 chs.add(channel);

--- a/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/NettyClientTest.java
+++ b/dubbo-remoting/dubbo-remoting-netty/src/test/java/org/apache/dubbo/remoting/transport/netty/NettyClientTest.java
@@ -58,7 +58,7 @@ public class NettyClientTest {
 
     @Test
     public void testClientClose() throws Exception {
-        List<ExchangeChannel> clients = new ArrayList<ExchangeChannel>(100);
+        List<ExchangeChannel> clients = new ArrayList<>(100);
         for (int i = 0; i < 100; i++) {
             ExchangeChannel client = Exchangers.connect(URL.valueOf("exchange://localhost:10001?client=netty3"));
             Thread.sleep(5);

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyChannel.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyChannel.java
@@ -39,11 +39,11 @@ final class NettyChannel extends AbstractChannel {
 
     private static final Logger logger = LoggerFactory.getLogger(NettyChannel.class);
 
-    private static final ConcurrentMap<Channel, NettyChannel> channelMap = new ConcurrentHashMap<Channel, NettyChannel>();
+    private static final ConcurrentMap<Channel, NettyChannel> channelMap = new ConcurrentHashMap<>();
 
     private final Channel channel;
 
-    private final Map<String, Object> attributes = new ConcurrentHashMap<String, Object>();
+    private final Map<String, Object> attributes = new ConcurrentHashMap<>();
 
     private NettyChannel(Channel channel, URL url, ChannelHandler handler) {
         super(url, handler);

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyServer.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyServer.java
@@ -141,7 +141,7 @@ public class NettyServer extends AbstractServer implements Server {
 
     @Override
     public Collection<Channel> getChannels() {
-        Collection<Channel> chs = new HashSet<Channel>();
+        Collection<Channel> chs = new HashSet<>();
         for (Channel channel : this.channels.values()) {
             if (channel.isConnected()) {
                 chs.add(channel);

--- a/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyServerHandler.java
+++ b/dubbo-remoting/dubbo-remoting-netty4/src/main/java/org/apache/dubbo/remoting/transport/netty4/NettyServerHandler.java
@@ -35,7 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @io.netty.channel.ChannelHandler.Sharable
 public class NettyServerHandler extends ChannelDuplexHandler {
 
-    private final Map<String, Channel> channels = new ConcurrentHashMap<String, Channel>(); // <ip:port, channel>
+    private final Map<String, Channel> channels = new ConcurrentHashMap<>(); // <ip:port, channel>
 
     private final URL url;
 

--- a/dubbo-remoting/dubbo-remoting-p2p/src/main/java/org/apache/dubbo/remoting/p2p/exchange/support/AbstractExchangeGroup.java
+++ b/dubbo-remoting/dubbo-remoting-p2p/src/main/java/org/apache/dubbo/remoting/p2p/exchange/support/AbstractExchangeGroup.java
@@ -46,9 +46,9 @@ public abstract class AbstractExchangeGroup implements ExchangeGroup {
 
     protected final URL url;
 
-    protected final Map<URL, ExchangeServer> servers = new ConcurrentHashMap<URL, ExchangeServer>();
+    protected final Map<URL, ExchangeServer> servers = new ConcurrentHashMap<>();
 
-    protected final Map<URL, ExchangeClient> clients = new ConcurrentHashMap<URL, ExchangeClient>();
+    protected final Map<URL, ExchangeClient> clients = new ConcurrentHashMap<>();
 
     protected final ExchangeHandlerDispatcher dispatcher = new ExchangeHandlerDispatcher();
 

--- a/dubbo-remoting/dubbo-remoting-p2p/src/main/java/org/apache/dubbo/remoting/p2p/exchange/support/ExchangeServerPeer.java
+++ b/dubbo-remoting/dubbo-remoting-p2p/src/main/java/org/apache/dubbo/remoting/p2p/exchange/support/ExchangeServerPeer.java
@@ -81,7 +81,7 @@ public class ExchangeServerPeer extends ExchangeServerDelegate implements Exchan
     public Collection<ExchangeChannel> getExchangeChannels() {
         Collection<ExchangeChannel> channels = super.getExchangeChannels();
         if (clients.size() > 0) {
-            channels = channels == null ? new ArrayList<ExchangeChannel>() : new ArrayList<ExchangeChannel>(channels);
+            channels = channels == null ? new ArrayList<>() : new ArrayList<>(channels);
             channels.addAll(clients.values());
         }
         return channels;

--- a/dubbo-remoting/dubbo-remoting-p2p/src/main/java/org/apache/dubbo/remoting/p2p/exchange/support/FileExchangeGroup.java
+++ b/dubbo-remoting/dubbo-remoting-p2p/src/main/java/org/apache/dubbo/remoting/p2p/exchange/support/FileExchangeGroup.java
@@ -119,7 +119,7 @@ public class FileExchangeGroup extends AbstractExchangeGroup {
         try {
             String full = url.toFullString();
             String[] lines = IOUtils.readLines(file);
-            List<String> saves = new ArrayList<String>();
+            List<String> saves = new ArrayList<>();
             for (String line : lines) {
                 if (full.equals(line)) {
                     return;

--- a/dubbo-remoting/dubbo-remoting-p2p/src/main/java/org/apache/dubbo/remoting/p2p/support/AbstractGroup.java
+++ b/dubbo-remoting/dubbo-remoting-p2p/src/main/java/org/apache/dubbo/remoting/p2p/support/AbstractGroup.java
@@ -42,9 +42,9 @@ public abstract class AbstractGroup implements Group {
 
     protected final URL url;
 
-    protected final Map<URL, Server> servers = new ConcurrentHashMap<URL, Server>();
+    protected final Map<URL, Server> servers = new ConcurrentHashMap<>();
 
-    protected final Map<URL, Client> clients = new ConcurrentHashMap<URL, Client>();
+    protected final Map<URL, Client> clients = new ConcurrentHashMap<>();
 
     protected final ChannelHandlerDispatcher dispatcher = new ChannelHandlerDispatcher();
 

--- a/dubbo-remoting/dubbo-remoting-p2p/src/main/java/org/apache/dubbo/remoting/p2p/support/FileGroup.java
+++ b/dubbo-remoting/dubbo-remoting-p2p/src/main/java/org/apache/dubbo/remoting/p2p/support/FileGroup.java
@@ -117,7 +117,7 @@ public class FileGroup extends AbstractGroup {
         try {
             String full = url.toFullString();
             String[] lines = IOUtils.readLines(file);
-            List<String> saves = new ArrayList<String>();
+            List<String> saves = new ArrayList<>();
             for (String line : lines) {
                 if (full.equals(line)) {
                     return;

--- a/dubbo-remoting/dubbo-remoting-p2p/src/main/java/org/apache/dubbo/remoting/p2p/support/ServerPeer.java
+++ b/dubbo-remoting/dubbo-remoting-p2p/src/main/java/org/apache/dubbo/remoting/p2p/support/ServerPeer.java
@@ -68,7 +68,7 @@ public class ServerPeer extends ServerDelegate implements Peer {
     public Collection<Channel> getChannels() {
         Collection<Channel> channels = super.getChannels();
         if (clients.size() > 0) {
-            channels = channels == null ? new ArrayList<Channel>() : new ArrayList<Channel>(channels);
+            channels = channels == null ? new ArrayList<>() : new ArrayList<>(channels);
             channels.addAll(clients.values());
         }
         return channels;

--- a/dubbo-remoting/dubbo-remoting-zookeeper/src/main/java/org/apache/dubbo/remoting/zookeeper/support/AbstractZookeeperClient.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/src/main/java/org/apache/dubbo/remoting/zookeeper/support/AbstractZookeeperClient.java
@@ -35,9 +35,9 @@ public abstract class AbstractZookeeperClient<TargetChildListener> implements Zo
 
     private final URL url;
 
-    private final Set<StateListener> stateListeners = new CopyOnWriteArraySet<StateListener>();
+    private final Set<StateListener> stateListeners = new CopyOnWriteArraySet<>();
 
-    private final ConcurrentMap<String, ConcurrentMap<ChildListener, TargetChildListener>> childListeners = new ConcurrentHashMap<String, ConcurrentMap<ChildListener, TargetChildListener>>();
+    private final ConcurrentMap<String, ConcurrentMap<ChildListener, TargetChildListener>> childListeners = new ConcurrentHashMap<>();
 
     private volatile boolean closed = false;
 

--- a/dubbo-remoting/dubbo-remoting-zookeeper/src/main/java/org/apache/dubbo/remoting/zookeeper/support/AbstractZookeeperTransporter.java
+++ b/dubbo-remoting/dubbo-remoting-zookeeper/src/main/java/org/apache/dubbo/remoting/zookeeper/support/AbstractZookeeperTransporter.java
@@ -107,7 +107,7 @@ public abstract class AbstractZookeeperTransporter implements ZookeeperTransport
      * @return such as 127.0.0.1:2181,127.0.0.1:8989,127.0.0.1:9999
      */
     List<String> getURLBackupAddress(URL url) {
-        List<String> addressList = new ArrayList<String>();
+        List<String> addressList = new ArrayList<>();
         addressList.add(url.getAddress());
 
         addressList.addAll(url.getParameter(Constants.BACKUP_KEY, Collections.EMPTY_LIST));

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AbstractResult.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/AbstractResult.java
@@ -25,7 +25,7 @@ import java.util.Map;
  *
  */
 public abstract class AbstractResult implements Result {
-    protected Map<String, String> attachments = new HashMap<String, String>();
+    protected Map<String, String> attachments = new HashMap<>();
 
     protected Object result;
 
@@ -38,7 +38,7 @@ public abstract class AbstractResult implements Result {
 
     @Override
     public void setAttachments(Map<String, String> map) {
-        this.attachments = map == null ? new HashMap<String, String>() : map;
+        this.attachments = map == null ? new HashMap<>() : map;
     }
 
     @Override
@@ -47,7 +47,7 @@ public abstract class AbstractResult implements Result {
             return;
         }
         if (this.attachments == null) {
-            this.attachments = new HashMap<String, String>();
+            this.attachments = new HashMap<>();
         }
         this.attachments.putAll(map);
     }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
@@ -68,8 +68,8 @@ public class RpcContext {
         }
     };
 
-    private final Map<String, String> attachments = new HashMap<String, String>();
-    private final Map<String, Object> values = new HashMap<String, Object>();
+    private final Map<String, String> attachments = new HashMap<>();
+    private final Map<String, Object> values = new HashMap<>();
     private Future<?> future;
 
     private List<URL> urls;
@@ -607,7 +607,7 @@ public class RpcContext {
     public RpcContext setInvokers(List<Invoker<?>> invokers) {
         this.invokers = invokers;
         if (CollectionUtils.isNotEmpty(invokers)) {
-            List<URL> urls = new ArrayList<URL>(invokers.size());
+            List<URL> urls = new ArrayList<>(invokers.size());
             for (Invoker<?> invoker : invokers) {
                 urls.add(invoker.getUrl());
             }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcInvocation.java
@@ -101,7 +101,7 @@ public class RpcInvocation implements Invocation, Serializable {
         this.methodName = methodName;
         this.parameterTypes = parameterTypes == null ? new Class<?>[0] : parameterTypes;
         this.arguments = arguments == null ? new Object[0] : arguments;
-        this.attachments = attachments == null ? new HashMap<String, String>() : attachments;
+        this.attachments = attachments == null ? new HashMap<>() : attachments;
         this.invoker = invoker;
     }
 
@@ -147,19 +147,19 @@ public class RpcInvocation implements Invocation, Serializable {
     }
 
     public void setAttachments(Map<String, String> attachments) {
-        this.attachments = attachments == null ? new HashMap<String, String>() : attachments;
+        this.attachments = attachments == null ? new HashMap<>() : attachments;
     }
 
     public void setAttachment(String key, String value) {
         if (attachments == null) {
-            attachments = new HashMap<String, String>();
+            attachments = new HashMap<>();
         }
         attachments.put(key, value);
     }
 
     public void setAttachmentIfAbsent(String key, String value) {
         if (attachments == null) {
-            attachments = new HashMap<String, String>();
+            attachments = new HashMap<>();
         }
         if (!attachments.containsKey(key)) {
             attachments.put(key, value);
@@ -171,7 +171,7 @@ public class RpcInvocation implements Invocation, Serializable {
             return;
         }
         if (this.attachments == null) {
-            this.attachments = new HashMap<String, String>();
+            this.attachments = new HashMap<>();
         }
         this.attachments.putAll(attachments);
     }

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java
@@ -32,10 +32,10 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class RpcStatus {
 
-    private static final ConcurrentMap<String, RpcStatus> SERVICE_STATISTICS = new ConcurrentHashMap<String, RpcStatus>();
+    private static final ConcurrentMap<String, RpcStatus> SERVICE_STATISTICS = new ConcurrentHashMap<>();
 
-    private static final ConcurrentMap<String, ConcurrentMap<String, RpcStatus>> METHOD_STATISTICS = new ConcurrentHashMap<String, ConcurrentMap<String, RpcStatus>>();
-    private final ConcurrentMap<String, Object> values = new ConcurrentHashMap<String, Object>();
+    private static final ConcurrentMap<String, ConcurrentMap<String, RpcStatus>> METHOD_STATISTICS = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Object> values = new ConcurrentHashMap<>();
     private final AtomicInteger active = new AtomicInteger();
     private final AtomicLong total = new AtomicLong();
     private final AtomicInteger failed = new AtomicInteger();

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/AccessLogFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/AccessLogFilter.java
@@ -76,7 +76,7 @@ public class AccessLogFilter implements Filter {
 
     private static final long LOG_OUTPUT_INTERVAL = 5000;
 
-    private final ConcurrentMap<String, Set<String>> logQueue = new ConcurrentHashMap<String, Set<String>>();
+    private final ConcurrentMap<String, Set<String>> logQueue = new ConcurrentHashMap<>();
 
     private final ScheduledExecutorService logScheduled = Executors.newScheduledThreadPool(2, new NamedThreadFactory("Dubbo-Access-Log", true));
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/DeprecatedFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/DeprecatedFilter.java
@@ -40,7 +40,7 @@ public class DeprecatedFilter implements Filter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DeprecatedFilter.class);
 
-    private static final Set<String> logged = new ConcurrentHashSet<String>();
+    private static final Set<String> logged = new ConcurrentHashSet<>();
 
     @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/tps/DefaultTPSLimiter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/tps/DefaultTPSLimiter.java
@@ -32,7 +32,7 @@ import java.util.concurrent.ConcurrentMap;
 public class DefaultTPSLimiter implements TPSLimiter {
 
     private final ConcurrentMap<String, StatItem> stats
-            = new ConcurrentHashMap<String, StatItem>();
+            = new ConcurrentHashMap<>();
 
     @Override
     public boolean isAllowable(URL url, Invocation invocation) {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/model/ConsumerModel.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/model/ConsumerModel.java
@@ -33,7 +33,7 @@ public class ConsumerModel {
     private final String serviceName;
     private final Class<?> serviceInterfaceClass;
 
-    private final Map<Method, ConsumerMethodModel> methodModels = new IdentityHashMap<Method, ConsumerMethodModel>();
+    private final Map<Method, ConsumerMethodModel> methodModels = new IdentityHashMap<>();
 
     /**
      *  This constructor create an instance of ConsumerModel and passed objects should not be null.
@@ -99,7 +99,7 @@ public class ConsumerModel {
      * @return method model list
      */
     public List<ConsumerMethodModel> getAllMethods() {
-        return new ArrayList<ConsumerMethodModel>(methodModels.values());
+        return new ArrayList<>(methodModels.values());
     }
 
     public Class<?> getServiceInterfaceClass() {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/model/ProviderModel.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/model/ProviderModel.java
@@ -30,7 +30,7 @@ public class ProviderModel {
     private final String serviceName;
     private final Object serviceInstance;
     private final Class<?> serviceInterfaceClass;
-    private final Map<String, List<ProviderMethodModel>> methods = new HashMap<String, List<ProviderMethodModel>>();
+    private final Map<String, List<ProviderMethodModel>> methods = new HashMap<>();
 
     public ProviderModel(String serviceName, Object serviceInstance, Class<?> serviceInterfaceClass) {
         if (null == serviceInstance) {
@@ -58,7 +58,7 @@ public class ProviderModel {
     }
 
     public List<ProviderMethodModel> getAllMethods() {
-        List<ProviderMethodModel> result = new ArrayList<ProviderMethodModel>();
+        List<ProviderMethodModel> result = new ArrayList<>();
         for (List<ProviderMethodModel> models : methods.values()) {
             result.addAll(models);
         }
@@ -86,7 +86,7 @@ public class ProviderModel {
 
             List<ProviderMethodModel> methodModels = methods.get(method.getName());
             if (methodModels == null) {
-                methodModels = new ArrayList<ProviderMethodModel>(1);
+                methodModels = new ArrayList<>(1);
                 methods.put(method.getName(), methodModels);
             }
             methodModels.add(new ProviderMethodModel(method, serviceName));

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractInvoker.java
@@ -80,7 +80,7 @@ public abstract class AbstractInvoker<T> implements Invoker<T> {
         if (ArrayUtils.isEmpty(keys)) {
             return null;
         }
-        Map<String, String> attachment = new HashMap<String, String>();
+        Map<String, String> attachment = new HashMap<>();
         for (String key : keys) {
             String value = url.getParameter(key);
             if (value != null && value.length() > 0) {

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractProtocol.java
@@ -38,10 +38,10 @@ public abstract class AbstractProtocol implements Protocol {
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
-    protected final Map<String, Exporter<?>> exporterMap = new ConcurrentHashMap<String, Exporter<?>>();
+    protected final Map<String, Exporter<?>> exporterMap = new ConcurrentHashMap<>();
 
     //TODO SOFEREFENCE
-    protected final Set<Invoker<?>> invokers = new ConcurrentHashSet<Invoker<?>>();
+    protected final Set<Invoker<?>> invokers = new ConcurrentHashSet<>();
 
     protected static String serviceKey(URL url) {
         int port = url.getParameter(Constants.BIND_PORT_KEY, url.getPort());

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractProxyProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractProxyProtocol.java
@@ -36,7 +36,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public abstract class AbstractProxyProtocol extends AbstractProtocol {
 
-    private final List<Class<?>> rpcExceptions = new CopyOnWriteArrayList<Class<?>>();
+    private final List<Class<?>> rpcExceptions = new CopyOnWriteArrayList<>();
 
     private ProxyFactory proxyFactory;
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/ProtocolListenerWrapper.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/ProtocolListenerWrapper.java
@@ -54,7 +54,7 @@ public class ProtocolListenerWrapper implements Protocol {
         if (Constants.REGISTRY_PROTOCOL.equals(invoker.getUrl().getProtocol())) {
             return protocol.export(invoker);
         }
-        return new ListenerExporterWrapper<T>(protocol.export(invoker),
+        return new ListenerExporterWrapper<>(protocol.export(invoker),
                 Collections.unmodifiableList(ExtensionLoader.getExtensionLoader(ExporterListener.class)
                         .getActivateExtension(invoker.getUrl(), Constants.EXPORTER_LISTENER_KEY)));
     }
@@ -64,7 +64,7 @@ public class ProtocolListenerWrapper implements Protocol {
         if (Constants.REGISTRY_PROTOCOL.equals(url.getProtocol())) {
             return protocol.refer(type, url);
         }
-        return new ListenerInvokerWrapper<T>(protocol.refer(type, url),
+        return new ListenerInvokerWrapper<>(protocol.refer(type, url),
                 Collections.unmodifiableList(
                         ExtensionLoader.getExtensionLoader(InvokerListener.class)
                                 .getActivateExtension(url, Constants.INVOKER_LISTENER_KEY)));

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/MockInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/MockInvoker.java
@@ -42,8 +42,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 final public class MockInvoker<T> implements Invoker<T> {
     private final static ProxyFactory proxyFactory = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
-    private final static Map<String, Invoker<?>> mocks = new ConcurrentHashMap<String, Invoker<?>>();
-    private final static Map<String, Throwable> throwables = new ConcurrentHashMap<String, Throwable>();
+    private final static Map<String, Invoker<?>> mocks = new ConcurrentHashMap<>();
+    private final static Map<String, Throwable> throwables = new ConcurrentHashMap<>();
 
     private final URL url;
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/MockProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/MockProtocol.java
@@ -39,6 +39,6 @@ final public class MockProtocol extends AbstractProtocol {
 
     @Override
     public <T> Invoker<T> refer(Class<T> type, URL url) throws RpcException {
-        return new MockInvoker<T>(url);
+        return new MockInvoker<>(url);
     }
 }

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/RpcContextTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/RpcContextTest.java
@@ -86,7 +86,7 @@ public class RpcContextTest {
     public void testAttachments() {
 
         RpcContext context = RpcContext.getContext();
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put("_11", "1111");
         map.put("_22", "2222");
         map.put(".33", "3333");
@@ -114,7 +114,7 @@ public class RpcContextTest {
     public void testObject() {
 
         RpcContext context = RpcContext.getContext();
-        Map<String, Object> map = new HashMap<String, Object>();
+        Map<String, Object> map = new HashMap<>();
         map.put("_11", "1111");
         map.put("_22", "2222");
         map.put(".33", "3333");

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/AccessLogFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/AccessLogFilterTest.java
@@ -38,7 +38,7 @@ public class AccessLogFilterTest {
     // Test filter won't throw an exception
     @Test
     public void testInvokeException() {
-        Invoker<AccessLogFilterTest> invoker = new MyInvoker<AccessLogFilterTest>(null);
+        Invoker<AccessLogFilterTest> invoker = new MyInvoker<>(null);
         Invocation invocation = new MockInvocation();
         LogUtil.start();
         accessLogFilter.invoke(invoker, invocation);
@@ -50,7 +50,7 @@ public class AccessLogFilterTest {
     @Test
     public void testDefault() {
         URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1");
-        Invoker<AccessLogFilterTest> invoker = new MyInvoker<AccessLogFilterTest>(url);
+        Invoker<AccessLogFilterTest> invoker = new MyInvoker<>(url);
         Invocation invocation = new MockInvocation();
         accessLogFilter.invoke(invoker, invocation);
     }
@@ -58,7 +58,7 @@ public class AccessLogFilterTest {
     @Test
     public void testCustom() {
         URL url = URL.valueOf("test://test:11/test?accesslog=custom-access.log");
-        Invoker<AccessLogFilterTest> invoker = new MyInvoker<AccessLogFilterTest>(url);
+        Invoker<AccessLogFilterTest> invoker = new MyInvoker<>(url);
         Invocation invocation = new MockInvocation();
         accessLogFilter.invoke(invoker, invocation);
     }

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ActiveLimitFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ActiveLimitFilterTest.java
@@ -46,7 +46,7 @@ public class ActiveLimitFilterTest {
     @Test
     public void testInvokeNoActives() {
         URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&actives=0");
-        Invoker<ActiveLimitFilterTest> invoker = new MyInvoker<ActiveLimitFilterTest>(url);
+        Invoker<ActiveLimitFilterTest> invoker = new MyInvoker<>(url);
         Invocation invocation = new MockInvocation();
         activeLimitFilter.invoke(invoker, invocation);
     }
@@ -54,7 +54,7 @@ public class ActiveLimitFilterTest {
     @Test
     public void testInvokeLessActives() {
         URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&actives=10");
-        Invoker<ActiveLimitFilterTest> invoker = new MyInvoker<ActiveLimitFilterTest>(url);
+        Invoker<ActiveLimitFilterTest> invoker = new MyInvoker<>(url);
         Invocation invocation = new MockInvocation();
         activeLimitFilter.invoke(invoker, invocation);
     }
@@ -63,7 +63,7 @@ public class ActiveLimitFilterTest {
     public void testInvokeGreaterActives() {
         AtomicInteger count = new AtomicInteger(0);
         URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&actives=1&timeout=1");
-        final Invoker<ActiveLimitFilterTest> invoker = new BlockMyInvoker<ActiveLimitFilterTest>(url, 100);
+        final Invoker<ActiveLimitFilterTest> invoker = new BlockMyInvoker<>(url, 100);
         final Invocation invocation = new MockInvocation();
         final CountDownLatch latch = new CountDownLatch(1);
         for (int i = 0; i < 100; i++) {
@@ -106,7 +106,7 @@ public class ActiveLimitFilterTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch latchBlocking = new CountDownLatch(totalThread);
         URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&actives=" + maxActives + "&timeout=" + timeout);
-        final Invoker<ActiveLimitFilterTest> invoker = new BlockMyInvoker<ActiveLimitFilterTest>(url, blockTime);
+        final Invoker<ActiveLimitFilterTest> invoker = new BlockMyInvoker<>(url, blockTime);
         final Invocation invocation = new MockInvocation();
         RpcStatus.removeStatus(url);
         RpcStatus.removeStatus(url, invocation.getMethodName());
@@ -151,7 +151,7 @@ public class ActiveLimitFilterTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch latchBlocking = new CountDownLatch(totalThread);
         URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&actives=" + maxActives + "&timeout=" + timeout);
-        final Invoker<ActiveLimitFilterTest> invoker = new BlockMyInvoker<ActiveLimitFilterTest>(url, blockTime);
+        final Invoker<ActiveLimitFilterTest> invoker = new BlockMyInvoker<>(url, blockTime);
         final Invocation invocation = new MockInvocation();
         for (int i = 0; i < totalThread; i++) {
             Thread thread = new Thread(new Runnable() {

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ConsumerContextFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ConsumerContextFilterTest.java
@@ -39,7 +39,7 @@ public class ConsumerContextFilterTest {
     @Test
     public void testSetContext() {
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
-        Invoker<DemoService> invoker = new MyInvoker<DemoService>(url);
+        Invoker<DemoService> invoker = new MyInvoker<>(url);
         Invocation invocation = new MockInvocation();
         consumerContextFilter.invoke(invoker, invocation);
         assertEquals(invoker, RpcContext.getContext().getInvoker());

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ContextFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ContextFilterTest.java
@@ -68,7 +68,7 @@ public class ContextFilterTest {
     @Test
     public void testWithAttachments() {
         URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
-        Invoker<DemoService> invoker = new MyInvoker<DemoService>(url);
+        Invoker<DemoService> invoker = new MyInvoker<>(url);
         Invocation invocation = new MockInvocation();
         Result result = contextFilter.invoke(invoker, invocation);
         assertNull(RpcContext.getContext().getInvoker());

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ExecuteLimitFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/ExecuteLimitFilterTest.java
@@ -96,7 +96,7 @@ public class ExecuteLimitFilterTest {
         when(invocation.getMethodName()).thenReturn("testMoreThanExecuteLimitInvoke");
 
         URL url = URL.valueOf("test://test:11/test?accesslog=true&group=dubbo&version=1.1&executes=" + maxExecute);
-        final Invoker<ExecuteLimitFilter> invoker = new BlockMyInvoker<ExecuteLimitFilter>(url, 1000);
+        final Invoker<ExecuteLimitFilter> invoker = new BlockMyInvoker<>(url, 1000);
 
         final CountDownLatch latch = new CountDownLatch(1);
         for (int i = 0; i < totalExecute; i++) {

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/GenericFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/GenericFilterTest.java
@@ -42,7 +42,7 @@ public class GenericFilterTest {
 
         Method genericInvoke = GenericService.class.getMethods()[0];
 
-        Map<String, Object> person = new HashMap<String, Object>();
+        Map<String, Object> person = new HashMap<>();
         person.put("name", "dubbo");
         person.put("age", 10);
 
@@ -68,7 +68,7 @@ public class GenericFilterTest {
         Assertions.assertThrows(RpcException.class, () -> {
             Method genericInvoke = GenericService.class.getMethods()[0];
 
-            Map<String, Object> person = new HashMap<String, Object>();
+            Map<String, Object> person = new HashMap<>();
             person.put("name", "dubbo");
             person.put("age", 10);
 
@@ -92,7 +92,7 @@ public class GenericFilterTest {
 
         Method genericInvoke = GenericService.class.getMethods()[0];
 
-        Map<String, Object> person = new HashMap<String, Object>();
+        Map<String, Object> person = new HashMap<>();
         person.put("name", "dubbo");
         person.put("age", 10);
 
@@ -116,7 +116,7 @@ public class GenericFilterTest {
 
         Method genericInvoke = GenericService.class.getMethods()[0];
 
-        Map<String, Object> person = new HashMap<String, Object>();
+        Map<String, Object> person = new HashMap<>();
         person.put("name", "dubbo");
         person.put("age", 10);
 

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/GenericImplFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/GenericImplFilterTest.java
@@ -54,7 +54,7 @@ public class GenericImplFilterTest {
                 "accesslog=true&group=dubbo&version=1.1&generic=true");
         Invoker invoker = Mockito.mock(Invoker.class);
 
-        Map<String, Object> person = new HashMap<String, Object>();
+        Map<String, Object> person = new HashMap<>();
         person.put("name", "dubbo");
         person.put("age", 10);
 
@@ -93,7 +93,7 @@ public class GenericImplFilterTest {
 
         Method genericInvoke = GenericService.class.getMethods()[0];
 
-        Map<String, Object> person = new HashMap<String, Object>();
+        Map<String, Object> person = new HashMap<>();
         person.put("name", "dubbo");
         person.put("age", 10);
 

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/TokenFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/TokenFilterTest.java
@@ -47,7 +47,7 @@ public class TokenFilterTest {
         when(invoker.getUrl()).thenReturn(url);
         when(invoker.invoke(any(Invocation.class))).thenReturn(new RpcResult("result"));
 
-        Map<String, String> attachments = new HashMap<String, String>();
+        Map<String, String> attachments = new HashMap<>();
         attachments.put(Constants.TOKEN_KEY, token);
         Invocation invocation = Mockito.mock(Invocation.class);
         when(invocation.getAttachments()).thenReturn(attachments);
@@ -66,7 +66,7 @@ public class TokenFilterTest {
             when(invoker.getUrl()).thenReturn(url);
             when(invoker.invoke(any(Invocation.class))).thenReturn(new RpcResult("result"));
 
-            Map<String, String> attachments = new HashMap<String, String>();
+            Map<String, String> attachments = new HashMap<>();
             attachments.put(Constants.TOKEN_KEY, "wrongToken");
             Invocation invocation = Mockito.mock(Invocation.class);
             when(invocation.getAttachments()).thenReturn(attachments);

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/TpsLimitFilterTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/filter/TpsLimitFilterTest.java
@@ -39,7 +39,7 @@ public class TpsLimitFilterTest {
         url = url.addParameter(Constants.INTERFACE_KEY,
                 "org.apache.dubbo.rpc.file.TpsService");
         url = url.addParameter(Constants.TPS_LIMIT_RATE_KEY, 5);
-        Invoker<TpsLimitFilterTest> invoker = new MyInvoker<TpsLimitFilterTest>(url);
+        Invoker<TpsLimitFilterTest> invoker = new MyInvoker<>(url);
         Invocation invocation = new MockInvocation();
         filter.invoke(invoker, invocation);
     }
@@ -51,7 +51,7 @@ public class TpsLimitFilterTest {
             url = url.addParameter(Constants.INTERFACE_KEY,
                     "org.apache.dubbo.rpc.file.TpsService");
             url = url.addParameter(Constants.TPS_LIMIT_RATE_KEY, 5);
-            Invoker<TpsLimitFilterTest> invoker = new MyInvoker<TpsLimitFilterTest>(url);
+            Invoker<TpsLimitFilterTest> invoker = new MyInvoker<>(url);
             Invocation invocation = new MockInvocation();
             for (int i = 0; i < 10; i++) {
                 try {

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/MockInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/MockInvocation.java
@@ -41,7 +41,7 @@ public class MockInvocation implements Invocation {
     }
 
     public Map<String, String> getAttachments() {
-        Map<String, String> attachments = new HashMap<String, String>();
+        Map<String, String> attachments = new HashMap<>();
         attachments.put(Constants.PATH_KEY, "dubbo");
         attachments.put(Constants.GROUP_KEY, "dubbo");
         attachments.put(Constants.VERSION_KEY, "1.0.0");

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/RpcUtilsTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/RpcUtilsTest.java
@@ -45,7 +45,7 @@ public class RpcUtilsTest {
     @Test
     public void testAttachInvocationIdIfAsync_normal() {
         URL url = URL.valueOf("dubbo://localhost/?test.async=true");
-        Map<String, String> attachments = new HashMap<String, String>();
+        Map<String, String> attachments = new HashMap<>();
         attachments.put("aa", "bb");
         Invocation inv = new RpcInvocation("test", new Class[]{}, new String[]{}, attachments);
         RpcUtils.attachInvocationIdIfAsync(url, inv);

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/CallbackServiceCodec.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/CallbackServiceCodec.java
@@ -153,7 +153,7 @@ class CallbackServiceCodec {
                     //ignore concurrent problem.
                     Set<Invoker<?>> callbackInvokers = (Set<Invoker<?>>) channel.getAttribute(Constants.CHANNEL_CALLBACK_KEY);
                     if (callbackInvokers == null) {
-                        callbackInvokers = new ConcurrentHashSet<Invoker<?>>(1);
+                        callbackInvokers = new ConcurrentHashSet<>(1);
                         callbackInvokers.add(invoker);
                         channel.setAttribute(Constants.CHANNEL_CALLBACK_KEY, callbackInvokers);
                     }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DecodeableRpcInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DecodeableRpcInvocation.java
@@ -124,7 +124,7 @@ public class DecodeableRpcInvocation extends RpcInvocation implements Codec, Dec
             if (map != null && map.size() > 0) {
                 Map<String, String> attachment = getAttachments();
                 if (attachment == null) {
-                    attachment = new HashMap<String, String>();
+                    attachment = new HashMap<>();
                 }
                 attachment.putAll(map);
                 setAttachments(attachment);

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocol.java
@@ -251,7 +251,7 @@ public class DubboProtocol extends AbstractProtocol {
 
         // export service.
         String key = serviceKey(url);
-        DubboExporter<T> exporter = new DubboExporter<T>(invoker, key, exporterMap);
+        DubboExporter<T> exporter = new DubboExporter<>(invoker, key, exporterMap);
         exporterMap.put(key, exporter);
 
         //export an stub service for dispatching event
@@ -361,7 +361,7 @@ public class DubboProtocol extends AbstractProtocol {
     public <T> Invoker<T> refer(Class<T> serviceType, URL url) throws RpcException {
         optimizeSerialization(url);
         // create rpc invoker.
-        DubboInvoker<T> invoker = new DubboInvoker<T>(serviceType, url, getClients(url), invokers);
+        DubboInvoker<T> invoker = new DubboInvoker<>(serviceType, url, getClients(url), invokers);
         invokers.add(invoker);
         return invoker;
     }

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/CountTelnetHandler.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/main/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/CountTelnetHandler.java
@@ -119,8 +119,8 @@ public class CountTelnetHandler implements TelnetHandler {
 
     private String count(Invoker<?> invoker, String method) {
         URL url = invoker.getUrl();
-        List<List<String>> table = new ArrayList<List<String>>();
-        List<String> header = new ArrayList<String>();
+        List<List<String>> table = new ArrayList<>();
+        List<String> header = new ArrayList<>();
         header.add("method");
         header.add("total");
         header.add("failed");
@@ -130,7 +130,7 @@ public class CountTelnetHandler implements TelnetHandler {
         if (method == null || method.length() == 0) {
             for (Method m : invoker.getInterface().getMethods()) {
                 RpcStatus count = RpcStatus.getStatus(url, m.getName());
-                List<String> row = new ArrayList<String>();
+                List<String> row = new ArrayList<>();
                 row.add(m.getName());
                 row.add(String.valueOf(count.getTotal()));
                 row.add(String.valueOf(count.getFailed()));
@@ -149,7 +149,7 @@ public class CountTelnetHandler implements TelnetHandler {
             }
             if (found) {
                 RpcStatus count = RpcStatus.getStatus(url, method);
-                List<String> row = new ArrayList<String>();
+                List<String> row = new ArrayList<>();
                 row.add(method);
                 row.add(String.valueOf(count.getTotal()));
                 row.add(String.valueOf(count.getFailed()));

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/DubboProtocolTest.java
@@ -71,7 +71,7 @@ public class DubboProtocolTest {
         assertEquals(service.enumlength(new Type[]{}), Type.Lower);
         assertEquals(service.getSize(null), -1);
         assertEquals(service.getSize(new String[]{"", "", ""}), 3);
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put("aa", "bb");
         Set<String> set = service.keys(map);
         assertEquals(set.size(), 1);
@@ -103,7 +103,7 @@ public class DubboProtocolTest {
             assertEquals(service.getSize(null), -1);
             assertEquals(service.getSize(new String[]{"", "", ""}), 3);
         }
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put("aa", "bb");
         for (int i = 0; i < 10; i++) {
             Set<String> set = service.keys(map);

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ExplicitCallbackTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ExplicitCallbackTest.java
@@ -275,7 +275,7 @@ public class ExplicitCallbackTest {
     }
 
     class DemoServiceImpl implements IDemoService {
-        private List<IDemoCallback> callbacks = new ArrayList<IDemoCallback>();
+        private List<IDemoCallback> callbacks = new ArrayList<>();
         private volatile Thread t = null;
         private volatile Lock lock = new ReentrantLock();
 
@@ -322,7 +322,7 @@ public class ExplicitCallbackTest {
                         public void run() {
                             while (callbacks.size() > 0) {
                                 try {
-                                    List<IDemoCallback> callbacksCopy = new ArrayList<IDemoCallback>(callbacks);
+                                    List<IDemoCallback> callbacksCopy = new ArrayList<>(callbacks);
                                     for (IDemoCallback callback : callbacksCopy) {
                                         try {
                                             callback.yyy("this is callback msg,current time is :" + System.currentTimeMillis());

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ImplicitCallBackTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/ImplicitCallBackTest.java
@@ -365,9 +365,9 @@ public class ImplicitCallBackTest {
     }
 
     class NofifyImpl implements Nofify {
-        public List<Integer> inv = new ArrayList<Integer>();
-        public Map<Integer, Person> ret = new HashMap<Integer, Person>();
-        public Map<Integer, Throwable> errors = new HashMap<Integer, Throwable>();
+        public List<Integer> inv = new ArrayList<>();
+        public Map<Integer, Person> ret = new HashMap<>();
+        public Map<Integer, Throwable> errors = new HashMap<>();
         public boolean exd = false;
 
         public void onreturn(Person msg, Integer id) {

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/support/EnumBak.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/support/EnumBak.java
@@ -142,7 +142,7 @@ public class EnumBak {
         Invoker<GenericService> reference = protocol.refer(GenericService.class, consumerurl);
 
         GenericService demoProxy = (GenericService) proxy.getProxy(reference);
-        Map<String, Object> arg = new HashMap<String, Object>();
+        Map<String, Object> arg = new HashMap<>();
         arg.put("type", "High");
         arg.put("name", "hi");
 

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/InvokerTelnetHandlerTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/protocol/dubbo/telnet/InvokerTelnetHandlerTest.java
@@ -188,7 +188,7 @@ public class InvokerTelnetHandlerTest {
 
     private Channel getChannelInstance() {
         return new Channel() {
-            private final Map<String, Object> attributes = new ConcurrentHashMap<String, Object>();
+            private final Map<String, Object> attributes = new ConcurrentHashMap<>();
 
             @Override
             public InetSocketAddress getRemoteAddress() {

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/service/GenericServiceTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/service/GenericServiceTest.java
@@ -51,7 +51,7 @@ public class GenericServiceTest {
 
     @Test
     public void testGenericServiceException() {
-        ServiceConfig<GenericService> service = new ServiceConfig<GenericService>();
+        ServiceConfig<GenericService> service = new ServiceConfig<>();
         service.setApplication(new ApplicationConfig("generic-provider"));
         service.setRegistry(new RegistryConfig("N/A"));
         service.setProtocol(new ProtocolConfig("dubbo", 29581));
@@ -74,7 +74,7 @@ public class GenericServiceTest {
         });
         service.export();
         try {
-            ReferenceConfig<DemoService> reference = new ReferenceConfig<DemoService>();
+            ReferenceConfig<DemoService> reference = new ReferenceConfig<>();
             reference.setApplication(new ApplicationConfig("generic-consumer"));
             reference.setInterface(DemoService.class);
             reference.setUrl("dubbo://127.0.0.1:29581?generic=true&timeout=3000");
@@ -83,7 +83,7 @@ public class GenericServiceTest {
                 // say name
                 Assertions.assertEquals("Generic Haha", demoService.sayName("Haha"));
                 // get users
-                List<User> users = new ArrayList<User>();
+                List<User> users = new ArrayList<>();
                 users.add(new User("Aaa"));
                 users = demoService.getUsers(users);
                 Assertions.assertEquals("Aaa", users.get(0).getName());
@@ -105,7 +105,7 @@ public class GenericServiceTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testGenericReferenceException() {
-        ServiceConfig<DemoService> service = new ServiceConfig<DemoService>();
+        ServiceConfig<DemoService> service = new ServiceConfig<>();
         service.setApplication(new ApplicationConfig("generic-provider"));
         service.setRegistry(new RegistryConfig("N/A"));
         service.setProtocol(new ProtocolConfig("dubbo", 29581));
@@ -113,15 +113,15 @@ public class GenericServiceTest {
         service.setRef(new DemoServiceImpl());
         service.export();
         try {
-            ReferenceConfig<GenericService> reference = new ReferenceConfig<GenericService>();
+            ReferenceConfig<GenericService> reference = new ReferenceConfig<>();
             reference.setApplication(new ApplicationConfig("generic-consumer"));
             reference.setInterface(DemoService.class);
             reference.setUrl("dubbo://127.0.0.1:29581?scope=remote&timeout=3000");
             reference.setGeneric(true);
             GenericService genericService = reference.get();
             try {
-                List<Map<String, Object>> users = new ArrayList<Map<String, Object>>();
-                Map<String, Object> user = new HashMap<String, Object>();
+                List<Map<String, Object>> users = new ArrayList<>();
+                Map<String, Object> user = new HashMap<>();
                 user.put("class", "org.apache.dubbo.config.api.User");
                 user.put("name", "actual.provider");
                 users.add(user);
@@ -138,7 +138,7 @@ public class GenericServiceTest {
 
     @Test
     public void testGenericSerializationJava() throws Exception {
-        ServiceConfig<DemoService> service = new ServiceConfig<DemoService>();
+        ServiceConfig<DemoService> service = new ServiceConfig<>();
         service.setApplication(new ApplicationConfig("generic-provider"));
         service.setRegistry(new RegistryConfig("N/A"));
         service.setProtocol(new ProtocolConfig("dubbo", 29581));
@@ -147,7 +147,7 @@ public class GenericServiceTest {
         service.setRef(ref);
         service.export();
         try {
-            ReferenceConfig<GenericService> reference = new ReferenceConfig<GenericService>();
+            ReferenceConfig<GenericService> reference = new ReferenceConfig<>();
             reference.setApplication(new ApplicationConfig("generic-consumer"));
             reference.setInterface(DemoService.class);
             reference.setUrl("dubbo://127.0.0.1:29581?scope=remote&timeout=3000");
@@ -166,7 +166,7 @@ public class GenericServiceTest {
                         .getExtension("nativejava").deserialize(null, new ByteArrayInputStream(result)).readObject().toString());
 
                 // getUsers
-                List<User> users = new ArrayList<User>();
+                List<User> users = new ArrayList<>();
                 User user = new User();
                 user.setName(name);
                 users.add(user);
@@ -206,7 +206,7 @@ public class GenericServiceTest {
 
     @Test
     public void testGenericInvokeWithBeanSerialization() throws Exception {
-        ServiceConfig<DemoService> service = new ServiceConfig<DemoService>();
+        ServiceConfig<DemoService> service = new ServiceConfig<>();
         service.setApplication(new ApplicationConfig("bean-provider"));
         service.setInterface(DemoService.class);
         service.setRegistry(new RegistryConfig("N/A"));
@@ -216,7 +216,7 @@ public class GenericServiceTest {
         service.export();
         ReferenceConfig<GenericService> reference = null;
         try {
-            reference = new ReferenceConfig<GenericService>();
+            reference = new ReferenceConfig<>();
             reference.setApplication(new ApplicationConfig("bean-consumer"));
             reference.setInterface(DemoService.class);
             reference.setUrl("dubbo://127.0.0.1:29581?scope=remote&timeout=3000");
@@ -224,7 +224,7 @@ public class GenericServiceTest {
             GenericService genericService = reference.get();
             User user = new User();
             user.setName("zhangsan");
-            List<User> users = new ArrayList<User>();
+            List<User> users = new ArrayList<>();
             users.add(user);
             Object result = genericService.$invoke("getUsers", new String[]{ReflectUtils.getName(List.class)}, new Object[]{JavaBeanSerializeUtil.serialize(users, JavaBeanAccessor.METHOD)});
             Assertions.assertTrue(result instanceof JavaBeanDescriptor);
@@ -245,7 +245,7 @@ public class GenericServiceTest {
     @Test
     public void testGenericImplementationWithBeanSerialization() throws Exception {
         final AtomicReference reference = new AtomicReference();
-        ServiceConfig<GenericService> service = new ServiceConfig<GenericService>();
+        ServiceConfig<GenericService> service = new ServiceConfig<>();
         service.setApplication(new ApplicationConfig("bean-provider"));
         service.setRegistry(new RegistryConfig("N/A"));
         service.setProtocol(new ProtocolConfig("dubbo", 29581));
@@ -270,14 +270,14 @@ public class GenericServiceTest {
         service.export();
         ReferenceConfig<DemoService> ref = null;
         try {
-            ref = new ReferenceConfig<DemoService>();
+            ref = new ReferenceConfig<>();
             ref.setApplication(new ApplicationConfig("bean-consumer"));
             ref.setInterface(DemoService.class);
             ref.setUrl("dubbo://127.0.0.1:29581?scope=remote&generic=bean&timeout=3000");
             DemoService demoService = ref.get();
             User user = new User();
             user.setName("zhangsan");
-            List<User> users = new ArrayList<User>();
+            List<User> users = new ArrayList<>();
             users.add(user);
             List<User> result = demoService.getUsers(users);
             Assertions.assertEquals(users.size(), result.size());

--- a/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/validation/ValidationTest.java
+++ b/dubbo-rpc/dubbo-rpc-dubbo/src/test/java/org/apache/dubbo/rpc/validation/ValidationTest.java
@@ -60,7 +60,7 @@ public class ValidationTest {
 
     @Test
     public void testValidation() {
-        ServiceConfig<ValidationService> service = new ServiceConfig<ValidationService>();
+        ServiceConfig<ValidationService> service = new ServiceConfig<>();
         service.setApplication(application);
         service.setRegistry(registryNA);
         service.setProtocol(protocolDubo29582);
@@ -69,7 +69,7 @@ public class ValidationTest {
         service.setValidation(String.valueOf(true));
         service.export();
         try {
-            ReferenceConfig<ValidationService> reference = new ReferenceConfig<ValidationService>();
+            ReferenceConfig<ValidationService> reference = new ReferenceConfig<>();
             reference.setApplication(application);
             reference.setInterface(ValidationService.class);
             reference.setUrl("dubbo://127.0.0.1:29582?scope=remote&validation=true");
@@ -186,7 +186,7 @@ public class ValidationTest {
 
     @Test
     public void testProviderValidation() {
-        ServiceConfig<ValidationService> service = new ServiceConfig<ValidationService>();
+        ServiceConfig<ValidationService> service = new ServiceConfig<>();
         service.setApplication(application);
         service.setRegistry(registryNA);
         service.setProtocol(protocolDubo29582);
@@ -195,7 +195,7 @@ public class ValidationTest {
         service.setValidation(String.valueOf(true));
         service.export();
         try {
-            ReferenceConfig<ValidationService> reference = new ReferenceConfig<ValidationService>();
+            ReferenceConfig<ValidationService> reference = new ReferenceConfig<>();
             reference.setApplication(application);
             reference.setInterface(ValidationService.class);
             reference.setUrl("dubbo://127.0.0.1:29582");
@@ -251,7 +251,7 @@ public class ValidationTest {
 
     @Test
     public void testGenericValidation() {
-        ServiceConfig<ValidationService> service = new ServiceConfig<ValidationService>();
+        ServiceConfig<ValidationService> service = new ServiceConfig<>();
         service.setApplication(application);
         service.setRegistry(registryNA);
         service.setProtocol(protocolDubo29582);
@@ -260,7 +260,7 @@ public class ValidationTest {
         service.setValidation(String.valueOf(true));
         service.export();
         try {
-            ReferenceConfig<GenericService> reference = new ReferenceConfig<GenericService>();
+            ReferenceConfig<GenericService> reference = new ReferenceConfig<>();
             reference.setApplication(application);
             reference.setInterface(ValidationService.class.getName());
             reference.setUrl("dubbo://127.0.0.1:29582?scope=remote&validation=true&timeout=9000000");
@@ -268,7 +268,7 @@ public class ValidationTest {
             GenericService validationService = reference.get();
             try {
                 // Save OK
-                Map<String, Object> parameter = new HashMap<String, Object>();
+                Map<String, Object> parameter = new HashMap<>();
                 parameter.put("name", "liangfei");
                 parameter.put("Email", "liangfei@liang.fei");
                 parameter.put("Age", 50);
@@ -278,7 +278,7 @@ public class ValidationTest {
 
                 // Save Error
                 try {
-                    parameter = new HashMap<String, Object>();
+                    parameter = new HashMap<>();
                     validationService.$invoke("save", new String[]{ValidationParameter.class.getName()}, new Object[]{parameter});
                     Assertions.fail();
                 } catch (GenericException e) {

--- a/dubbo-rpc/dubbo-rpc-hessian/src/main/java/org/apache/dubbo/rpc/protocol/hessian/HessianProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-hessian/src/main/java/org/apache/dubbo/rpc/protocol/hessian/HessianProtocol.java
@@ -49,9 +49,9 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class HessianProtocol extends AbstractProxyProtocol {
 
-    private final Map<String, HttpServer> serverMap = new ConcurrentHashMap<String, HttpServer>();
+    private final Map<String, HttpServer> serverMap = new ConcurrentHashMap<>();
 
-    private final Map<String, HessianSkeleton> skeletonMap = new ConcurrentHashMap<String, HessianSkeleton>();
+    private final Map<String, HessianSkeleton> skeletonMap = new ConcurrentHashMap<>();
 
     private HttpBinder httpBinder;
 

--- a/dubbo-rpc/dubbo-rpc-http/src/main/java/org/apache/dubbo/rpc/protocol/http/HttpProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-http/src/main/java/org/apache/dubbo/rpc/protocol/http/HttpProtocol.java
@@ -54,9 +54,9 @@ public class HttpProtocol extends AbstractProxyProtocol {
 
     public static final int DEFAULT_PORT = 80;
 
-    private final Map<String, HttpServer> serverMap = new ConcurrentHashMap<String, HttpServer>();
+    private final Map<String, HttpServer> serverMap = new ConcurrentHashMap<>();
 
-    private final Map<String, HttpInvokerServiceExporter> skeletonMap = new ConcurrentHashMap<String, HttpInvokerServiceExporter>();
+    private final Map<String, HttpInvokerServiceExporter> skeletonMap = new ConcurrentHashMap<>();
 
     private HttpBinder httpBinder;
 

--- a/dubbo-rpc/dubbo-rpc-injvm/src/main/java/org/apache/dubbo/rpc/protocol/injvm/InjvmProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-injvm/src/main/java/org/apache/dubbo/rpc/protocol/injvm/InjvmProtocol.java
@@ -84,12 +84,12 @@ public class InjvmProtocol extends AbstractProtocol implements Protocol {
 
     @Override
     public <T> Exporter<T> export(Invoker<T> invoker) throws RpcException {
-        return new InjvmExporter<T>(invoker, invoker.getUrl().getServiceKey(), exporterMap);
+        return new InjvmExporter<>(invoker, invoker.getUrl().getServiceKey(), exporterMap);
     }
 
     @Override
     public <T> Invoker<T> refer(Class<T> serviceType, URL url) throws RpcException {
-        return new InjvmInvoker<T>(serviceType, url, url.getServiceKey(), exporterMap);
+        return new InjvmInvoker<>(serviceType, url, url.getServiceKey(), exporterMap);
     }
 
     public boolean isInjvmRefer(URL url) {

--- a/dubbo-rpc/dubbo-rpc-injvm/src/test/java/org/apache/dubbo/rpc/protocol/injvm/InjvmProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-injvm/src/test/java/org/apache/dubbo/rpc/protocol/injvm/InjvmProtocolTest.java
@@ -48,7 +48,7 @@ public class InjvmProtocolTest {
 
     private Protocol protocol = ExtensionLoader.getExtensionLoader(Protocol.class).getAdaptiveExtension();
     private ProxyFactory proxy = ExtensionLoader.getExtensionLoader(ProxyFactory.class).getAdaptiveExtension();
-    private List<Exporter<?>> exporters = new ArrayList<Exporter<?>>();
+    private List<Exporter<?>> exporters = new ArrayList<>();
 
     @AfterEach
     public void after() throws Exception {
@@ -69,7 +69,7 @@ public class InjvmProtocolTest {
         assertEquals(service.getSize(new String[]{"", "", ""}), 3);
         service.invoke("injvm://127.0.0.1/TestService", "invoke");
 
-        InjvmInvoker injvmInvoker = new InjvmInvoker(DemoService.class, URL.valueOf("injvm://127.0.0.1/TestService"),null,new HashMap<String, Exporter<?>>());
+        InjvmInvoker injvmInvoker = new InjvmInvoker(DemoService.class, URL.valueOf("injvm://127.0.0.1/TestService"),null,new HashMap<>());
         assertFalse(injvmInvoker.isAvailable());
 
     }

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/NettyServer.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/NettyServer.java
@@ -42,7 +42,7 @@ public class NettyServer extends BaseRestServer {
             server.setHostname(bindIp);
         }
         server.setPort(url.getParameter(Constants.BIND_PORT_KEY, url.getPort()));
-        Map<ChannelOption, Object> channelOption = new HashMap<ChannelOption, Object>();
+        Map<ChannelOption, Object> channelOption = new HashMap<>();
         channelOption.put(ChannelOption.SO_KEEPALIVE, url.getParameter(Constants.KEEP_ALIVE_KEY, Constants.DEFAULT_KEEP_ALIVE));
         server.setChildChannelOptions(channelOption);
         server.setExecutorThreadCount(url.getParameter(Constants.THREADS_KEY, Constants.DEFAULT_THREADS));

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/RestProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/RestProtocol.java
@@ -65,12 +65,12 @@ public class RestProtocol extends AbstractProxyProtocol {
     private static final int HTTPCLIENTCONNECTIONMANAGER_CLOSEWAITTIME_MS = 1000;
     private static final int HTTPCLIENTCONNECTIONMANAGER_CLOSEIDLETIME_S = 30;
 
-    private final Map<String, RestServer> servers = new ConcurrentHashMap<String, RestServer>();
+    private final Map<String, RestServer> servers = new ConcurrentHashMap<>();
 
     private final RestServerFactory serverFactory = new RestServerFactory();
 
     // TODO in the future maybe we can just use a single rest client and connection manager
-    private final List<ResteasyClient> clients = Collections.synchronizedList(new LinkedList<ResteasyClient>());
+    private final List<ResteasyClient> clients = Collections.synchronizedList(new LinkedList<>());
 
     private volatile ConnectionMonitor connectionMonitor;
 
@@ -244,7 +244,7 @@ public class RestProtocol extends AbstractProxyProtocol {
 
     protected class ConnectionMonitor extends Thread {
         private volatile boolean shutdown;
-        private final List<PoolingHttpClientConnectionManager> connectionManagers = Collections.synchronizedList(new LinkedList<PoolingHttpClientConnectionManager>());
+        private final List<PoolingHttpClientConnectionManager> connectionManagers = Collections.synchronizedList(new LinkedList<>());
 
         public void addConnectionManager(PoolingHttpClientConnectionManager connectionManager) {
             connectionManagers.add(connectionManager);

--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/ViolationReport.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/ViolationReport.java
@@ -41,7 +41,7 @@ public class ViolationReport implements Serializable {
 
     public void addConstraintViolation(RestConstraintViolation constraintViolation) {
         if (constraintViolations == null) {
-            constraintViolations = new LinkedList<RestConstraintViolation>();
+            constraintViolations = new LinkedList<>();
         }
         constraintViolations.add(constraintViolation);
     }

--- a/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/integration/swagger/DubboSwaggerApiListingResourceTest.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/test/java/org/apache/dubbo/rpc/protocol/rest/integration/swagger/DubboSwaggerApiListingResourceTest.java
@@ -46,7 +46,7 @@ public class DubboSwaggerApiListingResourceTest {
 
         app = mock(Application.class);
         sc = mock(ServletConfig.class);
-        Set<Class<?>> sets = new HashSet<Class<?>>();
+        Set<Class<?>> sets = new HashSet<>();
         sets.add(SwaggerService.class);
 
         when(sc.getServletContext()).thenReturn(mock(ServletContext.class));

--- a/dubbo-rpc/dubbo-rpc-thrift/src/main/java/org/apache/dubbo/rpc/protocol/thrift/ThriftCodec.java
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/main/java/org/apache/dubbo/rpc/protocol/thrift/ThriftCodec.java
@@ -86,10 +86,10 @@ public class ThriftCodec implements Codec2 {
     public static final byte VERSION = (byte) 1;
     public static final short MAGIC = (short) 0xdabc;
     static final ConcurrentMap<Long, RequestData> cachedRequest =
-            new ConcurrentHashMap<Long, RequestData>();
+            new ConcurrentHashMap<>();
     private static final AtomicInteger THRIFT_SEQ_ID = new AtomicInteger(0);
     private static final ConcurrentMap<String, Class<?>> cachedClass =
-            new ConcurrentHashMap<String, Class<?>>();
+            new ConcurrentHashMap<>();
 
     private static int nextSeqId() {
         return THRIFT_SEQ_ID.incrementAndGet();
@@ -225,8 +225,8 @@ public class ThriftCodec implements Codec2 {
                 throw new RpcException(RpcException.SERIALIZATION_EXCEPTION, e.getMessage(), e);
             }
 
-            List<Object> parameters = new ArrayList<Object>();
-            List<Class<?>> parameterTypes = new ArrayList<Class<?>>();
+            List<Object> parameters = new ArrayList<>();
+            List<Class<?>> parameterTypes = new ArrayList<>();
             int index = 1;
 
             while (true) {

--- a/dubbo-rpc/dubbo-rpc-thrift/src/main/java/org/apache/dubbo/rpc/protocol/thrift/ThriftProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/main/java/org/apache/dubbo/rpc/protocol/thrift/ThriftProtocol.java
@@ -54,7 +54,7 @@ public class ThriftProtocol extends AbstractProtocol {
 
     // ip:port -> ExchangeServer
     private final ConcurrentMap<String, ExchangeServer> serverMap =
-            new ConcurrentHashMap<String, ExchangeServer>();
+            new ConcurrentHashMap<>();
 
     private ExchangeHandler handler = new ExchangeHandlerAdapter() {
 
@@ -126,7 +126,7 @@ public class ThriftProtocol extends AbstractProtocol {
         }
         // export service.
         key = serviceKey(url);
-        DubboExporter<T> exporter = new DubboExporter<T>(invoker, key, exporterMap);
+        DubboExporter<T> exporter = new DubboExporter<>(invoker, key, exporterMap);
         exporterMap.put(key, exporter);
 
         return exporter;
@@ -159,7 +159,7 @@ public class ThriftProtocol extends AbstractProtocol {
     @Override
     public <T> Invoker<T> refer(Class<T> type, URL url) throws RpcException {
 
-        ThriftInvoker<T> invoker = new ThriftInvoker<T>(type, url, getClients(url), invokers);
+        ThriftInvoker<T> invoker = new ThriftInvoker<>(type, url, getClients(url), invokers);
 
         invokers.add(invoker);
 

--- a/dubbo-rpc/dubbo-rpc-thrift/src/main/java/org/apache/dubbo/rpc/protocol/thrift/ThriftType.java
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/main/java/org/apache/dubbo/rpc/protocol/thrift/ThriftType.java
@@ -27,7 +27,7 @@ public enum ThriftType {
     BOOL, BYTE, I16, I32, I64, DOUBLE, STRING;
 
     private static final Map<Class<?>, ThriftType> types =
-            new HashMap<Class<?>, ThriftType>();
+            new HashMap<>();
 
     static {
         put(boolean.class, BOOL);

--- a/dubbo-rpc/dubbo-rpc-thrift/src/main/java/org/apache/dubbo/rpc/protocol/thrift/ext/MultiServiceProcessor.java
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/main/java/org/apache/dubbo/rpc/protocol/thrift/ext/MultiServiceProcessor.java
@@ -39,7 +39,7 @@ public class MultiServiceProcessor implements TProcessor {
 
     private static final Logger logger = LoggerFactory.getLogger(MultiServiceProcessor.class);
 
-    private ConcurrentMap<String, TProcessor> processorMap = new ConcurrentHashMap<String, TProcessor>();
+    private ConcurrentMap<String, TProcessor> processorMap = new ConcurrentHashMap<>();
 
     private TProtocolFactory protocolFactory = new TBinaryProtocol.Factory();
 

--- a/dubbo-rpc/dubbo-rpc-thrift/src/test/java/$__ClassNameTestDubboStub.java
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/test/java/$__ClassNameTestDubboStub.java
@@ -79,7 +79,7 @@ public class $__ClassNameTestDubboStub {
         private static final org.apache.thrift.protocol.TField ARG_FIELD_DESC = new org.apache.thrift.protocol.TField("arg", org.apache.thrift.protocol.TType.STRING, (short) 1);
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.ARG, new org.apache.thrift.meta_data.FieldMetaData("arg", org.apache.thrift.TFieldRequirementType.REQUIRED,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -319,7 +319,7 @@ public class $__ClassNameTestDubboStub {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             ARG((short) 1, "arg");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -381,7 +381,7 @@ public class $__ClassNameTestDubboStub {
         private static final org.apache.thrift.protocol.TField SUCCESS_FIELD_DESC = new org.apache.thrift.protocol.TField("success", org.apache.thrift.protocol.TType.STRING, (short) 0);
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -617,7 +617,7 @@ public class $__ClassNameTestDubboStub {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             SUCCESS((short) 0, "success");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {

--- a/dubbo-rpc/dubbo-rpc-thrift/src/test/java/ClassNameTestThrift.java
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/test/java/ClassNameTestThrift.java
@@ -165,7 +165,7 @@ public class ClassNameTestThrift {
         private static final org.apache.thrift.protocol.TField ARG_FIELD_DESC = new org.apache.thrift.protocol.TField("arg", org.apache.thrift.protocol.TType.STRING, (short) 1);
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.ARG, new org.apache.thrift.meta_data.FieldMetaData("arg", org.apache.thrift.TFieldRequirementType.REQUIRED,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -405,7 +405,7 @@ public class ClassNameTestThrift {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             ARG((short) 1, "arg");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -467,7 +467,7 @@ public class ClassNameTestThrift {
         private static final org.apache.thrift.protocol.TField SUCCESS_FIELD_DESC = new org.apache.thrift.protocol.TField("success", org.apache.thrift.protocol.TType.STRING, (short) 0);
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -703,7 +703,7 @@ public class ClassNameTestThrift {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             SUCCESS((short) 0, "success");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {

--- a/dubbo-rpc/dubbo-rpc-thrift/src/test/java/org/apache/dubbo/rpc/gen/dubbo/$__DemoStub.java
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/test/java/org/apache/dubbo/rpc/gen/dubbo/$__DemoStub.java
@@ -203,7 +203,7 @@ public class $__DemoStub {
         private static final int __ARG_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.ARG, new org.apache.thrift.meta_data.FieldMetaData("arg", org.apache.thrift.TFieldRequirementType.REQUIRED,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -438,7 +438,7 @@ public class $__DemoStub {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             ARG((short) 1, "arg");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -502,7 +502,7 @@ public class $__DemoStub {
         private static final int __SUCCESS_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -734,7 +734,7 @@ public class $__DemoStub {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             SUCCESS((short) 0, "success");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -798,7 +798,7 @@ public class $__DemoStub {
         private static final int __ARG_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.ARG, new org.apache.thrift.meta_data.FieldMetaData("arg", org.apache.thrift.TFieldRequirementType.REQUIRED,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BYTE)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -1033,7 +1033,7 @@ public class $__DemoStub {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             ARG((short) 1, "arg");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -1097,7 +1097,7 @@ public class $__DemoStub {
         private static final int __SUCCESS_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BYTE)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -1329,7 +1329,7 @@ public class $__DemoStub {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             SUCCESS((short) 0, "success");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -1393,7 +1393,7 @@ public class $__DemoStub {
         private static final int __ARG_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.ARG, new org.apache.thrift.meta_data.FieldMetaData("arg", org.apache.thrift.TFieldRequirementType.REQUIRED,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I16)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -1626,7 +1626,7 @@ public class $__DemoStub {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             ARG((short) 1, "arg");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -1690,7 +1690,7 @@ public class $__DemoStub {
         private static final int __SUCCESS_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I16)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -1918,7 +1918,7 @@ public class $__DemoStub {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             SUCCESS((short) 0, "success");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -1982,7 +1982,7 @@ public class $__DemoStub {
         private static final int __ARG_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.ARG, new org.apache.thrift.meta_data.FieldMetaData("arg", org.apache.thrift.TFieldRequirementType.REQUIRED,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -2213,7 +2213,7 @@ public class $__DemoStub {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             ARG((short) 1, "arg");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -2277,7 +2277,7 @@ public class $__DemoStub {
         private static final int __SUCCESS_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -2503,7 +2503,7 @@ public class $__DemoStub {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             SUCCESS((short) 0, "success");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -2567,7 +2567,7 @@ public class $__DemoStub {
         private static final int __ARG_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.ARG, new org.apache.thrift.meta_data.FieldMetaData("arg", org.apache.thrift.TFieldRequirementType.REQUIRED,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -2796,7 +2796,7 @@ public class $__DemoStub {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             ARG((short) 1, "arg");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -2860,7 +2860,7 @@ public class $__DemoStub {
         private static final int __SUCCESS_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -3086,7 +3086,7 @@ public class $__DemoStub {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             SUCCESS((short) 0, "success");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -3150,7 +3150,7 @@ public class $__DemoStub {
         private static final int __ARG_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.ARG, new org.apache.thrift.meta_data.FieldMetaData("arg", org.apache.thrift.TFieldRequirementType.REQUIRED,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.DOUBLE)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -3379,7 +3379,7 @@ public class $__DemoStub {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             ARG((short) 1, "arg");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -3443,7 +3443,7 @@ public class $__DemoStub {
         private static final int __SUCCESS_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.DOUBLE)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -3669,7 +3669,7 @@ public class $__DemoStub {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             SUCCESS((short) 0, "success");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -3731,7 +3731,7 @@ public class $__DemoStub {
         private static final org.apache.thrift.protocol.TField ARG_FIELD_DESC = new org.apache.thrift.protocol.TField("arg", org.apache.thrift.protocol.TType.STRING, (short) 1);
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.ARG, new org.apache.thrift.meta_data.FieldMetaData("arg", org.apache.thrift.TFieldRequirementType.REQUIRED,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -3962,7 +3962,7 @@ public class $__DemoStub {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             ARG((short) 1, "arg");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -4024,7 +4024,7 @@ public class $__DemoStub {
         private static final org.apache.thrift.protocol.TField SUCCESS_FIELD_DESC = new org.apache.thrift.protocol.TField("success", org.apache.thrift.protocol.TType.STRING, (short) 0);
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -4253,7 +4253,7 @@ public class $__DemoStub {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             SUCCESS((short) 0, "success");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {

--- a/dubbo-rpc/dubbo-rpc-thrift/src/test/java/org/apache/dubbo/rpc/gen/thrift/Demo.java
+++ b/dubbo-rpc/dubbo-rpc-thrift/src/test/java/org/apache/dubbo/rpc/gen/thrift/Demo.java
@@ -619,7 +619,7 @@ public class Demo {
         private static final int __ARG_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.ARG, new org.apache.thrift.meta_data.FieldMetaData("arg", org.apache.thrift.TFieldRequirementType.REQUIRED,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -854,7 +854,7 @@ public class Demo {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             ARG((short) 1, "arg");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -918,7 +918,7 @@ public class Demo {
         private static final int __SUCCESS_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -1148,7 +1148,7 @@ public class Demo {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             SUCCESS((short) 0, "success");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -1212,7 +1212,7 @@ public class Demo {
         private static final int __ARG_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.ARG, new org.apache.thrift.meta_data.FieldMetaData("arg", org.apache.thrift.TFieldRequirementType.REQUIRED,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BYTE)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -1447,7 +1447,7 @@ public class Demo {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             ARG((short) 1, "arg");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -1511,7 +1511,7 @@ public class Demo {
         private static final int __SUCCESS_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BYTE)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -1741,7 +1741,7 @@ public class Demo {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             SUCCESS((short) 0, "success");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -1805,7 +1805,7 @@ public class Demo {
         private static final int __ARG_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.ARG, new org.apache.thrift.meta_data.FieldMetaData("arg", org.apache.thrift.TFieldRequirementType.REQUIRED,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I16)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -2038,7 +2038,7 @@ public class Demo {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             ARG((short) 1, "arg");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -2102,7 +2102,7 @@ public class Demo {
         private static final int __SUCCESS_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I16)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -2328,7 +2328,7 @@ public class Demo {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             SUCCESS((short) 0, "success");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -2392,7 +2392,7 @@ public class Demo {
         private static final int __ARG_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.ARG, new org.apache.thrift.meta_data.FieldMetaData("arg", org.apache.thrift.TFieldRequirementType.REQUIRED,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -2623,7 +2623,7 @@ public class Demo {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             ARG((short) 1, "arg");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -2687,7 +2687,7 @@ public class Demo {
         private static final int __SUCCESS_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -2911,7 +2911,7 @@ public class Demo {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             SUCCESS((short) 0, "success");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -2975,7 +2975,7 @@ public class Demo {
         private static final int __ARG_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.ARG, new org.apache.thrift.meta_data.FieldMetaData("arg", org.apache.thrift.TFieldRequirementType.REQUIRED,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -3204,7 +3204,7 @@ public class Demo {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             ARG((short) 1, "arg");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -3268,7 +3268,7 @@ public class Demo {
         private static final int __SUCCESS_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -3492,7 +3492,7 @@ public class Demo {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             SUCCESS((short) 0, "success");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -3556,7 +3556,7 @@ public class Demo {
         private static final int __ARG_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.ARG, new org.apache.thrift.meta_data.FieldMetaData("arg", org.apache.thrift.TFieldRequirementType.REQUIRED,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.DOUBLE)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -3785,7 +3785,7 @@ public class Demo {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             ARG((short) 1, "arg");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -3849,7 +3849,7 @@ public class Demo {
         private static final int __SUCCESS_ISSET_ID = 0;
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.DOUBLE)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -4073,7 +4073,7 @@ public class Demo {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             SUCCESS((short) 0, "success");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -4135,7 +4135,7 @@ public class Demo {
         private static final org.apache.thrift.protocol.TField ARG_FIELD_DESC = new org.apache.thrift.protocol.TField("arg", org.apache.thrift.protocol.TType.STRING, (short) 1);
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.ARG, new org.apache.thrift.meta_data.FieldMetaData("arg", org.apache.thrift.TFieldRequirementType.REQUIRED,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -4366,7 +4366,7 @@ public class Demo {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             ARG((short) 1, "arg");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {
@@ -4428,7 +4428,7 @@ public class Demo {
         private static final org.apache.thrift.protocol.TField SUCCESS_FIELD_DESC = new org.apache.thrift.protocol.TField("success", org.apache.thrift.protocol.TType.STRING, (short) 0);
 
         static {
-            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+            Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<>(_Fields.class);
             tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
                     new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
             metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -4657,7 +4657,7 @@ public class Demo {
         public enum _Fields implements org.apache.thrift.TFieldIdEnum {
             SUCCESS((short) 0, "success");
 
-            private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+            private static final Map<String, _Fields> byName = new HashMap<>();
 
             static {
                 for (_Fields field : EnumSet.allOf(_Fields.class)) {

--- a/dubbo-rpc/dubbo-rpc-webservice/src/main/java/org/apache/dubbo/rpc/protocol/webservice/WebServiceProtocol.java
+++ b/dubbo-rpc/dubbo-rpc-webservice/src/main/java/org/apache/dubbo/rpc/protocol/webservice/WebServiceProtocol.java
@@ -55,7 +55,7 @@ public class WebServiceProtocol extends AbstractProxyProtocol {
 
     public static final int DEFAULT_PORT = 80;
 
-    private final Map<String, HttpServer> serverMap = new ConcurrentHashMap<String, HttpServer>();
+    private final Map<String, HttpServer> serverMap = new ConcurrentHashMap<>();
 
     private final ExtensionManagerBus bus = new ExtensionManagerBus();
 

--- a/dubbo-serialization/dubbo-serialization-kryo/src/main/java/org/apache/dubbo/common/serialize/kryo/utils/AbstractKryoFactory.java
+++ b/dubbo-serialization/dubbo-serialization-kryo/src/main/java/org/apache/dubbo/common/serialize/kryo/utils/AbstractKryoFactory.java
@@ -58,7 +58,7 @@ import java.util.regex.Pattern;
 
 public abstract class AbstractKryoFactory implements KryoFactory {
 
-    private final Set<Class> registrations = new LinkedHashSet<Class>();
+    private final Set<Class> registrations = new LinkedHashSet<>();
 
     private boolean registrationRequired;
 

--- a/dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/base/AbstractSerializationPersonFailTest.java
+++ b/dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/base/AbstractSerializationPersonFailTest.java
@@ -51,7 +51,7 @@ public abstract class AbstractSerializationPersonFailTest extends AbstractSerial
 
     @Test
     public void test_PersonList() throws Exception {
-        List<Person> args = new ArrayList<Person>();
+        List<Person> args = new ArrayList<>();
         args.add(new Person());
         try {
             ObjectOutput objectOutput = serialization.serialize(url, byteArrayOutputStream);
@@ -65,7 +65,7 @@ public abstract class AbstractSerializationPersonFailTest extends AbstractSerial
 
     @Test
     public void test_PersonSet() throws Exception {
-        Set<Person> args = new HashSet<Person>();
+        Set<Person> args = new HashSet<>();
         args.add(new Person());
         try {
             ObjectOutput objectOutput = serialization.serialize(url, byteArrayOutputStream);
@@ -80,7 +80,7 @@ public abstract class AbstractSerializationPersonFailTest extends AbstractSerial
 
     @Test
     public void test_IntPersonMap() throws Exception {
-        Map<Integer, Person> args = new HashMap<Integer, Person>();
+        Map<Integer, Person> args = new HashMap<>();
         args.put(1, new Person());
         try {
             ObjectOutput objectOutput = serialization.serialize(url, byteArrayOutputStream);
@@ -94,7 +94,7 @@ public abstract class AbstractSerializationPersonFailTest extends AbstractSerial
 
     @Test
     public void test_StringPersonMap() throws Exception {
-        Map<String, Person> args = new HashMap<String, Person>();
+        Map<String, Person> args = new HashMap<>();
         args.put("1", new Person());
         try {
             ObjectOutput objectOutput = serialization.serialize(url, byteArrayOutputStream);
@@ -108,9 +108,9 @@ public abstract class AbstractSerializationPersonFailTest extends AbstractSerial
 
     @Test
     public void test_StringPersonListMap() throws Exception {
-        Map<String, List<Person>> args = new HashMap<String, List<Person>>();
+        Map<String, List<Person>> args = new HashMap<>();
 
-        List<Person> sublist = new ArrayList<Person>();
+        List<Person> sublist = new ArrayList<>();
         sublist.add(new Person());
         args.put("1", sublist);
         try {
@@ -125,8 +125,8 @@ public abstract class AbstractSerializationPersonFailTest extends AbstractSerial
 
     @Test
     public void test_PersonListList() throws Exception {
-        List<List<Person>> args = new ArrayList<List<Person>>();
-        List<Person> sublist = new ArrayList<Person>();
+        List<List<Person>> args = new ArrayList<>();
+        List<Person> sublist = new ArrayList<>();
         sublist.add(new Person());
         args.add(sublist);
         try {

--- a/dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/base/AbstractSerializationPersonOkTest.java
+++ b/dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/base/AbstractSerializationPersonOkTest.java
@@ -39,7 +39,7 @@ public abstract class AbstractSerializationPersonOkTest extends AbstractSerializ
 
     @Test
     public void test_PersonList() throws Exception {
-        List<Phone> args = new ArrayList<Phone>();
+        List<Phone> args = new ArrayList<>();
         args.add(new Phone());
 
         assertObject(args);
@@ -47,7 +47,7 @@ public abstract class AbstractSerializationPersonOkTest extends AbstractSerializ
 
     @Test
     public void test_PersonSet() throws Exception {
-        Set<Phone> args = new HashSet<Phone>();
+        Set<Phone> args = new HashSet<>();
         args.add(new Phone());
 
         assertObject(args);
@@ -55,7 +55,7 @@ public abstract class AbstractSerializationPersonOkTest extends AbstractSerializ
 
     @Test
     public void test_IntPersonMap() throws Exception {
-        Map<Integer, Phone> args = new HashMap<Integer, Phone>();
+        Map<Integer, Phone> args = new HashMap<>();
         args.put(1, new Phone());
 
         assertObject(args);
@@ -63,7 +63,7 @@ public abstract class AbstractSerializationPersonOkTest extends AbstractSerializ
 
     @Test
     public void test_StringPersonMap() throws Exception {
-        Map<String, Phone> args = new HashMap<String, Phone>();
+        Map<String, Phone> args = new HashMap<>();
         args.put("1", new Phone());
 
         assertObject(args);
@@ -71,9 +71,9 @@ public abstract class AbstractSerializationPersonOkTest extends AbstractSerializ
 
     @Test
     public void test_StringPersonListMap() throws Exception {
-        Map<String, List<Phone>> args = new HashMap<String, List<Phone>>();
+        Map<String, List<Phone>> args = new HashMap<>();
 
-        List<Phone> sublist = new ArrayList<Phone>();
+        List<Phone> sublist = new ArrayList<>();
         sublist.add(new Phone());
         args.put("1", sublist);
 
@@ -82,8 +82,8 @@ public abstract class AbstractSerializationPersonOkTest extends AbstractSerializ
 
     @Test
     public void test_PersonListList() throws Exception {
-        List<List<Phone>> args = new ArrayList<List<Phone>>();
-        List<Phone> sublist = new ArrayList<Phone>();
+        List<List<Phone>> args = new ArrayList<>();
+        List<Phone> sublist = new ArrayList<>();
         sublist.add(new Phone());
         args.add(sublist);
 

--- a/dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/base/AbstractSerializationTest.java
+++ b/dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/base/AbstractSerializationTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractSerializationTest {
         bigPerson.setEmail("sm@1.com");
         bigPerson.setPenName("pname");
 
-        ArrayList<Phone> phones = new ArrayList<Phone>();
+        ArrayList<Phone> phones = new ArrayList<>();
         Phone phone1 = new Phone("86", "0571", "87654321", "001");
         Phone phone2 = new Phone("86", "0571", "87654322", "002");
         phones.add(phone1);
@@ -111,7 +111,7 @@ public abstract class AbstractSerializationTest {
         media.setDuration(93419235);
         media.setSize(3477897);
         media.setBitrate(94523);
-        List<String> persons = new ArrayList<String>();
+        List<String> persons = new ArrayList<>();
         persons.add("jerry");
         persons.add("tom");
         persons.add("lucy");
@@ -119,7 +119,7 @@ public abstract class AbstractSerializationTest {
         media.setCopyright("1999-2011");
         media.setPlayer(Media.Player.FLASH);
 
-        List<Image> images = new ArrayList<Image>();
+        List<Image> images = new ArrayList<>();
         for (int i = 0; i < 10; ++i) {
             Image image = new Image();
             image.setUri("url" + i);
@@ -937,14 +937,14 @@ public abstract class AbstractSerializationTest {
 
     @Test
     public void test_StringArrayList() throws Exception {
-        List<String> args = new ArrayList<String>(Arrays.asList(new String[]{"1", "b"}));
+        List<String> args = new ArrayList<>(Arrays.asList(new String[]{"1", "b"}));
 
         assertObject(args);
     }
 
     @Test
     public void test_StringSet() throws Exception {
-        Set<String> args = new HashSet<String>();
+        Set<String> args = new HashSet<>();
         args.add("1");
 
         assertObject(args);
@@ -952,7 +952,7 @@ public abstract class AbstractSerializationTest {
 
     @Test
     public void test_LinkedHashMap() throws Exception {
-        LinkedHashMap<String, String> data = new LinkedHashMap<String, String>();
+        LinkedHashMap<String, String> data = new LinkedHashMap<>();
         data.put("1", "a");
         data.put("2", "b");
 
@@ -983,7 +983,7 @@ public abstract class AbstractSerializationTest {
 
     @Test
     public void test_SPersonList() throws Exception {
-        List<SerializablePerson> args = new ArrayList<SerializablePerson>();
+        List<SerializablePerson> args = new ArrayList<>();
         args.add(new SerializablePerson());
 
         assertObject(args);
@@ -991,7 +991,7 @@ public abstract class AbstractSerializationTest {
 
     @Test
     public void test_SPersonSet() throws Exception {
-        Set<SerializablePerson> args = new HashSet<SerializablePerson>();
+        Set<SerializablePerson> args = new HashSet<>();
         args.add(new SerializablePerson());
 
         assertObject(args);
@@ -1001,7 +1001,7 @@ public abstract class AbstractSerializationTest {
 
     @Test
     public void test_IntSPersonMap() throws Exception {
-        Map<Integer, SerializablePerson> args = new HashMap<Integer, SerializablePerson>();
+        Map<Integer, SerializablePerson> args = new HashMap<>();
         args.put(1, new SerializablePerson());
 
         assertObject(args);
@@ -1009,7 +1009,7 @@ public abstract class AbstractSerializationTest {
 
     @Test
     public void test_StringSPersonMap() throws Exception {
-        Map<String, SerializablePerson> args = new HashMap<String, SerializablePerson>();
+        Map<String, SerializablePerson> args = new HashMap<>();
         args.put("1", new SerializablePerson());
 
         assertObject(args);
@@ -1017,9 +1017,9 @@ public abstract class AbstractSerializationTest {
 
     @Test
     public void test_StringSPersonListMap() throws Exception {
-        Map<String, List<SerializablePerson>> args = new HashMap<String, List<SerializablePerson>>();
+        Map<String, List<SerializablePerson>> args = new HashMap<>();
 
-        List<SerializablePerson> sublist = new ArrayList<SerializablePerson>();
+        List<SerializablePerson> sublist = new ArrayList<>();
         sublist.add(new SerializablePerson());
         args.put("1", sublist);
 
@@ -1028,8 +1028,8 @@ public abstract class AbstractSerializationTest {
 
     @Test
     public void test_SPersonListList() throws Exception {
-        List<List<SerializablePerson>> args = new ArrayList<List<SerializablePerson>>();
-        List<SerializablePerson> sublist = new ArrayList<SerializablePerson>();
+        List<List<SerializablePerson>> args = new ArrayList<>();
+        List<SerializablePerson> sublist = new ArrayList<>();
         sublist.add(new SerializablePerson());
         args.add(sublist);
 
@@ -1165,7 +1165,7 @@ public abstract class AbstractSerializationTest {
     @Test
     public void test_LoopReference() throws Exception {
         assertTimeout(ofMillis(3000), () -> {
-            Map<String, Object> map = new HashMap<String, Object>();
+            Map<String, Object> map = new HashMap<>();
             map.put("k1", "v1");
             map.put("self", map);
 


### PR DESCRIPTION
## What is the purpose of the change

Replace all explicit type parameters with diamond operator (supported with Java7+)

## Brief changelog

"Find and replace" old style parameters with diamond operator by the help of a regular expression and some after manual work for specific cases. 

## Verifying this change

No eclipse warnings or SonarQube issues specific to this case exists anymore.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
