### PR TITLE
fix context filter's bug

### DIFF
--- a/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/RpcContextFilter.java
+++ b/dubbo-rpc/dubbo-rpc-rest/src/main/java/org/apache/dubbo/rpc/protocol/rest/RpcContextFilter.java
@@ -18,7 +18,6 @@ package org.apache.dubbo.rpc.protocol.rest;
 
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.rpc.RpcContext;
-
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
 import javax.annotation.Priority;
@@ -29,6 +28,7 @@ import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 @Priority(Integer.MIN_VALUE + 1)
@@ -71,14 +71,14 @@ public class RpcContextFilter implements ContainerRequestFilter, ClientRequestFi
         int size = 0;
         for (Map.Entry<String, String> entry : RpcContext.getContext().getAttachments().entrySet()) {
             String key = entry.getKey();
-            String value = entry.getKey();
+            String value = entry.getValue();
             if (illegalForRest(key) || illegalForRest(value)) {
                 throw new IllegalArgumentException("The attachments of " + RpcContext.class.getSimpleName() + " must not contain ',' or '=' when using rest protocol");
             }
 
             // TODO for now we don't consider the differences of encoding and server limit
             if (value != null) {
-                size += value.getBytes("UTF-8").length;
+                size += value.getBytes(StandardCharsets.UTF_8).length;
             }
             if (size > MAX_HEADER_SIZE) {
                 throw new IllegalArgumentException("The attachments of " + RpcContext.class.getSimpleName() + " is too big");


### PR DESCRIPTION
fix context filter's bug:
`String value = entry.getKey();` -> `String value = entry.getValue();`