### PR TITLE
[Dubbo-3787] Enable reactive programming api

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
@@ -862,5 +862,7 @@ public class Constants {
     public static final String DUBBO_GROUP = "dubbo";
     public static final String METRICS_KEY = "metrics";
 
-
+    public static final String KEY_PUBLISHER_TYPE = "Publisher";
+    public static final String VALUE_PUBLISHER_MONO = "mono";
+    public static final String VALUE_PUBLISHER_FLUX = "flux";
 }

--- a/dubbo-demo/dubbo-demo-interface/pom.xml
+++ b/dubbo-demo/dubbo-demo-interface/pom.xml
@@ -28,4 +28,12 @@
     <properties>
         <skip_maven_deploy>true</skip_maven_deploy>
     </properties>
+    <dependencies>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.2.8.RELEASE</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/dubbo-demo/dubbo-demo-interface/src/main/java/org/apache/dubbo/demo/ReactiveDemoService.java
+++ b/dubbo-demo/dubbo-demo-interface/src/main/java/org/apache/dubbo/demo/ReactiveDemoService.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.demo;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+public interface ReactiveDemoService {
+    //test single element
+    Mono<String> sayHello(String name);
+    //test single element with parameterized type
+    Mono<List<String>> sayHellos(String name);
+    //test several elements
+    Flux<String> namesList();
+    //test several elements with parameterized type
+    Flux<List<String>> namesMatrix();
+
+}

--- a/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-consumer/pom.xml
+++ b/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-consumer/pom.xml
@@ -1,4 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-consumer/pom.xml
+++ b/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-consumer/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-demo-reactive</artifactId>
+        <groupId>org.apache.dubbo</groupId>
+        <version>2.7.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dubbo-demo-reactive-consumer</artifactId>
+
+
+    <properties>
+        <skip_maven_deploy>true</skip_maven_deploy>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-demo-interface</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-config-spring</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-registry-zookeeper</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-registry-multicast</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-rpc-dubbo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-remoting-netty4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-serialization-hessian2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-configcenter-zookeeper</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-metadata-report-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-metadata-report-zookeeper</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.2.8.RELEASE</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-consumer/src/main/java/org/apache/dubbo/demo/consumer/Application.java
+++ b/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-consumer/src/main/java/org/apache/dubbo/demo/consumer/Application.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.dubbo.demo.consumer;
+
+import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
+import org.apache.dubbo.demo.ReactiveDemoService;
+import org.apache.dubbo.demo.consumer.comp.ReactiveDemoServiceComponent;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import reactor.core.publisher.Flux;
+
+public class Application {
+    /**
+     * In order to make sure multicast registry works, need to specify '-Djava.net.preferIPv4Stack=true' before
+     * launch the application
+     */
+    public static void main(String[] args) {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ConsumerConfiguration.class);
+        context.start();
+        ReactiveDemoService reactiveService = context.getBean("reactiveDemoServiceComponent", ReactiveDemoServiceComponent.class);
+        reactiveService.sayHello("world")
+            .subscribe(s -> System.out.println("result :" + s));
+        reactiveService.sayHellos("world")
+            .subscribe(list -> {
+                list.forEach(System.out::println);
+            });
+        Flux<String> nameFlux = reactiveService.namesList();
+        nameFlux.subscribe(System.out::println);
+        reactiveService
+            .namesMatrix()
+            .doOnNext(list -> {
+                list.forEach(System.out::print);
+                System.out.println();
+            }).subscribe();
+    }
+
+    @Configuration
+    @EnableDubbo(scanBasePackages = "org.apache.dubbo.demo.consumer.comp")
+    @PropertySource("classpath:/spring/dubbo-consumer.properties")
+    @ComponentScan(value = {"org.apache.dubbo.demo.consumer.comp"})
+    static class ConsumerConfiguration {
+
+    }
+}

