### PR TITLE
fix fastjson serialization with generic return type

### DIFF
--- a/dubbo-serialization/dubbo-serialization-fastjson/src/main/java/org/apache/dubbo/common/serialize/fastjson/FastJsonObjectInput.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson/src/main/java/org/apache/dubbo/common/serialize/fastjson/FastJsonObjectInput.java
@@ -103,8 +103,8 @@ public class FastJsonObjectInput implements ObjectInput {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T readObject(Class<T> cls, Type type) throws IOException, ClassNotFoundException {
-        Object value = readObject(cls);
-        return (T) PojoUtils.realize(value, cls, type);
+        String json = readLine();
+        return (T) JSON.parseObject(json, type);
     }
 
     private String readLine() throws IOException, EOFException {

--- a/dubbo-serialization/dubbo-serialization-fastjson/src/main/java/org/apache/dubbo/common/serialize/fastjson/FastJsonObjectInput.java
+++ b/dubbo-serialization/dubbo-serialization-fastjson/src/main/java/org/apache/dubbo/common/serialize/fastjson/FastJsonObjectInput.java
@@ -17,7 +17,6 @@
 package org.apache.dubbo.common.serialize.fastjson;
 
 import org.apache.dubbo.common.serialize.ObjectInput;
-import org.apache.dubbo.common.utils.PojoUtils;
 
 import com.alibaba.fastjson.JSON;
 

--- a/dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/fastjson/FastJsonObjectInputTest.java
+++ b/dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/fastjson/FastJsonObjectInputTest.java
@@ -18,6 +18,10 @@ package org.apache.dubbo.common.serialize.fastjson;
 
 import com.alibaba.fastjson.JSONObject;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.List;
+import org.apache.dubbo.common.serialize.model.Organization;
 import org.apache.dubbo.common.serialize.model.Person;
 
 import org.junit.jupiter.api.Assertions;
@@ -32,6 +36,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FastJsonObjectInputTest {
     private FastJsonObjectInput fastJsonObjectInput;
@@ -150,5 +155,45 @@ public class FastJsonObjectInputTest {
         assertThat(readObject, not(nullValue()));
         assertThat(readObject.getString("name"), is("John"));
         assertThat(readObject.getInteger("age"), is(30));
+    }
+
+
+    @Test
+    public void testReadObjectWithTowType() throws Exception {
+        fastJsonObjectInput = new FastJsonObjectInput(new StringReader("[{\"name\":\"John\",\"age\":30},{\"name\":\"Born\",\"age\":24}]"));
+
+        Method methodReturnType = getClass().getMethod("towLayer");
+        Type type = methodReturnType.getGenericReturnType();
+        List<Person> o = fastJsonObjectInput.readObject(List.class, type);
+
+        assertTrue(o instanceof List);
+        assertTrue(o.get(0) instanceof Person);
+
+        assertThat(o.size(), is(2));
+        assertThat(o.get(1).getName(), is("Born"));
+    }
+
+    @Test
+    public void testReadObjectWithThreeType() throws Exception {
+        fastJsonObjectInput = new FastJsonObjectInput(new StringReader("{\"data\":[{\"name\":\"John\",\"age\":30},{\"name\":\"Born\",\"age\":24}]}"));
+
+        Method methodReturnType = getClass().getMethod("threeLayer");
+        Type type = methodReturnType.getGenericReturnType();
+        Organization<List<Person>> o = fastJsonObjectInput.readObject(Organization.class, type);
+
+        assertTrue(o instanceof Organization);
+        assertTrue(o.getData() instanceof List);
+        assertTrue(o.getData().get(0) instanceof Person);
+
+        assertThat(o.getData().size(), is(2));
+        assertThat(o.getData().get(1).getName(), is("Born"));
+    }
+
+    public List<Person> towLayer() {
+        return null;
+    }
+
+    public Organization<List<Person>> threeLayer() {
+        return null;
     }
 }

--- a/dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/model/Organization.java
+++ b/dubbo-serialization/dubbo-serialization-test/src/test/java/org/apache/dubbo/common/serialize/model/Organization.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.serialize.model;
+
+public class Organization<T> {
+
+    private T data;
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

修复fastjson序列的问题，有三层泛型以上时序列化报错 如：A<B<C>>

## Brief changelog

修复fastjson序列的问题，有三层泛型以上时序列化报错 如：A<B<C>>

## Verifying this change

三层泛型以上 会序列化成JSONArray 或者 JSONObject导致获取对象时发生强转异常
： Class1 cannot be cast to Class2

some issues https://github.com/apache/incubator-dubbo/pull/3767

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
