### PR TITLE
[Dubbo-619] Fix #619 and PR #2956 is not enough

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcResult.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcResult.java
@@ -94,9 +94,14 @@ public class RpcResult extends AbstractResult {
     }
 
     /**
-     * fix issue#619
-     * @param e
-     * @return
+     * we need to deal the exception whose stack trace is null.
+     * <p>
+     * see https://github.com/apache/incubator-dubbo/pull/2956
+     * and https://github.com/apache/incubator-dubbo/pull/3634
+     * and https://github.com/apache/incubator-dubbo/issues/619
+     *
+     * @param e exception
+     * @return exception after deal with stack trace
      */
     private Throwable handleStackTraceNull(Throwable e) {
         if (e != null) {

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/RpcResultTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/RpcResultTest.java
@@ -20,28 +20,62 @@ package org.apache.dubbo.rpc;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
 public class RpcResultTest {
     @Test
-    public void testRecreateWithNormalException() {
+    public void testRpcResultWithNormalException() {
         NullPointerException npe = new NullPointerException();
         RpcResult rpcResult = new RpcResult(npe);
-        try {
-            rpcResult.recreate();
-            fail();
-        } catch (Throwable throwable) {
-            StackTraceElement[] stackTrace = throwable.getStackTrace();
-            Assertions.assertNotNull(stackTrace);
-            Assertions.assertTrue(stackTrace.length > 1);
-        }
+
+        StackTraceElement[] stackTrace = rpcResult.getException().getStackTrace();
+        Assertions.assertNotNull(stackTrace);
+        Assertions.assertTrue(stackTrace.length > 1);
     }
 
     /**
      * please run this test in Run mode
      */
     @Test
-    public void testRecreateWithEmptyStackTraceException() {
+    public void testRpcResultWithEmptyStackTraceException() {
+        Throwable throwable = buildEmptyStackTraceException();
+        if (throwable == null) {
+            return;
+        }
+        RpcResult rpcResult = new RpcResult(throwable);
+
+        StackTraceElement[] stackTrace = rpcResult.getException().getStackTrace();
+        Assertions.assertNotNull(stackTrace);
+        Assertions.assertTrue(stackTrace.length == 0);
+    }
+
+    @Test
+    public void testSetExceptionWithNormalException() {
+        NullPointerException npe = new NullPointerException();
+        RpcResult rpcResult = new RpcResult();
+        rpcResult.setException(npe);
+
+        StackTraceElement[] stackTrace = rpcResult.getException().getStackTrace();
+        Assertions.assertNotNull(stackTrace);
+        Assertions.assertTrue(stackTrace.length > 1);
+    }
+
+    /**
+     * please run this test in Run mode
+     */
+    @Test
+    public void testSetExceptionWithEmptyStackTraceException() {
+        Throwable throwable = buildEmptyStackTraceException();
+        if (throwable == null) {
+            return;
+        }
+        RpcResult rpcResult = new RpcResult();
+        rpcResult.setException(throwable);
+
+        StackTraceElement[] stackTrace = rpcResult.getException().getStackTrace();
+        Assertions.assertNotNull(stackTrace);
+        Assertions.assertTrue(stackTrace.length == 0);
+    }
+
+    private Throwable buildEmptyStackTraceException() {
         // begin to construct a NullPointerException with empty stackTrace
         Throwable throwable = null;
         Long begin = System.currentTimeMillis();
@@ -59,19 +93,11 @@ public class RpcResultTest {
          * may be there is -XX:-OmitStackTraceInFastThrow or run in Debug mode
          */
         if (throwable == null) {
-            System.out.println("###testRecreateWithEmptyStackTraceException fail to construct NPE");
-            return;
+            System.out.println("###buildEmptyStackTraceException fail to construct NPE");
+            return null;
         }
         // end construct a NullPointerException with empty stackTrace
 
-        RpcResult rpcResult = new RpcResult(throwable);
-        try {
-            rpcResult.recreate();
-            fail();
-        } catch (Throwable t) {
-            StackTraceElement[] stackTrace = t.getStackTrace();
-            Assertions.assertNotNull(stackTrace);
-            Assertions.assertTrue(stackTrace.length == 0);
-        }
+        return throwable;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix #619 , and PR #2956 is not enough in the following use case:

In souche.com, we add 'trace' function in dubbo, such as in FailoverClusterInvoker.doInvoke, we get stackTrace from exception to log detail exception info using the following:

`org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace(result.getException())`

The above sentence will result the same problem with issue #619 .

So, we should solve this in decode stage.

#619 这个问题, PR #2956 貌似已经解决了, 但是我们公司(souche.com)在对dubbo加全链路埋点时, 还是遇到了之前的问题, 因为 #2956 是在InvokerInvocationHandler.invoke()方法的invoker.invoke(invocation)后解决了问题, 但是我们在FailoverClusterInvoker.doInvoke()方法里坐全链路埋点时, 为了能取到异常栈的信息, 用了如下的语句:
`org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace(result.getException())`
导致了异常栈又出问题了..

所以应该在decode后, 对exception对象做判断才对.

## Brief changelog

RpcResult.java
RpcResultTest.java

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
