### PR TITLE
[Dubbo-3875] dubbo TagRouter does not work with dubbo:parameter.

### DIFF
--- a/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/ClusterUtils.java
+++ b/dubbo-cluster/src/main/java/org/apache/dubbo/rpc/cluster/support/ClusterUtils.java
@@ -95,24 +95,11 @@ public class ClusterUtils {
         }
         if (remoteMap != null && remoteMap.size() > 0) {
             // Use version passed from provider side
-            String dubbo = remoteMap.get(Constants.DUBBO_VERSION_KEY);
-            if (dubbo != null && dubbo.length() > 0) {
-                map.put(Constants.DUBBO_VERSION_KEY, dubbo);
-            }
-            String version = remoteMap.get(Constants.VERSION_KEY);
-            if (version != null && version.length() > 0) {
-                map.put(Constants.VERSION_KEY, version);
-            }
-            String methods = remoteMap.get(Constants.METHODS_KEY);
-            if (methods != null && methods.length() > 0) {
-                map.put(Constants.METHODS_KEY, methods);
-            }
-            // Reserve timestamp of provider url.
-            String remoteTimestamp = remoteMap.get(Constants.TIMESTAMP_KEY);
-            if (remoteTimestamp != null && remoteTimestamp.length() > 0) {
-                map.put(Constants.REMOTE_TIMESTAMP_KEY, remoteMap.get(Constants.TIMESTAMP_KEY));
-            }
-
+            reserveRemoteValue(Constants.DUBBO_VERSION_KEY, map, remoteMap);
+            reserveRemoteValue(Constants.VERSION_KEY, map, remoteMap);
+            reserveRemoteValue(Constants.METHODS_KEY, map, remoteMap);
+            reserveRemoteValue(Constants.TIMESTAMP_KEY, map, remoteMap);
+            reserveRemoteValue(Constants.TAG_KEY, map, remoteMap);
             // TODO, for compatibility consideration, we cannot simply change the value behind APPLICATION_KEY from Consumer to Provider. So just add an extra key here.
             // Reserve application name from provider.
             map.put(Constants.REMOTE_APPLICATION_KEY, remoteMap.get(Constants.APPLICATION_KEY));
@@ -133,6 +120,13 @@ public class ClusterUtils {
         }
 
         return remoteUrl.clearParameters().addParameters(map);
+    }
+
+    private static void reserveRemoteValue(String key, Map<String, String> map, Map<String, String> remoteMap) {
+        String remoteValue = remoteMap.get(key);
+        if (StringUtils.isNotEmpty(remoteValue)) {
+            map.put(key, remoteValue);
+        }
     }
 
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractInterfaceConfig.java
@@ -155,6 +155,8 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
     // the scope for referring/exporting a service, if it's local, it means searching in current JVM only.
     private String scope;
 
+    protected String tag;
+
     /**
      * Check whether the registry config is exists, and then conversion it to {@link RegistryConfig}
      */
