### PR TITLE
[Dubbo-3625]Add constant 'MIN_PATH_ARRAY_LENGTH'

### DIFF
--- a/dubbo-configcenter/dubbo-configcenter-zookeeper/src/main/java/org/apache/dubbo/configcenter/support/zookeeper/CacheListener.java
+++ b/dubbo-configcenter/dubbo-configcenter-zookeeper/src/main/java/org/apache/dubbo/configcenter/support/zookeeper/CacheListener.java
@@ -67,7 +67,8 @@ public class CacheListener implements TreeCacheListener {
         // TODO We limit the notification of config changes to a specific path level, for example
         //  /dubbo/config/service/configurators, other config changes not in this level will not get notified,
         //  say /dubbo/config/dubbo.properties
-        if (data.getPath().split("/").length >= 5) {
+        final int MIN_PATH_ARRAY_LENGTH = 5;
+        if (data.getPath().split("/").length >= MIN_PATH_ARRAY_LENGTH) {
             byte[] value = data.getData();
             String key = pathToKey(data.getPath());
             ConfigChangeType changeType;


### PR DESCRIPTION
Fixes #3625.

## What is the purpose of the change

Remove magic number in org.apache.dubbo.configcenter.support.zookeeper.CacheListener#childEvent

## Brief changelog

Add constant 'MIN_PATH_ARRAY_LENGTH'.

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