--- a/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-consumer/src/main/java/org/apache/dubbo/demo/consumer/comp/ReactiveDemoServiceComponent.java
+++ b/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-consumer/src/main/java/org/apache/dubbo/demo/consumer/comp/ReactiveDemoServiceComponent.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.dubbo.demo.consumer.comp;
+
+import org.apache.dubbo.config.annotation.Reference;
+import org.apache.dubbo.demo.ReactiveDemoService;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component("reactiveDemoServiceComponent")
+public class ReactiveDemoServiceComponent implements ReactiveDemoService {
+    @Reference
+    private ReactiveDemoService reactiveDemoService;
+
+    @Override
+    public Mono<String> sayHello(String name) {
+        return reactiveDemoService.sayHello(name);
+    }
+
+    @Override
+    public Mono<List<String>> sayHellos(String name) {
+        return reactiveDemoService.sayHellos(name);
+    }
+
+    @Override
+    public Flux<String> namesList() {
+        return reactiveDemoService.namesList();
+    }
+
+    @Override
+    public Flux<List<String>> namesMatrix() {
+        return reactiveDemoService.namesMatrix();
+    }
+}

--- a/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-consumer/src/main/resources/log4j.properties
+++ b/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-consumer/src/main/resources/log4j.properties
@@ -1,0 +1,7 @@
+###set log levels###
+log4j.rootLogger=info, stdout
+###output to the console###
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d{dd/MM/yy HH:mm:ss:SSS z}] %t %5p %c{2}: %m%n

--- a/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-consumer/src/main/resources/spring/dubbo-consumer.properties
+++ b/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-consumer/src/main/resources/spring/dubbo-consumer.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+dubbo.application.name=dubbo-demo-reactive-consumer
+dubbo.registry.address=multicast://224.5.6.7:1234

--- a/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-provider/pom.xml
+++ b/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-provider/pom.xml
@@ -1,4 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-provider/pom.xml
+++ b/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-provider/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-demo-reactive</artifactId>
+        <groupId>org.apache.dubbo</groupId>
+        <version>2.7.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dubbo-demo-reactive-provider</artifactId>
+
+    <properties>
+        <skip_maven_deploy>true</skip_maven_deploy>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-demo-interface</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-config-spring</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-registry-zookeeper</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-registry-multicast</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-rpc-dubbo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-remoting-netty4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-serialization-hessian2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-configcenter-zookeeper</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-metadata-report-zookeeper</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-metadata-report-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-qos</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.2.8.RELEASE</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-provider/src/main/java/org/apache/dubbo/demo/provider/Application.java
+++ b/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-provider/src/main/java/org/apache/dubbo/demo/provider/Application.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.dubbo.demo.provider;
+
+import org.apache.dubbo.config.RegistryConfig;
+import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+public class Application {
+    /**
+     * In order to make sure multicast registry works, need to specify '-Djava.net.preferIPv4Stack=true' before
+     * launch the application
+     */
+    public static void main(String[] args) throws Exception {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ProviderConfiguration.class);
+        context.start();
+        System.in.read();
+    }
+
+    @Configuration
+    @EnableDubbo(scanBasePackages = "org.apache.dubbo.demo.provider")
+    @PropertySource("classpath:/spring/dubbo-provider.properties")
+    static class ProviderConfiguration {
+        @Bean
+        public RegistryConfig registryConfig() {
+            RegistryConfig registryConfig = new RegistryConfig();
+            registryConfig.setAddress("multicast://224.5.6.7:1234");
+            return registryConfig;
+        }
+    }
+}

--- a/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-provider/src/main/java/org/apache/dubbo/demo/provider/ReactiveDemoServiceImpl.java
+++ b/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-provider/src/main/java/org/apache/dubbo/demo/provider/ReactiveDemoServiceImpl.java
@@ -21,6 +21,7 @@ package org.apache.dubbo.demo.provider;
 import org.apache.dubbo.config.annotation.Service;
 import org.apache.dubbo.demo.ReactiveDemoService;
 import org.apache.dubbo.rpc.RpcContext;
+import org.apache.dubbo.rpc.proxy.javassist.ReactiveJavassistProxyFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -30,7 +31,7 @@ import java.util.Arrays;
 import java.util.List;
 
 //specify a reactive proxy factory
