### PR TITLE
Fix bug with CacheFilter when use async call.

### DIFF
--- a/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/filter/CacheFilter.java
+++ b/dubbo-filter/dubbo-filter-cache/src/main/java/org/apache/dubbo/cache/filter/CacheFilter.java
@@ -45,10 +45,10 @@ import java.io.Serializable;
  *        3)&lt;dubbo:provider cache="expiring" /&gt;
  *        4)&lt;dubbo:consumer cache="jcache" /&gt;
  *
- *If cache type is defined in method level then method level type will get precedence. According to above provided
- *example, if service has two method, method1 and method2, method2 will have cache type as <b>threadlocal</b> where others will
- *be backed by <b>lru</b>
- *</pre>
+ * If cache type is defined in method level then method level type will get precedence. According to above provided
+ * example, if service has two method, method1 and method2, method2 will have cache type as <b>threadlocal</b> where others will
+ * be backed by <b>lru</b>
+ * </pre>
  *
  * @see org.apache.dubbo.rpc.Filter
  * @see org.apache.dubbo.cache.support.lru.LruCacheFactory
@@ -59,7 +59,6 @@ import java.io.Serializable;
  * @see org.apache.dubbo.cache.support.threadlocal.ThreadLocalCache
  * @see org.apache.dubbo.cache.support.expiring.ExpiringCacheFactory
  * @see org.apache.dubbo.cache.support.expiring.ExpiringCache
