### PR TITLE
use revision in pom.xml of dubbo-metadata-report-etcd

### DIFF
--- a/dubbo-metadata-report/dubbo-metadata-report-etcd/pom.xml
+++ b/dubbo-metadata-report/dubbo-metadata-report-etcd/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>dubbo-metadata-report</artifactId>
         <groupId>org.apache.dubbo</groupId>
-        <version>2.7.2-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## What is the purpose of the change

change  `2.7.2-SNAPSHOT` to `revision` in pom.xml of dubbo-metadata-report-etcd, otherwise there are maven package failures as following:

```
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for org.apache.dubbo:dubbo-metadata-report-etcd:2.7.2-SNAPSHOT: Could not find artifact org.apache.dubbo:dubbo-metadata-report:pom:2.7.2-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 22, column 13
 @ 
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project org.apache.dubbo:dubbo-metadata-report-etcd:2.7.2-SNAPSHOT (~/gh-incubator-dubbo/dubbo-metadata-report/dubbo-metadata-report-etcd/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for org.apache.dubbo:dubbo-metadata-report-etcd:2.7.2-SNAPSHOT: Could not find artifact org.apache.dubbo:dubbo-metadata-report:pom:2.7.2-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 22, column 13 -> [Help 2]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
```