-@Service(proxy = "reactivejavassist")
+@Service(proxy = ReactiveJavassistProxyFactory.NAME)
 public class ReactiveDemoServiceImpl implements ReactiveDemoService {
     private static final Logger logger = LoggerFactory.getLogger(ReactiveDemoServiceImpl.class);
 

--- a/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-provider/src/main/java/org/apache/dubbo/demo/provider/ReactiveDemoServiceImpl.java
+++ b/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-provider/src/main/java/org/apache/dubbo/demo/provider/ReactiveDemoServiceImpl.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.dubbo.demo.provider;
+
+import org.apache.dubbo.config.annotation.Service;
+import org.apache.dubbo.demo.ReactiveDemoService;
+import org.apache.dubbo.rpc.RpcContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+import java.util.List;
+
+//specify a reactive proxy factory
+@Service(proxy = "reactivejavassist")
+public class ReactiveDemoServiceImpl implements ReactiveDemoService {
+    private static final Logger logger = LoggerFactory.getLogger(ReactiveDemoServiceImpl.class);
+
+    @Override
+    public Mono<String> sayHello(String name) {
+        return Mono.create(sink -> {
+            logger.info("Hello " + name + ", request from consumer: " + RpcContext.getContext().getRemoteAddress());
+            sink.success("Hello " + name + ", response from provider: " + RpcContext.getContext().getLocalAddress());
+        });
+    }
+
+    @Override
+    public Mono<List<String>> sayHellos(String name) {
+        return Mono.create(sink -> {
+            logger.info("Hello " + name + ", request from consumer: " + RpcContext.getContext().getRemoteAddress());
+            sink.success(Arrays
+                    .asList("Hello " + name + ", response from provider: " + RpcContext.getContext().getLocalAddress(),
+                            "Aloha " + name + ", response from provider: " + RpcContext.getContext().getLocalAddress()));
+        });
+    }
+
+    @Override
+    public Flux<String> namesList() {
+        return Flux.create(sink -> {
+            logger.info("request from consumer: " + RpcContext.getContext().getRemoteAddress());
+            sink.next("name1");
+            sink.next("name2");
+            sink.next("name3");
+            sink.complete();
+        });
+    }
+
+    @Override
+    public Flux<List<String>> namesMatrix() {
+        return Flux.create(sink -> {
+            logger.info("request from consumer: " + RpcContext.getContext().getRemoteAddress());
+            sink.next(Arrays.asList("name1","name2","name3"));
+            sink.next(Arrays.asList("name4","name5"));
+            sink.complete();
+        });
+    }
+
+}

--- a/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-provider/src/main/resources/log4j.properties
+++ b/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-provider/src/main/resources/log4j.properties
@@ -1,0 +1,7 @@
+###set log levels###
+log4j.rootLogger=info, stdout
+###output to the console###
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d{dd/MM/yy HH:mm:ss:SSS z}] %t %5p %c{2}: %m%n

--- a/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-provider/src/main/resources/spring/dubbo-provider.properties
+++ b/dubbo-demo/dubbo-demo-reactive/dubbo-demo-reactive-provider/src/main/resources/spring/dubbo-provider.properties
@@ -1,0 +1,22 @@
+#
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#
+
+dubbo.application.name=dubbo-demo-reactive-provider
+dubbo.protocol.name=dubbo
+dubbo.protocol.port=20880

--- a/dubbo-demo/dubbo-demo-reactive/pom.xml
+++ b/dubbo-demo/dubbo-demo-reactive/pom.xml
@@ -1,4 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/dubbo-demo/dubbo-demo-reactive/pom.xml
+++ b/dubbo-demo/dubbo-demo-reactive/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-demo</artifactId>
+        <groupId>org.apache.dubbo</groupId>
+        <version>2.7.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+    <modules>
+        <module>dubbo-demo-reactive-provider</module>
+        <module>dubbo-demo-reactive-consumer</module>
+    </modules>
+    <artifactId>dubbo-demo-reactive</artifactId>
+
+
+</project>

--- a/dubbo-demo/pom.xml
+++ b/dubbo-demo/pom.xml
@@ -34,6 +34,7 @@
         <module>dubbo-demo-xml</module>
         <module>dubbo-demo-annotation</module>
         <module>dubbo-demo-api</module>
+        <module>dubbo-demo-reactive</module>
     </modules>
 
     <dependencyManagement>

