### PR TITLE
Fix issue 3785

### DIFF
--- a/dubbo-compatible/src/main/java/com/alibaba/dubbo/config/annotation/Service.java
+++ b/dubbo-compatible/src/main/java/com/alibaba/dubbo/config/annotation/Service.java
@@ -47,7 +47,7 @@ public @interface Service {
 
     boolean deprecated() default false;
 
-    boolean dynamic() default false;
+    boolean dynamic() default true;
 
     String accesslog() default "";
 

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractServiceConfig.java
@@ -74,7 +74,7 @@ public abstract class AbstractServiceConfig extends AbstractInterfaceConfig {
      * after the service registered,and it needs to be enabled manually; if you want to disable the service, you also need
      * manual processing
      */
-    protected Boolean dynamic = false;
+    protected Boolean dynamic = true;
 
     /**
      * Whether to use token

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/annotation/Service.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/annotation/Service.java
@@ -79,9 +79,9 @@ public @interface Service {
     boolean deprecated() default false;
 
     /**
-     * Whether the service is dynamic, default value is false
+     * Whether the service is dynamic, default value is true
      */
-    boolean dynamic() default false;
+    boolean dynamic() default true;
 
     /**
      * Access log for the service, default value is ""


### PR DESCRIPTION
Make `dynamic` default true to promise that the url will delete from zk whenever provider shutdown.

Fix issue:
https://github.com/apache/incubator-dubbo/issues/3785
