### PR TITLE
fix issue #274: monitor的cluster一定是failsafe的，而且无法修改

### DIFF
--- a/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/DubboMonitorFactory.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/DubboMonitorFactory.java
@@ -16,7 +16,6 @@
  */
 package org.apache.dubbo.monitor.dubbo;
 
-import org.apache.dubbo.common.Constants;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.monitor.Monitor;

--- a/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/DubboMonitorFactory.java
+++ b/dubbo-monitor/dubbo-monitor-default/src/main/java/org/apache/dubbo/monitor/dubbo/DubboMonitorFactory.java
@@ -26,6 +26,10 @@ import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Protocol;
 import org.apache.dubbo.rpc.ProxyFactory;
 
+import static org.apache.dubbo.common.Constants.CHECK_KEY;
+import static org.apache.dubbo.common.Constants.PROTOCOL_KEY;
+import static org.apache.dubbo.common.Constants.REFERENCE_FILTER_KEY;
+
 /**
  * DefaultMonitorFactory
  */
@@ -45,18 +49,17 @@ public class DubboMonitorFactory extends AbstractMonitorFactory {
 
     @Override
     protected Monitor createMonitor(URL url) {
-        url = url.setProtocol(url.getParameter(Constants.PROTOCOL_KEY, "dubbo"));
+        url = url.setProtocol(url.getParameter(PROTOCOL_KEY, "dubbo"));
         if (StringUtils.isEmpty(url.getPath())) {
             url = url.setPath(MonitorService.class.getName());
         }
-        String filter = url.getParameter(Constants.REFERENCE_FILTER_KEY);
+        String filter = url.getParameter(REFERENCE_FILTER_KEY);
         if (StringUtils.isEmpty(filter)) {
             filter = "";
         } else {
             filter = filter + ",";
         }
-        url = url.addParameters(Constants.CLUSTER_KEY, "failsafe", Constants.CHECK_KEY, String.valueOf(false),
-                Constants.REFERENCE_FILTER_KEY, filter + "-monitor");
+        url = url.addParameters(CHECK_KEY, String.valueOf(false), REFERENCE_FILTER_KEY, filter + "-monitor");
         Invoker<MonitorService> monitorInvoker = protocol.refer(MonitorService.class, url);
         MonitorService monitorService = proxyFactory.getProxy(monitorInvoker);
         return new DubboMonitor(monitorInvoker, monitorService);


### PR DESCRIPTION
## What is the purpose of the change

fix issue #274: monitor的cluster一定是failsafe的，而且无法修改

## Brief changelog

XXXXX

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
