### PR TITLE
[Dubbo-3662]fix ServerContext can not transform data in sync invoke

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ContextFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ContextFilter.java
@@ -80,7 +80,6 @@ public class ContextFilter implements Filter {
         } finally {
             // IMPORTANT! For async scenario, we must remove context from current thread, so we always create a new RpcContext for the next invoke for the same thread.
             RpcContext.removeContext();
-            RpcContext.removeServerContext();
         }
     }
 
@@ -88,6 +87,7 @@ public class ContextFilter implements Filter {
     public Result onResponse(Result result, Invoker<?> invoker, Invocation invocation) {
         // pass attachments to result
         result.addAttachments(RpcContext.getServerContext().getAttachments());
+        RpcContext.removeServerContext();
         return result;
     }
 }


### PR DESCRIPTION
Make RpcContext's ServerContext can transform data from provider to consumer

## What is the purpose of the change

When user use sync invoke, the RpcContext's ServerContext cannot transform data from provider to consumer.

## Brief changelog

Make ContextFilter remove ServerContext after it copy data from ServerContext to result's attachments of the invoke when provider is responding consumer.

## Verifying this change

Have been tested.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
