### PR TITLE
Fix inefficient use of keySet iterator instead of entrySet iterator

### DIFF
--- a/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/ProviderConsumerRegTable.java
+++ b/dubbo-registry/dubbo-registry-api/src/main/java/org/apache/dubbo/registry/support/ProviderConsumerRegTable.java
@@ -72,9 +72,9 @@ public class ProviderConsumerRegTable {
             return null;
         }
 
-        for (Invoker inv : invokers.keySet()) {
-            if (inv == invoker) {
-                return invokers.get(inv);
+        for (Map.Entry<Invoker, ProviderInvokerWrapper> entry : invokers.entrySet()) {
+            if (entry.getKey() == invoker) {
+                return entry.getValue();
             }
         }
 


### PR DESCRIPTION
FindBugs-3.0.1 ([http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)) reported a WMI_WRONG_MAP_ITERATOR warning on master:
```
WMI_WRONG_MAP_ITERATOR: org.apache.dubbo.registry.support.ProviderConsumerRegTable.getProviderWrapper(URL, Invoker) makes inefficient use of keySet iterator instead of entrySet iterator At ProviderConsumerRegTable.java:[line 77]
```
The description of this bug is as follows:
> WMI: Inefficient use of keySet iterator instead of entrySet iterator (WMI_WRONG_MAP_ITERATOR)
> This method accesses the value of a `Map` entry, using a key that was retrieved from a `keySet` iterator. It is more efficient to use an iterator on the `entrySet` of the map, to avoid the `Map.get(key)` lookup.
 [http://findbugs.sourceforge.net/bugDescriptions.html#WMI_WRONG_MAP_ITERATOR](http://findbugs.sourceforge.net/bugDescriptions.html#WMI_WRONG_MAP_ITERATOR)