- *
  */
 @Activate(group = {Constants.CONSUMER, Constants.PROVIDER}, value = Constants.CACHE_KEY)
 public class CacheFilter implements Filter {
@@ -81,45 +80,65 @@ public class CacheFilter implements Filter {
      * If cache is configured, dubbo will invoke method on each method call. If cache value is returned by cache store
      * then it will return otherwise call the remote method and return value. If remote method's return valeu has error
      * then it will not cache the value.
+     *
      * @param invoker    service
      * @param invocation invocation.
      * @return Cache returned value if found by the underlying cache store. If cache miss it will call target method.
-     * @throws RpcException
+     * @throws RpcException rpc exception
      */
     @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
-        if (cacheFactory != null && ConfigUtils.isNotEmpty(invoker.getUrl().getMethodParameter(invocation.getMethodName(), Constants.CACHE_KEY))) {
-            Cache cache = cacheFactory.getCache(invoker.getUrl(), invocation);
-            if (cache != null) {
-                String key = StringUtils.toArgumentString(invocation.getArguments());
-                Object value = cache.get(key);
-                if (value != null) {
-                    if (value instanceof ValueWrapper) {
-                        return new RpcResult(((ValueWrapper)value).get());
-                    } else {
-                        return new RpcResult(value);
-                    }
-                }
-                Result result = invoker.invoke(invocation);
-                if (!result.hasException()) {
-                    cache.put(key, new ValueWrapper(result.getValue()));
-                }
-                return result;
+        Cache cache = openCache(invoker, invocation);
+        if (cache == null) {
+            return invoker.invoke(invocation);
+        }
+        String key = StringUtils.toArgumentString(invocation.getArguments());
+        Object value = cache.get(key);
+        if (value != null) {
+            if (value instanceof ValueWrapper) {
+                return new RpcResult(((ValueWrapper) value).get());
+            } else {
+                return new RpcResult(value);
             }
         }
         return invoker.invoke(invocation);
     }
 
+    @Override
+    public Result onResponse(Result result, Invoker<?> invoker, Invocation invocation) {
+        Cache cache = openCache(invoker, invocation);
+        if (cache == null) {
+            return result;
+        }
+        String key = StringUtils.toArgumentString(invocation.getArguments());
+        if (!result.hasException()) {
+            cache.put(key, new ValueWrapper(result.getValue()));
+        }
+        return result;
+    }
+
+    private Cache openCache(Invoker<?> invoker, Invocation invocation) {
+        if (cacheFactory == null ||
+                ConfigUtils.isEmpty(invoker.getUrl().getMethodParameter(invocation.getMethodName(), Constants.CACHE_KEY))) {
+            return null;
+        }
+        Cache cache = cacheFactory.getCache(invoker.getUrl(), invocation);
+        if (cache == null) {
+            return null;
+        }
+        return cache;
+    }
+
     /**
      * Cache value wrapper.
      */
-    static class ValueWrapper implements Serializable{
+    static class ValueWrapper implements Serializable {
 
         private static final long serialVersionUID = -1777337318019193256L;
 
         private final Object value;
 
-        public ValueWrapper(Object value){
+        public ValueWrapper(Object value) {
             this.value = value;
         }
 

--- a/dubbo-filter/dubbo-filter-cache/src/test/java/org/apache/dubbo/cache/filter/CacheFilterTest.java
+++ b/dubbo-filter/dubbo-filter-cache/src/test/java/org/apache/dubbo/cache/filter/CacheFilterTest.java
@@ -23,9 +23,9 @@ import org.apache.dubbo.cache.support.lru.LruCacheFactory;
 import org.apache.dubbo.cache.support.threadlocal.ThreadLocalCacheFactory;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.RpcInvocation;
 import org.apache.dubbo.rpc.RpcResult;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -84,9 +84,15 @@ public class CacheFilterTest {
         invocation.setParameterTypes(new Class<?>[]{});
         invocation.setArguments(new Object[]{});
 
-        cacheFilter.invoke(invoker, invocation);
+        Result r = cacheFilter.invoke(invoker, invocation);
+        cacheFilter.onResponse(r, invoker, invocation);
+
         RpcResult rpcResult1 = (RpcResult) cacheFilter.invoke(invoker1, invocation);
+        cacheFilter.onResponse(rpcResult1, invoker, invocation);
+
         RpcResult rpcResult2 = (RpcResult) cacheFilter.invoke(invoker2, invocation);
+        cacheFilter.onResponse(rpcResult2, invoker, invocation);
+
         Assertions.assertEquals(rpcResult1.getValue(), rpcResult2.getValue());
         Assertions.assertEquals(rpcResult1.getValue(), "value");
     }
@@ -99,9 +105,15 @@ public class CacheFilterTest {
         invocation.setParameterTypes(new Class<?>[]{String.class});
         invocation.setArguments(new Object[]{"arg1"});
 
-        cacheFilter.invoke(invoker, invocation);
+        Result r = cacheFilter.invoke(invoker, invocation);
+        cacheFilter.onResponse(r, invoker, invocation);
+
         RpcResult rpcResult1 = (RpcResult) cacheFilter.invoke(invoker1, invocation);
+        cacheFilter.onResponse(rpcResult1, invoker1, invocation);
+
         RpcResult rpcResult2 = (RpcResult) cacheFilter.invoke(invoker2, invocation);
+        cacheFilter.onResponse(rpcResult2, invoker2, invocation);
+
         Assertions.assertEquals(rpcResult1.getValue(), rpcResult2.getValue());
         Assertions.assertEquals(rpcResult1.getValue(), "value");
     }
@@ -114,8 +126,12 @@ public class CacheFilterTest {
         invocation.setParameterTypes(new Class<?>[]{String.class});
         invocation.setArguments(new Object[]{"arg2"});
 
-        cacheFilter.invoke(invoker3, invocation);
+        Result r = cacheFilter.invoke(invoker3, invocation);
+        cacheFilter.onResponse(r, invoker3, invocation);
+
         RpcResult rpcResult = (RpcResult) cacheFilter.invoke(invoker2, invocation);
+        cacheFilter.onResponse(rpcResult, invoker2, invocation);
+
         Assertions.assertEquals(rpcResult.getValue(), "value2");
     }
 
@@ -127,9 +143,15 @@ public class CacheFilterTest {
         invocation.setParameterTypes(new Class<?>[]{String.class});
         invocation.setArguments(new Object[]{"arg3"});
 
-        cacheFilter.invoke(invoker4, invocation);
+        Result r = cacheFilter.invoke(invoker4, invocation);
+        cacheFilter.onResponse(r, invoker4, invocation);
+
         RpcResult rpcResult1 = (RpcResult) cacheFilter.invoke(invoker1, invocation);
+        cacheFilter.onResponse(rpcResult1, invoker1, invocation);
+
         RpcResult rpcResult2 = (RpcResult) cacheFilter.invoke(invoker2, invocation);
+        cacheFilter.onResponse(rpcResult2, invoker2, invocation);
+
         Assertions.assertEquals(rpcResult1.getValue(), null);
         Assertions.assertEquals(rpcResult2.getValue(), null);
     }


### PR DESCRIPTION
When use async call with cacheFilter, we will cache a empty result which is incorrect.