@@ -836,5 +838,14 @@ public abstract class AbstractInterfaceConfig extends AbstractMethodConfig {
 
     public void setMetrics(MetricsConfig metrics) {
         this.metrics = metrics;
+    }
+
+    @Parameter(key = Constants.TAG_KEY, useKeyAsProperty = false)
+    public String getTag() {
+        return tag;
+    }
+
+    public void setTag(String tag) {
+        this.tag = tag;
     }
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/AbstractServiceConfig.java
@@ -17,8 +17,8 @@
 package org.apache.dubbo.config;
 
 import org.apache.dubbo.common.Constants;
-import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.common.utils.CollectionUtils;
+import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.config.support.Parameter;
 import org.apache.dubbo.rpc.ExporterListener;
 
@@ -91,8 +91,7 @@ public abstract class AbstractServiceConfig extends AbstractInterfaceConfig {
      */
     protected List<ProtocolConfig> protocols;
     protected String protocolIds;
-    // provider tag
-    protected String tag;
+
     // max allowed execute times
     private Integer executes;
 
@@ -286,14 +285,5 @@ public abstract class AbstractServiceConfig extends AbstractInterfaceConfig {
 
     public void setSerialization(String serialization) {
         this.serialization = serialization;
-    }
-
-    @Parameter(key = Constants.TAG_KEY, useKeyAsProperty = false)
-    public String getTag() {
-        return tag;
-    }
-
-    public void setTag(String tag) {
-        this.tag = tag;
     }
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ReferenceConfig.java
@@ -280,7 +280,9 @@ public class ReferenceConfig<T> extends AbstractReferenceConfig {
         appendParameters(map, metrics);
         appendParameters(map, application);
         appendParameters(map, module);
-        appendParameters(map, consumer, Constants.DEFAULT_KEY);
+        // remove 'default.' prefix for configs from ConsumerConfig
+        // appendParameters(map, consumer, Constants.DEFAULT_KEY);
+        appendParameters(map, consumer);
         appendParameters(map, this);
         Map<String, Object> attributes = null;
         if (CollectionUtils.isNotEmpty(methods)) {
@@ -457,22 +459,14 @@ public class ReferenceConfig<T> extends AbstractReferenceConfig {
     }
 
     private void checkDefault() {
-        createConsumerIfAbsent();
-    }
-
-    private void createConsumerIfAbsent() {
         if (consumer != null) {
             return;
         }
-        setConsumer(
-                        ConfigManager.getInstance()
-                            .getDefaultConsumer()
-                            .orElseGet(() -> {
-                                ConsumerConfig consumerConfig = new ConsumerConfig();
-                                consumerConfig.refresh();
-                                return consumerConfig;
-                            })
-                );
+        setConsumer(ConfigManager.getInstance().getDefaultConsumer().orElseGet(() -> {
+            ConsumerConfig consumerConfig = new ConsumerConfig();
+            consumerConfig.refresh();
+            return consumerConfig;
+        }));
     }
 
     private void completeCompoundConfigs() {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/ServiceConfig.java
@@ -431,7 +431,9 @@ public class ServiceConfig<T> extends AbstractServiceConfig {
         appendParameters(map, metrics);
         appendParameters(map, application);
         appendParameters(map, module);
-        appendParameters(map, provider, Constants.DEFAULT_KEY);
+        // remove 'default.' prefix for configs from ProviderConfig
+        // appendParameters(map, provider, Constants.DEFAULT_KEY);
+        appendParameters(map, provider);
         appendParameters(map, protocolConfig);
         appendParameters(map, this);
         if (CollectionUtils.isNotEmpty(methods)) {

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/annotation/Reference.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/annotation/Reference.java
@@ -258,6 +258,11 @@ public @interface Reference {
     String protocol() default "";
 
     /**
+     * Service tag name
+     */
+    String tag() default "";
+
+    /**
      * methods support
      * @return
      */

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/builders/AbstractInterfaceBuilder.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/builders/AbstractInterfaceBuilder.java
@@ -121,6 +121,8 @@ public abstract class AbstractInterfaceBuilder<T extends AbstractInterfaceConfig
     // the scope for referring/exporting a service, if it's local, it means searching in current JVM only.
     private String scope;
 
+    private String tag;
+
     /**
      * @param local
      * @see org.apache.dubbo.config.builders.AbstractInterfaceBuilder#stub(String)
@@ -267,6 +269,11 @@ public abstract class AbstractInterfaceBuilder<T extends AbstractInterfaceConfig
         return getThis();
     }
 
+    public B tag(String tag) {
+        this.tag = tag;
+        return getThis();
+    }
+
     @Override
     public void build(T instance) {
         super.build(instance);
@@ -330,6 +337,9 @@ public abstract class AbstractInterfaceBuilder<T extends AbstractInterfaceConfig
         }
         if (!StringUtils.isEmpty(scope)) {
             instance.setScope(scope);
+        }
+        if (StringUtils.isNotEmpty(tag)) {
+            instance.setTag(tag);
         }
     }
 }

--- a/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/builders/AbstractServiceBuilder.java
+++ b/dubbo-config/dubbo-config-api/src/main/java/org/apache/dubbo/config/builders/AbstractServiceBuilder.java
@@ -88,8 +88,7 @@ public abstract class AbstractServiceBuilder<T extends AbstractServiceConfig, B 
      */
     protected List<ProtocolConfig> protocols;
     protected String protocolIds;
-    // provider tag
-    protected String tag;
+
     // max allowed execute times
     private Integer executes;
 
@@ -197,11 +196,6 @@ public abstract class AbstractServiceBuilder<T extends AbstractServiceConfig, B 
         return getThis();
     }
 
-    public B tag(String tag) {
-        this.tag = tag;
-        return getThis();
-    }
-
     public B executes(Integer executes) {
         this.executes = executes;
         return getThis();
@@ -261,9 +255,6 @@ public abstract class AbstractServiceBuilder<T extends AbstractServiceConfig, B 
         }
         if (!StringUtils.isEmpty(protocolIds)) {
             instance.setProtocolIds(protocolIds);
-        }
-        if (tag != null) {
-            instance.setTag(tag);
         }
         if (executes != null) {
             instance.setExecutes(executes);

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/ServiceConfigTest.java
@@ -134,7 +134,7 @@ public class ServiceConfigTest {
         assertThat(url.getParameters(), hasEntry(Constants.APPLICATION_KEY, "app"));
         assertThat(url.getParameters(), hasKey(Constants.BIND_IP_KEY));
         assertThat(url.getParameters(), hasKey(Constants.BIND_PORT_KEY));
-        assertThat(url.getParameters(), hasEntry(Constants.DEFAULT_KEY + "." + Constants.EXPORT_KEY, "true"));
+        assertThat(url.getParameters(), hasEntry(Constants.EXPORT_KEY, "true"));
         assertThat(url.getParameters(), hasEntry("echo.0.callback", "false"));
         assertThat(url.getParameters(), hasEntry(Constants.GENERIC_KEY, "false"));
         assertThat(url.getParameters(), hasEntry(Constants.INTERFACE_KEY, DemoService.class.getName()));

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/url/InvokerSideConfigUrlTest.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/url/InvokerSideConfigUrlTest.java
@@ -28,8 +28,8 @@ import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.config.mock.MockRegistry;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -112,18 +112,11 @@ public class InvokerSideConfigUrlTest extends UrlTestBase {
             //{"", "", "", "", "", "", "", "", "", ""}, 
     };
 
-    private Object consumerConfTable[][] = {
-            {"timeout", "default.timeout", "int", 5000, 8000, "", "", "", "", ""},
-            {"retries", "default.retries", "int", 2, 5, "", "", "", "", ""},
-            {"loadbalance", "default.loadbalance", "string", "random", "leastactive", "", "", "", "", ""},
-            {"async", "default.async", "boolean", false, true, "", "", "", "", ""},
-            {"connections", "default.connections", "int", 100, 5, "", "", "", "", ""},
+    private Object consumerConfTable[][] = {{"timeout", "timeout", "int", 5000, 8000, "", "", "", "", ""}, {"retries", "retries", "int", 2, 5, "", "", "", "", ""}, {"loadbalance", "loadbalance", "string", "random", "leastactive", "", "", "", "", ""}, {"async", "async", "boolean", false, true, "", "", "", "", ""}, {"connections", "connections", "int", 100, 5, "", "", "", "", ""},
 //            {"generic", "generic", "boolean", false, false, "", "", "", "", ""}, 
             {"check", "check", "boolean", true, false, "", "", "", "", ""},
             {"proxy", "proxy", "string", "javassist", "jdk", "javassist", "", "", "", ""},
-            {"owner", "owner", "string", "", "haomin", "", "", "", "", ""},
-            {"actives", "default.actives", "int", 0, 5, "", "", "", "", ""},
-            {"cluster", "default.cluster", "string", "failover", "forking", "", "", "", "", ""},
+            {"owner", "owner", "string", "", "haomin", "", "", "", "", ""}, {"actives", "actives", "int", 0, 5, "", "", "", "", ""}, {"cluster", "cluster", "string", "failover", "forking", "", "", "", "", ""},
             {"filter", "", "string", "", "", "", "", "", "", ""},
             {"listener", "", "string", "", "", "", "", "", "", ""},
 //            {"", "", "", "", "", "", "", "", "", ""}, 

--- a/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/url/UrlTestBase.java
+++ b/dubbo-config/dubbo-config-api/src/test/java/org/apache/dubbo/config/url/UrlTestBase.java
@@ -80,13 +80,7 @@ public class UrlTestBase {
             //            {"subscribe", "subscribe", "boolean", true, false, "", "", "", "", ""},
             {"dynamic", "dynamic", "boolean", true, false, "", "", "", "", ""},
     };
-    protected Object provConfTable[][] = {
-            {"cluster", "default.cluster", "string", "string", "failover", "failfast", "failsafe", "", "", ""},
-            {"async", "default.async", "boolean", false, true, "", "", "", "", ""},
-            {"loadbalance", "default.loadbalance", "string", "random", "leastactive", "", "", "", "", ""},
-            {"connections", "default.connections", "int", 0, 60, "", "", "", "", ""},
-            {"retries", "default.retries", "int", 2, 60, "", "", "", "", ""},
-            {"timeout", "default.timeout", "int", 5000, 60, "", "", "", "", ""},
+    protected Object provConfTable[][] = {{"cluster", "cluster", "string", "string", "failover", "failfast", "failsafe", "", "", ""}, {"async", "async", "boolean", false, true, "", "", "", "", ""}, {"loadbalance", "loadbalance", "string", "random", "leastactive", "", "", "", "", ""}, {"connections", "connections", "int", 0, 60, "", "", "", "", ""}, {"retries", "retries", "int", 2, 60, "", "", "", "", ""}, {"timeout", "timeout", "int", 5000, 60, "", "", "", "", ""},
             //change by fengting listener 没有缺省值
             //{"listener", "exporter.listener", "string", "", "", "", "", "", "", ""},
             //{"filter", "service.filter", "string", "", "", "", "", "", "", ""},

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/compat/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/compat/dubbo.xsd
@@ -172,6 +172,12 @@
                             <![CDATA[ Defines the service visibility, choise:[local remote]. default is remote, which can be invoked by network。  ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
+                <xsd:attribute name="tag" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            <![CDATA[ Defines the service tag]]></xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
@@ -315,12 +321,6 @@
                 <xsd:attribute name="serialization" type="xsd:string">
                     <xsd:annotation>
                         <xsd:documentation><![CDATA[ The serialization protocol of service. ]]></xsd:documentation>
-                    </xsd:annotation>
-                </xsd:attribute>
-                <xsd:attribute name="tag" type="xsd:string">
-                    <xsd:annotation>
-                        <xsd:documentation>
-                            <![CDATA[ Defines the service tag]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
                 <xsd:anyAttribute namespace="##other" processContents="lax"/>

--- a/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
+++ b/dubbo-config/dubbo-config-spring/src/main/resources/META-INF/dubbo.xsd
@@ -172,6 +172,12 @@
                             <![CDATA[ Defines the service visibility, choise:[local remote]. default is remote, which can be invoked by network。  ]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
+                <xsd:attribute name="tag" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            <![CDATA[ Defines the service tag]]></xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
@@ -315,12 +321,6 @@
                 <xsd:attribute name="serialization" type="xsd:string">
                     <xsd:annotation>
                         <xsd:documentation><![CDATA[ The serialization protocol of service. ]]></xsd:documentation>
-                    </xsd:annotation>
-                </xsd:attribute>
-                <xsd:attribute name="tag" type="xsd:string">
-                    <xsd:annotation>
-                        <xsd:documentation>
-                            <![CDATA[ Defines the service tag]]></xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
                 <xsd:anyAttribute namespace="##other" processContents="lax"/>


### PR DESCRIPTION
## What is the purpose of the change

Fixes #3875, support using the following on consumer side:
`<dubbo:parameter key="dubbo.tag" value="groupA"/>`

Related issue https://github.com/apache/incubator-dubbo/issues/3359

## Brief changelog

XXXXX

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/incubator-dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/incubator-dubbo/tree/master/dubbo-test).
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure unit-test and integration-test pass.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/incubator-dubbo/wiki/Software-donation-guide).
