### PR TITLE
Fix invocation of toString on an array

### DIFF
--- a/dubbo-metadata-report/dubbo-metadata-definition/src/main/java/org/apache/dubbo/metadata/definition/builder/CollectionTypeBuilder.java
+++ b/dubbo-metadata-report/dubbo-metadata-definition/src/main/java/org/apache/dubbo/metadata/definition/builder/CollectionTypeBuilder.java
@@ -22,6 +22,7 @@ import org.apache.dubbo.metadata.definition.model.TypeDefinition;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
@@ -48,7 +49,7 @@ public class CollectionTypeBuilder implements TypeBuilder {
         Type[] actualTypeArgs = parameterizedType.getActualTypeArguments();
         if (actualTypeArgs == null || actualTypeArgs.length != 1) {
             throw new IllegalArgumentException(MessageFormat.format(
-                    "[ServiceDefinitionBuilder] Collection type [{0}] with unexpected amount of arguments [{1}]." + actualTypeArgs,
+                    "[ServiceDefinitionBuilder] Collection type [{0}] with unexpected amount of arguments [{1}]." + Arrays.toString(actualTypeArgs),
                     new Object[]{type, actualTypeArgs}));
         }
 

--- a/dubbo-metadata-report/dubbo-metadata-definition/src/main/java/org/apache/dubbo/metadata/definition/builder/MapTypeBuilder.java
+++ b/dubbo-metadata-report/dubbo-metadata-definition/src/main/java/org/apache/dubbo/metadata/definition/builder/MapTypeBuilder.java
@@ -22,6 +22,7 @@ import org.apache.dubbo.metadata.definition.model.TypeDefinition;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -47,7 +48,7 @@ public class MapTypeBuilder implements TypeBuilder {
         Type[] actualTypeArgs = parameterizedType.getActualTypeArguments();
         if (actualTypeArgs == null || actualTypeArgs.length != 2) {
             throw new IllegalArgumentException(MessageFormat.format(
-                    "[ServiceDefinitionBuilder] Map type [{0}] with unexpected amount of arguments [{1}]." + actualTypeArgs, new Object[]{
+                    "[ServiceDefinitionBuilder] Map type [{0}] with unexpected amount of arguments [{1}]." + Arrays.toString(actualTypeArgs), new Object[]{
                             type, actualTypeArgs}));
         }
 


### PR DESCRIPTION
FindBugs-3.0.1 ([http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)) reported two DMI_INVOKING_TOSTRING_ON_ARRAY warnings on master:
```
DMI_INVOKING_TOSTRING_ON_ARRAY: Invocation of toString on actualTypeArgs in org.apache.dubbo.metadata.definition.builder.CollectionTypeBuilder.build(Type, Class, Map) At CollectionTypeBuilder.java:[line 50]
DMI_INVOKING_TOSTRING_ON_ARRAY: Invocation of toString on actualTypeArgs in org.apache.dubbo.metadata.definition.builder.MapTypeBuilder.build(Type, Class, Map) At MapTypeBuilder.java:[line 49]
```
The description of this bug is as follows:
> USELESS_STRING: Invocation of toString on an array (DMI_INVOKING_TOSTRING_ON_ARRAY)
> The code invokes `toString` on an array, which will generate a fairly useless result such as `[C@16f0472`. Consider using `Arrays.toString` to convert the array into a readable String that gives the contents of the array. See Programming Puzzlers, chapter 3, puzzle 12.
 [http://findbugs.sourceforge.net/bugDescriptions.html#DMI_INVOKING_TOSTRING_ON_ARRAY](http://findbugs.sourceforge.net/bugDescriptions.html#DMI_INVOKING_TOSTRING_ON_ARRAY)