--- a/dubbo-rpc/dubbo-rpc-api/pom.xml
+++ b/dubbo-rpc/dubbo-rpc-api/pom.xml
@@ -44,5 +44,17 @@
             <artifactId>dubbo-remoting-api</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.2.8.RELEASE</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <version>3.2.8.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/AbstractReactiveProxyFactory.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/AbstractReactiveProxyFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.rpc.proxy;
 
 import org.apache.dubbo.common.URL;

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/AbstractReactiveProxyFactory.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/AbstractReactiveProxyFactory.java
@@ -1,0 +1,25 @@
+package org.apache.dubbo.rpc.proxy;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.bytecode.Wrapper;
+import org.apache.dubbo.rpc.Invoker;
+
+/**
+ * @author cherry
+ */
+public abstract class AbstractReactiveProxyFactory extends AbstractProxyFactory {
+
+    @Override
+    public <T> Invoker<T> getInvoker(T proxy, Class<T> type, URL url) {
+        // TODO Wrapper cannot handle this scenario correctly: the classname contains '$'
+        final Wrapper wrapper = Wrapper.getWrapper(proxy.getClass().getName().indexOf('$') < 0 ? proxy.getClass() : type);
+        return new AbstractReactiveProxyInvoker<T>(proxy, type, url) {
+            @Override
+            protected Object doInvoke(T proxy, String methodName,
+                                      Class<?>[] parameterTypes,
+                                      Object[] arguments) throws Throwable {
+                return wrapper.invokeMethod(proxy, methodName, parameterTypes, arguments);
+            }
+        };
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/AbstractReactiveProxyInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/AbstractReactiveProxyInvoker.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.rpc.proxy;
 
 import org.apache.dubbo.common.URL;

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/AbstractReactiveProxyInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/AbstractReactiveProxyInvoker.java
@@ -1,0 +1,70 @@
+package org.apache.dubbo.rpc.proxy;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.utils.StringUtils;
+import org.apache.dubbo.rpc.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.dubbo.common.Constants.*;
+
+
+/**
+ * Abstraction of reactive proxy invoker which will delegate consumer in provider side.
+ * @author cherry
+ */
+public abstract class AbstractReactiveProxyInvoker<T> extends AbstractProxyInvoker<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractReactiveProxyInvoker.class);
+    protected final T proxy;
+    private final Class<T> type;
+    private final URL url;
+
+    public AbstractReactiveProxyInvoker(T proxy, Class<T> type, URL url) {
+        super(proxy, type, url);
+        this.proxy = proxy;
+        this.type = type;
+        this.url = url;
+    }
+
+    @Override
+    public Result invoke(Invocation invocation) throws RpcException {
+        String publisher = invocation.getAttachment(KEY_PUBLISHER_TYPE);
+        if(StringUtils.isBlank(publisher)) {
+            return super.invoke(invocation);
+        }
+        RpcContext rpcContext = RpcContext.getContext();
+        try {
+            Object obj = doInvoke(proxy, invocation.getMethodName(), invocation.getParameterTypes(), invocation.getArguments());
+            Mono mono = null;
+            if(publisher.equals(VALUE_PUBLISHER_MONO)) {
+                mono = (Mono) obj;
+            } else if(publisher.equals(VALUE_PUBLISHER_FLUX)) {
+                Flux<Object> flux = (Flux<Object>) obj;
+                mono = flux.collect(ArrayList::new,ArrayList::add);
+            }
+            if(mono==null) {
+                CompletableFuture future = new CompletableFuture();
+                Exception ex = new IllegalArgumentException("unexpected publisher type:"+publisher);
+                future.completeExceptionally(ex);
+                return new AsyncRpcResult(future);
+            } else {
+                return new AsyncRpcResult(mono.toFuture());
+            }
+        } catch (InvocationTargetException e) {
+            // TODO async throw exception before async thread write back, should stop asyncContext
+            if (rpcContext.isAsyncStarted() && !rpcContext.stopAsync()) {
+                LOGGER.error("Provider async started, but got an exception from the original method, cannot write the exception back to consumer because an async result may have returned the new thread.", e);
+            }
+            return new RpcResult(e.getTargetException());
+        } catch (Throwable e) {
+            throw new RpcException("Failed to invoke remote proxy method " + invocation.getMethodName() + " to " + getUrl() + ", cause: " + e.getMessage(), e);
+        }
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/AbstractReactiveProxyInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/AbstractReactiveProxyInvoker.java
@@ -12,7 +12,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 
-import static org.apache.dubbo.common.Constants.*;
+import static org.apache.dubbo.common.Constants.KEY_PUBLISHER_TYPE;
+import static org.apache.dubbo.common.Constants.VALUE_PUBLISHER_MONO;
+import static org.apache.dubbo.common.Constants.VALUE_PUBLISHER_FLUX;
 
 
 /**

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/AbstractReactiveProxyInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/AbstractReactiveProxyInvoker.java
@@ -4,7 +4,12 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.StringUtils;
-import org.apache.dubbo.rpc.*;
+import org.apache.dubbo.rpc.AsyncRpcResult;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcContext;
+import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.RpcResult;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/ReactiveInvokerInvocationHandler.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/ReactiveInvokerInvocationHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.rpc.proxy;
 
 import org.apache.dubbo.common.Constants;

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/ReactiveInvokerInvocationHandler.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/ReactiveInvokerInvocationHandler.java
@@ -1,0 +1,98 @@
+package org.apache.dubbo.rpc.proxy;
+
+import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.RpcInvocation;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.dubbo.common.Constants.*;
+
+/**
+ * Reactive implementation of InvokerInvocationHandler which actually communicate with the real providers.
+ * @author cherry
+ */
+public class ReactiveInvokerInvocationHandler extends InvokerInvocationHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReactiveInvokerInvocationHandler.class);
+    private final Invoker<?> invoker;
+    public ReactiveInvokerInvocationHandler(Invoker<?> handler) {
+        super(handler);
+        this.invoker = handler;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        //if the invocation returns a publisher,make a publisher wrapping the real invocation
+        Class returnType = method.getReturnType();
+        if (Publisher.class.isAssignableFrom(returnType)) {
+            RpcInvocation invocation = createInvocation(method, args);
+            if (Mono.class.isAssignableFrom(returnType)) {
+                invocation.setAttachment(KEY_PUBLISHER_TYPE,VALUE_PUBLISHER_MONO);
+                return Mono.create(monoSink -> {
+                    try {
+                        CompletableFuture<Object> future
+                                = (CompletableFuture<Object>) invoker.invoke(invocation).recreate();
+                        future.whenComplete((v, t) -> {
+                            if (t != null) {
+                                monoSink.error(t);
+                            } else {
+                                monoSink.success(v);
+                            }
+                        });
+                    } catch (Throwable throwable) {
+                        if(LOGGER.isErrorEnabled()) {
+                            LOGGER.error("mono invocation",throwable);
+                        }
+                        monoSink.error(throwable);
+                    }
+                });
+            } else if (Flux.class.isAssignableFrom(returnType)) {
+                invocation.setAttachment(KEY_PUBLISHER_TYPE,VALUE_PUBLISHER_FLUX);
+                return Flux.create(fluxSink -> {
+                    try {
+                        CompletableFuture<Object> future
+                                = (CompletableFuture<Object>) invoker.invoke(invocation).recreate();
+                        future.whenComplete((v, t) -> {
+                            if (t != null) {
+                                fluxSink.error(t);
+                            } else if (v instanceof List){
+                                List list = (List) v;
+                                if(list!=null) {
+                                    list.forEach(fluxSink::next);
+                                }
+                                fluxSink.complete();
+                            } else {
+                                Exception ex = new IllegalArgumentException("unexpected return type:"+v.getClass());
+                                fluxSink.error(ex);
+                            }
+                        });
+                    } catch (Throwable throwable) {
+                        if(LOGGER.isErrorEnabled()) {
+                            LOGGER.error("flux invocation",throwable);
+                        }
+                        fluxSink.error(throwable);
+                    }
+                });
+            } else {
+                //TODO other publishers support
+                throw new IllegalArgumentException(
+                        String.format("%s not supported now", method.getReturnType().getSimpleName()));
+            }
+        }
+        return super.invoke(proxy, method, args);
+    }
+
+    protected RpcInvocation createInvocation(Method method, Object[] args) {
+        RpcInvocation invocation = new RpcInvocation(method, args);
+        invocation.setAttachment(Constants.FUTURE_RETURNTYPE_KEY, "true");
+        invocation.setAttachment(Constants.ASYNC_KEY, "true");
+        return invocation;
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/ReactiveInvokerInvocationHandler.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/ReactiveInvokerInvocationHandler.java
@@ -13,7 +13,9 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static org.apache.dubbo.common.Constants.*;
+import static org.apache.dubbo.common.Constants.KEY_PUBLISHER_TYPE;
+import static org.apache.dubbo.common.Constants.VALUE_PUBLISHER_MONO;
+import static org.apache.dubbo.common.Constants.VALUE_PUBLISHER_FLUX;
 
 /**
  * Reactive implementation of InvokerInvocationHandler which actually communicate with the real providers.

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/javassist/ReactiveJavassistProxyFactory.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/javassist/ReactiveJavassistProxyFactory.java
@@ -1,0 +1,20 @@
+package org.apache.dubbo.rpc.proxy.javassist;
+
+import org.apache.dubbo.common.bytecode.Proxy;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.proxy.AbstractReactiveProxyFactory;
+import org.apache.dubbo.rpc.proxy.ReactiveInvokerInvocationHandler;
+
+/**
+ * Reactive implementation of JavassistProxyFactory
+ * @author cherry
+ */
+public class ReactiveJavassistProxyFactory extends AbstractReactiveProxyFactory {
+    public static final String NAME = "reactivejavassist";
+
+    @Override
+    public <T> T getProxy(Invoker<T> invoker, Class<?>[] interfaces) {
+        return (T) Proxy.getProxy(interfaces).newInstance(new ReactiveInvokerInvocationHandler(invoker));
+    }
+
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/javassist/ReactiveJavassistProxyFactory.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/javassist/ReactiveJavassistProxyFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.rpc.proxy.javassist;
 
 import org.apache.dubbo.common.bytecode.Proxy;

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/jdk/ReactiveJdkProxyFactory.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/jdk/ReactiveJdkProxyFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.rpc.proxy.jdk;
 
 import org.apache.dubbo.rpc.Invoker;

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/jdk/ReactiveJdkProxyFactory.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/proxy/jdk/ReactiveJdkProxyFactory.java
@@ -1,0 +1,21 @@
+package org.apache.dubbo.rpc.proxy.jdk;
+
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.proxy.AbstractReactiveProxyFactory;
+import org.apache.dubbo.rpc.proxy.ReactiveInvokerInvocationHandler;
+
+import java.lang.reflect.Proxy;
+
+/**
+ * Reactive implementation of JdkProxyFactory
+ * @author cherry
+ */
+public class ReactiveJdkProxyFactory extends AbstractReactiveProxyFactory {
+    public static final String NAME = "reactivejdk";
+
+    @Override
+    public <T> T getProxy(Invoker<T> invoker, Class<?>[] interfaces) {
+        return (T) Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),
+                interfaces, new ReactiveInvokerInvocationHandler(invoker));
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/RpcUtils.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/support/RpcUtils.java
@@ -24,8 +24,7 @@ import org.apache.dubbo.common.utils.ReflectUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.RpcInvocation;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
+
 import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl;
 
 import java.lang.reflect.Method;

--- a/dubbo-rpc/dubbo-rpc-api/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.ProxyFactory
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.ProxyFactory
@@ -1,3 +1,5 @@
 stub=org.apache.dubbo.rpc.proxy.wrapper.StubProxyFactoryWrapper
 jdk=org.apache.dubbo.rpc.proxy.jdk.JdkProxyFactory
 javassist=org.apache.dubbo.rpc.proxy.javassist.JavassistProxyFactory
+reactivejdk=org.apache.dubbo.rpc.proxy.jdk.ReactiveJdkProxyFactory
+reactivejavassist=org.apache.dubbo.rpc.proxy.javassist.ReactiveJavassistProxyFactory

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/proxy/AbstractReactiveProxyTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/proxy/AbstractReactiveProxyTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.rpc.proxy;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.ProxyFactory;
+import org.apache.dubbo.rpc.RpcInvocation;
+import org.apache.dubbo.rpc.support.ReactiveDemoService;
+import org.apache.dubbo.rpc.support.ReactiveDemoServiceImpl;
+import org.apache.dubbo.rpc.support.MyReactiveInvoker;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.dubbo.common.Constants.*;
+
+
+public abstract class AbstractReactiveProxyTest {
+
+    protected ProxyFactory factory;
+
+    @Test
+    public void testGetProxy() throws Exception {
+        URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
+
+        Invoker<ReactiveDemoService> invoker = new MyReactiveInvoker<>(url);
+
+        ReactiveDemoService proxy = factory.getProxy(invoker);
+
+        Assertions.assertNotNull(proxy);
+
+        Assertions.assertTrue(Arrays.asList(proxy.getClass().getInterfaces()).contains(ReactiveDemoService.class));
+
+        RpcInvocation invocation = new RpcInvocation("sayHello", new Class[]{String.class}, new Object[]{"aa"});
+        invocation.setAttachment(KEY_PUBLISHER_TYPE,VALUE_PUBLISHER_MONO);
+        try {
+            Object retVal = invoker.invoke(invocation).recreate();
+            Mono mono = Mono.fromFuture((CompletableFuture<?>) retVal);
+            StepVerifier
+                    .create(mono)
+                    .expectNext("Hello aa")
+                    .expectComplete();
+        } catch (Throwable throwable) {
+            throwable.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testGetInvoker() throws Exception {
+        URL url = URL.valueOf("test://test:11/test?group=dubbo&version=1.1");
+
+        ReactiveDemoService origin = new ReactiveDemoServiceImpl();
+
+        Invoker<ReactiveDemoService> invoker = factory.getInvoker(new ReactiveDemoServiceImpl(), ReactiveDemoService.class, url);
+
+        Assertions.assertEquals(invoker.getInterface(), ReactiveDemoService.class);
+
+        RpcInvocation invocation = new RpcInvocation("sayHello", new Class[]{String.class}, new Object[]{"aa"});
+        invocation.setAttachment(KEY_PUBLISHER_TYPE,VALUE_PUBLISHER_MONO);
+        StepVerifier
+                .create(origin.sayHello("aa"))
+                .expectNext("Hello aa")
+                .expectComplete();
+
+        try {
+            Mono mono = Mono.fromFuture((CompletableFuture<?>) invoker.invoke(invocation).recreate());
+
+            StepVerifier
+                    .create(mono)
+                    .expectNext("Hello aa")
+                    .expectComplete();
+        } catch (Throwable throwable) {
+            throwable.printStackTrace();
+        }
+    }
+
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/proxy/AbstractReactiveProxyTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/proxy/AbstractReactiveProxyTest.java
@@ -32,7 +32,8 @@ import reactor.test.StepVerifier;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
-import static org.apache.dubbo.common.Constants.*;
+import static org.apache.dubbo.common.Constants.KEY_PUBLISHER_TYPE;
+import static org.apache.dubbo.common.Constants.VALUE_PUBLISHER_MONO;
 
 
 public abstract class AbstractReactiveProxyTest {

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/proxy/javassist/ReactiveJavassistProxyFactoryTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/proxy/javassist/ReactiveJavassistProxyFactoryTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.proxy.javassist;
+
+import org.apache.dubbo.rpc.proxy.AbstractReactiveProxyTest;
+
+public class ReactiveJavassistProxyFactoryTest extends AbstractReactiveProxyTest {
+    public ReactiveJavassistProxyFactoryTest() {
+        factory = new ReactiveJavassistProxyFactory();
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/proxy/jdk/ReactiveJdkProxyFactoryTest.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/proxy/jdk/ReactiveJdkProxyFactoryTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.proxy.jdk;
+
+import org.apache.dubbo.rpc.proxy.AbstractReactiveProxyTest;
+
+public class ReactiveJdkProxyFactoryTest extends AbstractReactiveProxyTest {
+    public ReactiveJdkProxyFactoryTest() {
+        factory = new ReactiveJdkProxyFactory();
+    }
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/MyReactiveInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/MyReactiveInvoker.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.support;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.rpc.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.dubbo.common.Constants.*;
+
+/**
+ * MockInvoker.java
+ */
+public class MyReactiveInvoker<T> implements Invoker<T> {
+
+    URL url;
+    Class<T> type;
+    boolean hasException = false;
+    ReactiveDemoService proxy;
+
+    public MyReactiveInvoker(URL url) {
+        this(url,false);
+    }
+
+    public MyReactiveInvoker(URL url, boolean hasException) {
+        this.url = url;
+        type = (Class<T>) ReactiveDemoService.class;
+        this.hasException = hasException;
+        proxy = new ReactiveDemoServiceImpl();
+    }
+
+    @Override
+    public Class<T> getInterface() {
+        return type;
+    }
+
+    public URL getUrl() {
+        return url;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return false;
+    }
+
+    public Result invoke(Invocation invocation) throws RpcException {
+        String publisher = invocation.getAttachment(KEY_PUBLISHER_TYPE);
+        try {
+            Method method = ReactiveDemoService.class.getMethod(invocation.getMethodName(),invocation.getParameterTypes());
+            Object obj = method.invoke(proxy,invocation.getArguments());
+
+            Mono mono = null;
+            if(publisher.equals(VALUE_PUBLISHER_MONO)) {
+                mono = (Mono) obj;
+            } else if(publisher.equals(VALUE_PUBLISHER_FLUX)) {
+                Flux<Object> flux = (Flux<Object>) obj;
+                mono = flux.collect(ArrayList::new,ArrayList::add);
+            }
+            if(mono==null) {
+                CompletableFuture future = new CompletableFuture();
+                Exception ex = new IllegalArgumentException("unexpected publisher type:"+publisher);
+                future.completeExceptionally(ex);
+                return new AsyncRpcResult(future);
+            } else {
+                return new AsyncRpcResult(mono.toFuture());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new RpcResult(e);
+        }
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public String toString() {
+        return "MyInvoker.toString()";
+    }
+
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/MyReactiveInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/MyReactiveInvoker.java
@@ -17,7 +17,12 @@
 package org.apache.dubbo.rpc.support;
 
 import org.apache.dubbo.common.URL;
-import org.apache.dubbo.rpc.*;
+import org.apache.dubbo.rpc.AsyncRpcResult;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.RpcResult;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/MyReactiveInvoker.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/MyReactiveInvoker.java
@@ -25,7 +25,9 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 
-import static org.apache.dubbo.common.Constants.*;
+import static org.apache.dubbo.common.Constants.KEY_PUBLISHER_TYPE;
+import static org.apache.dubbo.common.Constants.VALUE_PUBLISHER_MONO;
+import static org.apache.dubbo.common.Constants.VALUE_PUBLISHER_FLUX;
 
 /**
  * MockInvoker.java

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/ReactiveDemoService.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/ReactiveDemoService.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.support;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+public interface ReactiveDemoService {
+    //test single element
+    Mono<String> sayHello(String name);
+    //test single element with parameterized type
+    Mono<List<String>> sayHellos(String name);
+    //test several elements
+    Flux<String> namesList();
+    //test several elements with parameterized type
+    Flux<List<String>> namesMatrix();
+}

--- a/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/ReactiveDemoServiceImpl.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/test/java/org/apache/dubbo/rpc/support/ReactiveDemoServiceImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.rpc.support;
+
+import org.apache.dubbo.rpc.RpcContext;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * ReactiveDemoServiceImpl
+ */
+
+public class ReactiveDemoServiceImpl implements ReactiveDemoService {
+
+    @Override
+    public Mono<String> sayHello(String name) {
+        return Mono.create(sink -> {
+            sink.success("Hello " + name + ", response from provider: " + RpcContext.getContext().getLocalAddress());
+        });
+    }
+
+    @Override
+    public Mono<List<String>> sayHellos(String name) {
+        return Mono.create(sink -> {
+            sink.success(Arrays
+                    .asList("Hello " + name + ", response from provider: " + RpcContext.getContext().getLocalAddress(),
+                            "Aloha " + name + ", response from provider: " + RpcContext.getContext().getLocalAddress()));
+        });
+    }
+
+    @Override
+    public Flux<String> namesList() {
+        return Flux.create(sink -> {
+            sink.next("name1");
+            sink.next("name2");
+            sink.next("name3");
+            sink.complete();
+        });
+    }
+
+    @Override
+    public Flux<List<String>> namesMatrix() {
+        return Flux.create(sink -> {
+            sink.next(Arrays.asList("name1","name2","name3"));
+            sink.next(Arrays.asList("name4","name5"));
+            sink.complete();
+        });
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

To enable dubbo to supply Reactive Programming api(Mono/Flux)

## Brief changelog

Add AbstractReactiveProxyFactory combined with AbstractReactiveProxyInvoker and ReactiveInvokerInvocationHandler to supply reactive programming ability for provider and consumer side.

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
