### PR TITLE
add a switch to control whether to prefer to register public address or site local address

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/Constants.java
@@ -860,6 +860,8 @@ public class Constants {
 
     public static final int DEFAULT_GRPC_QUEUES = 300_0000;
 
+    public static final String PREFER_PUBLIC_ADDRESS = "dubbo.prefer.public.address";
+
     /**
      * metrics
      */

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
@@ -123,9 +123,10 @@ public class ApplicationConfig extends AbstractConfig {
      */
     private String shutwait;
 
-
-    private Boolean preferPublicIp;
-
+    /**
+     * Config the dubbo.prefer.public.address
+     */
+    private Boolean preferPublicAddress;
 
     public ApplicationConfig() {
     }
@@ -331,11 +332,14 @@ public class ApplicationConfig extends AbstractConfig {
         return !StringUtils.isEmpty(name);
     }
 
-    public Boolean getPreferPublicIp() {
-        return preferPublicIp;
+    @Parameter(key = Constants.PREFER_PUBLIC_ADDRESS)
+    public Boolean getPreferPublicAddress() {
+        return preferPublicAddress;
     }
 
-    public void setPreferPublicIp(Boolean preferPublicIp) {
-        this.preferPublicIp = preferPublicIp;
+    public void setPreferPublicAddress(Boolean preferPublicAddress) {
+        System.setProperty(Constants.PREFER_PUBLIC_ADDRESS, Boolean.toString(preferPublicAddress));
+        this.preferPublicAddress = preferPublicAddress;
     }
+
 }

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/compat/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/compat/dubbo.xsd
@@ -392,6 +392,11 @@
                 <xsd:documentation><![CDATA[ The application shutDown-wait time. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
+        <xsd:attribute name="prefer-public-address" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[ prefer public address. ]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
         <xsd:attribute name="default" type="xsd:string">
             <xsd:annotation>
                 <xsd:documentation><![CDATA[ Is default. ]]></xsd:documentation>

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
@@ -387,6 +387,11 @@
                 <xsd:documentation><![CDATA[ The application monitor. ]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
+        <xsd:attribute name="prefer-public-address" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[ prefer public address. ]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
         <xsd:attribute name="default" type="xsd:string">
             <xsd:annotation>
                 <xsd:documentation><![CDATA[ Is default. ]]></xsd:documentation>


### PR DESCRIPTION
## What is the purpose of the change

fix the issue: https://github.com/apache/incubator-dubbo/issues/3802
improve the existing changes: https://github.com/apache/incubator-dubbo/pull/3520

## Brief changelog

- add a switch `dubbo.prefer.public.address`.
- change the strategy to achieve IP address.

steps to achieve IP:

1. judge the switch `dubbo.prefer.public.address`
2. search from hosts mapping using `InetAddress.getLocalHost()`
3. search from the network cards using `NetworkInterface.getNetworkInterfaces()`
4. if the address achieved in 2 & 3 not match the `dubbo.prefer.public.address`, downgrade to the reverse property of `dubbo.prefer.public.address`. In words, if no public address found, downgrade to site-local address; if no site-local address found, downgrade to public address;
5. if no address found, using loopback address 127.0.0.1. 
