### PR TITLE
fix fastjson serialize type

### DIFF
--- a/dubbo-serialization/dubbo-serialization-fastjson/src/main/java/com/alibaba/dubbo/common/serialize/fastjson/FastJsonObjectInput.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson/src/main/java/com/alibaba/dubbo/common/serialize/fastjson/FastJsonObjectInput.java
@@ -17,7 +17,6 @@
 package com.alibaba.dubbo.common.serialize.fastjson;
 
 import com.alibaba.dubbo.common.serialize.ObjectInput;
-import com.alibaba.dubbo.common.utils.PojoUtils;
 import com.alibaba.fastjson.JSON;
 
 import java.io.BufferedReader;

--- a/dubbo-serialization/dubbo-serialization-fastjson/src/main/java/com/alibaba/dubbo/common/serialize/fastjson/FastJsonObjectInput.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson/src/main/java/com/alibaba/dubbo/common/serialize/fastjson/FastJsonObjectInput.java
@@ -99,8 +99,8 @@ public class FastJsonObjectInput implements ObjectInput {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T readObject(Class<T> cls, Type type) throws IOException, ClassNotFoundException {
-        Object value = readObject(cls);
-        return (T) PojoUtils.realize(value, cls, type);
+        String json = readLine();
+        return (T) JSON.parseObject(json, type);
     }
 
     private String readLine() throws IOException, EOFException {

--- a/dubbo-serialization/dubbo-serialization-fastjson/src/test/java/com/alibaba/dubbo/common/serialize/fastjson/model/Organization.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson/src/test/java/com/alibaba/dubbo/common/serialize/fastjson/model/Organization.java
@@ -1,0 +1,17 @@
+package com.alibaba.dubbo.common.serialize.fastjson.model;
+
+/**
+ * @author Born
+ */
+public class Organization<T> {
+
+    private T data;
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+}

--- a/dubbo-serialization/dubbo-serialization-fastjson/src/test/java/com/alibaba/dubbo/common/serialize/fastjson/model/Organization.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson/src/test/java/com/alibaba/dubbo/common/serialize/fastjson/model/Organization.java
@@ -1,8 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.dubbo.common.serialize.fastjson.model;
 
-/**
- * @author Born
- */
 public class Organization<T> {
 
     private T data;


### PR DESCRIPTION
## What is the purpose of the change

修复fastjson序列的问题，有三层泛型以上时序列化报错 如：A\<B\<C\>\>

## Brief changelog

修复fastjson序列的问题，有三层泛型以上时序列化报错 如：A\<B\<C\>\>

## Verifying this change

三层泛型以上 会序列化成JSONArray 或者 JSONObject导致获取对象时发生强转异常
： Class1 cannot be cast to Class2
