### PR TITLE
RpcContext新增remoteApplicationName字段

### DIFF
--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java
@@ -85,6 +85,9 @@ public class RpcContext {
     private InetSocketAddress localAddress;
 
     private InetSocketAddress remoteAddress;
+
+    private String remoteApplicationName;
+
     @Deprecated
     private List<Invoker<?>> invokers;
     @Deprecated
@@ -149,6 +152,7 @@ public class RpcContext {
         copy.arguments = this.arguments;
         copy.localAddress = this.localAddress;
         copy.remoteAddress = this.remoteAddress;
+        copy.remoteApplicationName = this.remoteApplicationName;
         copy.invokers = this.invokers;
         copy.invoker = this.invoker;
         copy.invocation = this.invocation;
@@ -404,6 +408,15 @@ public class RpcContext {
      */
     public RpcContext setRemoteAddress(InetSocketAddress address) {
         this.remoteAddress = address;
+        return this;
+    }
+
+    public String getRemoteApplicationName() {
+        return remoteApplicationName;
+    }
+
+    public RpcContext setRemoteApplicationName(String remoteApplicationName) {
+        this.remoteApplicationName = remoteApplicationName;
         return this;
     }
 

--- a/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ContextFilter.java
+++ b/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ContextFilter.java
@@ -29,6 +29,8 @@ import org.apache.dubbo.rpc.RpcInvocation;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.dubbo.common.Constants.REMOTE_APPLICATION_KEY;
+
 /**
  * ContextFilter set the provider RpcContext with invoker, invocation, local port it is using and host for
  * current execution thread.
@@ -59,8 +61,8 @@ public class ContextFilter implements Filter {
                 .setInvoker(invoker)
                 .setInvocation(invocation)
 //                .setAttachments(attachments)  // merged from dubbox
-                .setLocalAddress(invoker.getUrl().getHost(),
-                        invoker.getUrl().getPort());
+                .setLocalAddress(invoker.getUrl().getHost(), invoker.getUrl().getPort())
+                .setRemoteApplicationName(invoker.getUrl().getParameter(REMOTE_APPLICATION_KEY));
 
         // merged from dubbox
         // we may already added some attachments into RpcContext before this filter (e.g. in rest protocol)


### PR DESCRIPTION
## What is the purpose of the change

In the process of using Dubbo, there are many scenarios where the Provider needs to know the applicationName of the Consumer (not just the Consumer IP). For example, I want to output the upstream caller to the log file and want to limit the flow according to the upstream application. Or downgrade, want to use the upstream application for arson drills, etc., so we usually add Filter to achieve (for example, DubboAppContextFilter in Sentinel, which is specifically done on the Consumer side: https://github.com/alibaba/Sentinel/ Blob/6bb4ff21dadde00c9453a5f57d030d55f87b71a8/sentinel-adapter/sentinel-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/DubboAppContextFilter.java), so I also hope that Dubbo can put this inside Simple things have been done

在我们使用Dubbo的过程中，有很多场景Provider端需要知道Consumer端的applicationName（而不仅仅只需要知道Consumer的IP），比如我想将上游调用方输出到出入口日志中、想根据上游应用来限流或降级、想根据上游应用来进行放火演练等，所以我们通常会自己加Filter来实现（例如Sentinel中的DubboAppContextFilter，就是专门在Consumer端做这个事情：https://github.com/alibaba/Sentinel/blob/6bb4ff21dadde00c9453a5f57d030d55f87b71a8/sentinel-adapter/sentinel-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/dubbo/DubboAppContextFilter.java），

所以，我也特别希望Dubbo内部能把这块简单的事情给做了
