### PR TITLE
Activate SPI sort

### DIFF
--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/extension/support/ActivateComparator.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/extension/support/ActivateComparator.java
@@ -45,11 +45,19 @@ public class ActivateComparator implements Comparator<Object> {
         }
         Activate a1 = o1.getClass().getAnnotation(Activate.class);
         Activate a2 = o2.getClass().getAnnotation(Activate.class);
+        Class<?> spiClass = null;
+        if(o1.getClass().getInterfaces().length > 0){
+            for (Class<?> item : o1.getClass().getInterfaces()) {
+                if (item.isAnnotationPresent(SPI.class)) {
+                    spiClass = item;
+                    break;
+                }
+            }
+        }
         if ((a1.before().length > 0 || a1.after().length > 0
                 || a2.before().length > 0 || a2.after().length > 0)
-                && o1.getClass().getInterfaces().length > 0
-                && o1.getClass().getInterfaces()[0].isAnnotationPresent(SPI.class)) {
-            ExtensionLoader<?> extensionLoader = ExtensionLoader.getExtensionLoader(o1.getClass().getInterfaces()[0]);
+                && spiClass != null) {
+            ExtensionLoader<?> extensionLoader = ExtensionLoader.getExtensionLoader(spiClass);
             if (a1.before().length > 0 || a1.after().length > 0) {
                 String n2 = extensionLoader.getExtensionName(o2.getClass());
                 for (String before : a1.before()) {

--- a/dubbo-common/src/main/java/com/alibaba/dubbo/common/extension/support/ActivateComparator.java
+++ b/dubbo-common/src/main/java/com/alibaba/dubbo/common/extension/support/ActivateComparator.java
@@ -46,7 +46,7 @@ public class ActivateComparator implements Comparator<Object> {
         Activate a1 = o1.getClass().getAnnotation(Activate.class);
         Activate a2 = o2.getClass().getAnnotation(Activate.class);
         Class<?> spiClass = null;
-        if(o1.getClass().getInterfaces().length > 0){
+        if (o1.getClass().getInterfaces().length > 0) {
             for (Class<?> item : o1.getClass().getInterfaces()) {
                 if (item.isAnnotationPresent(SPI.class)) {
                     spiClass = item;


### PR DESCRIPTION
## What is the purpose of the change

[dubbo-3309] fix #3309 
When all active implementation classes of a SPI interface are sorted (Activate Comparator), and when the implementation classes of the SPI interface not only implement the SPI interface, but also other non-SPI interfaces, if the SPI interface is not in the first place of the implements, the function of before and after will fail.

## Brief changelog

get the specified SPI interface modifier.

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
