### PR TITLE
Fix bug of ConfigManger#checkDuplicate

### DIFF
--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -689,7 +689,10 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
     }
 
     public void setApplication(ApplicationConfig application) {
-        ConfigManager.getInstance().setApplication(application);
+        if (!ConfigManager.getInstance().getApplication().isPresent() ||
+                !ConfigManager.getInstance().getApplication().get().equals(application)) {
+            ConfigManager.getInstance().setApplication(application);
+        }
         this.application = application;
     }
 
@@ -714,7 +717,10 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
     }
 
     public void setModule(ModuleConfig module) {
-        ConfigManager.getInstance().setModule(module);
+        if (!ConfigManager.getInstance().getModule().isPresent()
+                || !ConfigManager.getInstance().getModule().get().equals(module)) {
+            ConfigManager.getInstance().setModule(module);
+        }
         this.module = module;
     }
 
@@ -756,7 +762,10 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
     }
 
     public void setMonitor(MonitorConfig monitor) {
-        ConfigManager.getInstance().setMonitor(monitor);
+        if (!ConfigManager.getInstance().getMonitor().isPresent()
+                || !ConfigManager.getInstance().getMonitor().get().equals(monitor)) {
+            ConfigManager.getInstance().setMonitor(monitor);
+        }
         this.monitor = monitor;
     }
 
@@ -774,7 +783,10 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
     }
 
     public void setConfigCenter(ConfigCenterConfig configCenter) {
-        ConfigManager.getInstance().setConfigCenter(configCenter);
+        if (!ConfigManager.getInstance().getConfigCenter().isPresent()
+                || !ConfigManager.getInstance().getConfigCenter().get().equals(configCenter)) {
+            ConfigManager.getInstance().setConfigCenter(configCenter);
+        }
         this.configCenter = configCenter;
     }
 

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -689,10 +689,7 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
     }
 
     public void setApplication(ApplicationConfig application) {
-        if (!ConfigManager.getInstance().getApplication().isPresent() ||
-                !ConfigManager.getInstance().getApplication().get().equals(application)) {
-            ConfigManager.getInstance().setApplication(application);
-        }
+        ConfigManager.getInstance().setApplication(application);
         this.application = application;
     }
 
@@ -717,10 +714,7 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
     }
 
     public void setModule(ModuleConfig module) {
-        if (!ConfigManager.getInstance().getModule().isPresent()
-                || !ConfigManager.getInstance().getModule().get().equals(module)) {
-            ConfigManager.getInstance().setModule(module);
-        }
+        ConfigManager.getInstance().setModule(module);
         this.module = module;
     }
 
@@ -762,10 +756,7 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
     }
 
     public void setMonitor(MonitorConfig monitor) {
-        if (!ConfigManager.getInstance().getMonitor().isPresent()
-                || !ConfigManager.getInstance().getMonitor().get().equals(monitor)) {
-            ConfigManager.getInstance().setMonitor(monitor);
-        }
+        ConfigManager.getInstance().setMonitor(monitor);
         this.monitor = monitor;
     }
 
@@ -783,10 +774,7 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
     }
 
     public void setConfigCenter(ConfigCenterConfig configCenter) {
-        if (!ConfigManager.getInstance().getConfigCenter().isPresent()
-                || !ConfigManager.getInstance().getConfigCenter().get().equals(configCenter)) {
-            ConfigManager.getInstance().setConfigCenter(configCenter);
-        }
+        ConfigManager.getInstance().setConfigCenter(configCenter);
         this.configCenter = configCenter;
     }
 

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/context/ConfigManager.java
@@ -310,7 +310,7 @@ public class ConfigManager {
     }
 
     private void checkDuplicate(AbstractConfig oldOne, AbstractConfig newOne) {
-        if (oldOne != null && !oldOne.equals(newOne)) {
+        if (oldOne != null && oldOne.equals(newOne)) {
             String configName = oldOne.getClass().getSimpleName();
             throw new IllegalStateException("Duplicate Config found for " + configName + ", you should use only one unique " + configName + " for one application.");
         }

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractInterfaceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/AbstractInterfaceConfigTest.java
@@ -124,6 +124,22 @@ public class AbstractInterfaceConfigTest {
     }
 
     @Test
+    public void checkDuplicateApplication() {
+        try {
+            System.setProperty("dubbo.application.name", "demo");
+            Assertions.assertThrows(IllegalStateException.class,
+                    () -> {
+                        InterfaceConfig interfaceConfig = new InterfaceConfig();
+                        interfaceConfig.checkApplication();
+                        interfaceConfig = new InterfaceConfig();
+                        interfaceConfig.checkApplication();
+                    });
+        } finally {
+            System.clearProperty("dubbo.application.name");
+        }
+    }
+
+    @Test
     public void testLoadRegistries() {
         System.setProperty("dubbo.registry.address", "addr1");
         InterfaceConfig interfaceConfig = new InterfaceConfig();


### PR DESCRIPTION
## What is the purpose of the change

- The logic of the `ConfigManger#checkDuplicate `method is wrong
- `AbstractInterfaceConfig#setApplication` `AbstractInterfaceConfig#setModule` `AbstractInterfaceConfig#setMonitor` `AbstractInterfaceConfig#setConfigCenter`
first check config of ConfigManger class，then update it

## Brief changelog

调整`!oldOne.equals(newOne)`为`oldOne.equals(newOne)`

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
