### PR TITLE
[Dubbo-3625] Add constant 'MIN_PATH_ARRAY_LENGTH'

### DIFF
--- a/dubbo-configcenter/dubbo-configcenter-zookeeper/src/main/java/org/apache/dubbo/configcenter/support/zookeeper/CacheListener.java
+++ b/dubbo-configcenter/dubbo-configcenter-zookeeper/src/main/java/org/apache/dubbo/configcenter/support/zookeeper/CacheListener.java
@@ -89,7 +89,8 @@ public class CacheListener implements DataListener {
         // TODO We limit the notification of config changes to a specific path level, for example
         //  /dubbo/config/service/configurators, other config changes not in this level will not get notified,
         //  say /dubbo/config/dubbo.properties
-        if (path.split("/").length >= 5) {
+        final int MIN_PATH_ARRAY_LENGTH = 5;
+        if (path.split("/").length >= MIN_PATH_ARRAY_LENGTH) {
             String key = pathToKey(path);
             ConfigChangeType changeType;
             switch (eventType) {

--- a/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/DefaultFuture.java
+++ b/dubbo-remoting/dubbo-remoting-api/src/main/java/org/apache/dubbo/remoting/exchange/support/DefaultFuture.java
@@ -329,9 +329,7 @@ public class DefaultFuture implements ResponseFuture {
         lock.lock();
         try {
             response = res;
-            if (done != null) {
-                done.signal();
-            }
+            done.signalAll();
         } finally {
             lock.unlock();
         }


### PR DESCRIPTION
Fixes #3625

## What is the purpose of the change

Remove magic number 5 in line 70 of org.apache.dubbo.configcenter.support.zookeeper.CacheListener#childEvent.

## Brief changelog

Add constant 'MIN_PATH_ARRAY_LENGTH'

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
