### PR TITLE
Rmi support generic

### DIFF
--- a/dubbo-rpc/dubbo-rpc-rmi/src/main/java/org/apache/dubbo/rpc/protocol/rmi/RmiRemoteInvocation.java
+++ b/dubbo-rpc/dubbo-rpc-rmi/src/main/java/org/apache/dubbo/rpc/protocol/rmi/RmiRemoteInvocation.java
@@ -16,6 +16,8 @@
  */
 package org.apache.dubbo.rpc.protocol.rmi;
 
+import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.rpc.RpcContext;
 
 import org.aopalliance.intercept.MethodInvocation;
@@ -34,7 +36,7 @@ public class RmiRemoteInvocation extends RemoteInvocation {
      */
     public RmiRemoteInvocation(MethodInvocation methodInvocation) {
         super(methodInvocation);
-        addAttribute(dubboAttachmentsAttrName, new HashMap<String, String>(RpcContext.getContext().getAttachments()));
+        addAttribute(dubboAttachmentsAttrName, new HashMap<>(RpcContext.getContext().getAttachments()));
     }
 
     /**
@@ -48,6 +50,10 @@ public class RmiRemoteInvocation extends RemoteInvocation {
             InvocationTargetException {
         RpcContext context = RpcContext.getContext();
         context.setAttachments((Map<String, String>) getAttribute(dubboAttachmentsAttrName));
+        String generic = (String) getAttribute(Constants.GENERIC_KEY);
+        if (StringUtils.isNotEmpty(generic)) {
+            context.setAttachment(Constants.GENERIC_KEY, generic);
+        }
         try {
             return super.invoke(targetObject);
         } finally {

--- a/dubbo-rpc/dubbo-rpc-rmi/src/test/java/org/apache/dubbo/rpc/protocol/rmi/DemoService.java
+++ b/dubbo-rpc/dubbo-rpc-rmi/src/test/java/org/apache/dubbo/rpc/protocol/rmi/DemoService.java
@@ -23,6 +23,8 @@ package org.apache.dubbo.rpc.protocol.rmi;
 public interface DemoService {
     void sayHello(String name);
 
+    String sayHi(String name);
+
     String echo(String text);
 
     long timestamp();

--- a/dubbo-rpc/dubbo-rpc-rmi/src/test/java/org/apache/dubbo/rpc/protocol/rmi/DemoServiceImpl.java
+++ b/dubbo-rpc/dubbo-rpc-rmi/src/test/java/org/apache/dubbo/rpc/protocol/rmi/DemoServiceImpl.java
@@ -31,6 +31,10 @@ public class DemoServiceImpl implements DemoService {
         System.out.println("hello " + name);
     }
 
+    public String sayHi(String name) {
+        return "Hi, " + name;
+    }
+
     public String echo(String text) {
         return text;
     }

--- a/dubbo-rpc/dubbo-rpc-rmi/src/test/java/org/apache/dubbo/rpc/protocol/rmi/RmiProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-rmi/src/test/java/org/apache/dubbo/rpc/protocol/rmi/RmiProtocolTest.java
@@ -19,12 +19,11 @@ package org.apache.dubbo.rpc.protocol.rmi;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
-import org.apache.dubbo.rpc.Exporter;
-import org.apache.dubbo.rpc.Protocol;
-import org.apache.dubbo.rpc.ProxyFactory;
-import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.*;
 import org.apache.dubbo.rpc.service.EchoService;
 
+import org.apache.dubbo.rpc.service.GenericService;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -113,6 +112,19 @@ public class RmiProtocolTest {
         assertEquals(echo.$echo(1234), 1234);
 
         rpcExporter.unexport();
+    }
+
+    @Test
+    public void testGenericInvoke() {
+        DemoService service = new DemoServiceImpl();
+        URL url = URL.valueOf("rmi://127.0.0.1:9003/" + DemoService.class.getName() + "?release=2.7.0");
+        Exporter<DemoService> exporter = protocol.export(proxy.getInvoker(service, DemoService.class, url));
+        Invoker<GenericService> invoker = protocol.refer(GenericService.class, url);
+        GenericService client = proxy.getProxy(invoker, true);
+        String result = (String) client.$invoke("sayHi", new String[]{"java.lang.String"}, new Object[]{"haha"});
+        Assertions.assertEquals("Hi, haha", result);
+        invoker.destroy();
+        exporter.unexport();
     }
 
     public static interface NonStdRmiInterface {

--- a/dubbo-rpc/dubbo-rpc-rmi/src/test/java/org/apache/dubbo/rpc/protocol/rmi/RmiProtocolTest.java
+++ b/dubbo-rpc/dubbo-rpc-rmi/src/test/java/org/apache/dubbo/rpc/protocol/rmi/RmiProtocolTest.java
@@ -19,7 +19,11 @@ package org.apache.dubbo.rpc.protocol.rmi;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.ExtensionLoader;
-import org.apache.dubbo.rpc.*;
+import org.apache.dubbo.rpc.Exporter;
+import org.apache.dubbo.rpc.Protocol;
+import org.apache.dubbo.rpc.ProxyFactory;
+import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.service.EchoService;
 
 import org.apache.dubbo.rpc.service.GenericService;


### PR DESCRIPTION
## What is the purpose of the change

fix RMI protocol doesn't support generic invocation. #2779

## Brief changelog

XXXXX

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
