### PR TITLE
Use singleton RegistryProtocol in tests

### DIFF
--- a/dubbo-registry/dubbo-registry-default/src/test/java/org/apache/dubbo/registry/dubbo/RegistryProtocolTest.java
+++ b/dubbo-registry/dubbo-registry-default/src/test/java/org/apache/dubbo/registry/dubbo/RegistryProtocolTest.java
@@ -61,14 +61,14 @@ public class RegistryProtocolTest {
 
     @Test
     public void testDefaultPort() {
-        RegistryProtocol registryProtocol = new RegistryProtocol();
+        RegistryProtocol registryProtocol = RegistryProtocol.getRegistryProtocol();
         assertEquals(9090, registryProtocol.getDefaultPort());
     }
 
     @Test
     public void testExportUrlNull() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            RegistryProtocol registryProtocol = new RegistryProtocol();
+            RegistryProtocol registryProtocol = RegistryProtocol.getRegistryProtocol();
             registryProtocol.setCluster(new FailfastCluster());
 
             Protocol dubboProtocol = DubboProtocol.getDubboProtocol();
@@ -81,7 +81,7 @@ public class RegistryProtocolTest {
 
     @Test
     public void testExport() {
-        RegistryProtocol registryProtocol = new RegistryProtocol();
+        RegistryProtocol registryProtocol = RegistryProtocol.getRegistryProtocol();
         registryProtocol.setCluster(new FailfastCluster());
         registryProtocol.setRegistryFactory(ExtensionLoader.getExtensionLoader(RegistryFactory.class).getAdaptiveExtension());
 
@@ -165,7 +165,7 @@ public class RegistryProtocolTest {
 
     @Test
     public void testGetParamsToRegistry() {
-        RegistryProtocol registryProtocol = new RegistryProtocol();
+        RegistryProtocol registryProtocol = RegistryProtocol.getRegistryProtocol();
         String[] additionalParams = new String[]{"key1", "key2"};
         String[] registryParams = registryProtocol.getParamsToRegistry(DEFAULT_REGISTER_PROVIDER_KEYS, additionalParams);
         String[] expectParams = ArrayUtils.addAll(DEFAULT_REGISTER_PROVIDER_KEYS, additionalParams);


### PR DESCRIPTION
## What is the purpose of the change

Currently some tests in RegistryProtocolTest do not use the RegistryProtocol.getRegistryProtocol() method to get the singleton RegistryProtocol instance. These tests directly create new instances of RegistryProtocol, which changes the singleton to point to the newly created instance. Doing so leads to tests in test class to fail when run in certain orders. For example, running the tests [testNotifyOverride_notmatch, testExportUrlNull, testNotifyOverride] in that exact order leads to testNotifyOverride to fail.

The proposed change is to have every test use the RegistryProtocol.getRegistryProtocol() method to get the same instance of RegistryProtocol.

## Brief changelog

dubbo-registry/dubbo-registry-default/src/test/java/org/apache/dubbo/registry/dubbo/RegistryProtocolTest.java
